### PR TITLE
remove `DynPushPullHook2D` with more objects because initial state sampling is too slow

### DIFF
--- a/prbench/src/prbench/__init__.py
+++ b/prbench/src/prbench/__init__.py
@@ -84,7 +84,7 @@ def register_all_environments() -> None:
         )
 
     # DynPushPullStick2D environment with different numbers of obstructions.
-    num_obstructions = [0, 1, 5, 10, 15]
+    num_obstructions = [0, 1, 5]
     for num_obstruction in num_obstructions:
         _register(
             id=f"prbench/DynPushPullHook2D-o{num_obstruction}-v0",

--- a/prbench/tests/envs/dynamic2d/test_dyn_pushpullstick2d.py
+++ b/prbench/tests/envs/dynamic2d/test_dyn_pushpullstick2d.py
@@ -12,7 +12,7 @@ def test_dyn_obstruction2d_observation_random_actions():
     Also tests env creation and random actions.
     """
     prbench.register_all_environments()
-    env = prbench.make("prbench/DynPushPullHook2D-o10-v0")
+    env = prbench.make("prbench/DynPushPullHook2D-o5-v0")
     assert isinstance(env.observation_space, Box)
     for _ in range(5):
         obs, _ = env.reset()


### PR DESCRIPTION
closes #45 