### PR TITLE
Move mobile robot to pre-grasp pose

### DIFF
--- a/prpl-llm-utils/src/prpl_llm_utils/cache.py
+++ b/prpl-llm-utils/src/prpl_llm_utils/cache.py
@@ -93,8 +93,7 @@ class SQLite3PretrainedLargeModelCache(PretrainedLargeModelCache):
 
     def _get_query_hash(self, query: Query, model_id: str) -> str:
         """Get a unique hash for the query and model combination."""
-        query_id = query.get_id()
-        return f"{model_id}_{hash(query_id)}"
+        return f"{model_id}_{hash(query)}"
 
     def _ensure_initialized(self, query: Query) -> None:
         """Initialize the database with the required tables and columns."""

--- a/prpl-llm-utils/src/prpl_llm_utils/utils.py
+++ b/prpl-llm-utils/src/prpl_llm_utils/utils.py
@@ -7,14 +7,14 @@ from typing import Any, Callable
 
 
 def consistent_hash(obj: Any) -> int:
-    """A hash function that is consistent between sessions, unlike hash()."""
+    """A hash function that is consistent across sessions, unlike hash()."""
     obj_str = repr(obj)
     obj_bytes = obj_str.encode("utf-8")
-    hash_hex = hashlib.sha256(obj_bytes).hexdigest()
-    hash_int = int(hash_hex, 16)
+    hash_bytes = hashlib.sha256(obj_bytes).digest()
+    hash_int = int.from_bytes(hash_bytes[:8], "big", signed=False)
     # Mimic Python's built-in hash() behavior by returning a 64-bit signed int.
     # This makes it comparable to hash()'s output range.
-    return hash_int if hash_int < 2**63 else hash_int - 2**6
+    return hash_int if hash_int < 2**63 else hash_int - 2**64
 
 
 class Scope:


### PR DESCRIPTION
- Add a skill that will enable the robot (1): move the base toward the target object. (2): Move the arm back to the retract configuration. (3): move the arm to the pre-grasp pose. 
- fixed a bug about coordinate frame transformation between the mobile base and arm. 

Some example videos: 

https://github.com/user-attachments/assets/75100e14-8f0e-40a6-a4b6-290cf8e33503

https://github.com/user-attachments/assets/192c67f1-aeba-47e7-976c-b06c7a0285d4

