### PR TITLE
add back uv cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,15 @@ runs:
   steps:
     - name: Install uv
       uses: astral-sh/setup-uv@v3
+    - name: Cache uv dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/uv
+          .venv
+        key: uv-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('**/pyproject.toml', '**/prpl_requirements.txt') }}
+        restore-keys: |
+          uv-${{ runner.os }}-py${{ inputs.python-version }}-
     - name: Set up Python ${{ inputs.python-version }}
       shell: bash
       run: uv venv --python=${{ inputs.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ env:
   # Tell git/uv to NOT download LFS blobs, just keep pointer files
   GIT_LFS_SKIP_SMUDGE: "1"
 
-  # Prevent caches from filling the runner disk
-  UV_NO_CACHE: "1"
-  PIP_NO_CACHE_DIR: "1"
-
   # Base SHA for selective testing in PRs
   CI_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
 


### PR DESCRIPTION
the memory issues we were experiencing before were most likely related to the lerobot dependency in prpl-tidybot. adding this back in the hope that it leads to speedups