### PR TITLE
fix bug in accessing arm joint infos

### DIFF
--- a/prbench-models/src/prbench_models/dynamic3d/ground/parameterized_skills.py
+++ b/prbench-models/src/prbench_models/dynamic3d/ground/parameterized_skills.py
@@ -1084,7 +1084,7 @@ class PickGroundController(GroundParameterizedController[ObjectCentricState, Arr
             gripper_pose = self._get_current_robot_gripper_pose()
             next_conf = self._current_arm_joint_plan[0]
             action = np.zeros(11, dtype=np.float32)
-            joint_infos = self._pybullet_sim.robot.joint_infos  # type: ignore
+            joint_infos = self._pybullet_sim.robot._joint_infos  # type: ignore  # pylint: disable=protected-access
             free_joints_infos = [
                 joint_info for joint_info in joint_infos if joint_info.qIndex > -1
             ]
@@ -1118,7 +1118,7 @@ class PickGroundController(GroundParameterizedController[ObjectCentricState, Arr
             gripper_pose = self._get_current_robot_gripper_pose()
             next_conf = self._current_retract_plan[0]  # type: ignore
             action = np.zeros(11, dtype=np.float32)
-            joint_infos = self._pybullet_sim.robot.joint_infos  # type: ignore
+            joint_infos = self._pybullet_sim.robot._joint_infos  # type: ignore  # pylint: disable=protected-access
             free_joints_infos = [
                 joint_info for joint_info in joint_infos if joint_info.qIndex > -1
             ]
@@ -1408,7 +1408,7 @@ class PlaceGroundController(GroundParameterizedController[ObjectCentricState, Ar
             gripper_pose = self._get_current_robot_gripper_pose()
             next_conf = self._current_arm_joint_plan[0]
             action = np.zeros(11, dtype=np.float32)
-            joint_infos = self._pybullet_sim.robot.joint_infos  # type: ignore
+            joint_infos = self._pybullet_sim.robot._joint_infos  # type: ignore  # pylint: disable=protected-access
             free_joints_infos = [
                 joint_info for joint_info in joint_infos if joint_info.qIndex > -1
             ]
@@ -1438,7 +1438,7 @@ class PlaceGroundController(GroundParameterizedController[ObjectCentricState, Ar
             gripper_pose = self._get_current_robot_gripper_pose()
             next_conf = self._current_retract_plan[0]  # type: ignore
             action = np.zeros(11, dtype=np.float32)
-            joint_infos = self._pybullet_sim.robot.joint_infos  # type: ignore
+            joint_infos = self._pybullet_sim.robot._joint_infos  # type: ignore  # pylint: disable=protected-access
             free_joints_infos = [
                 joint_info for joint_info in joint_infos if joint_info.qIndex > -1
             ]

--- a/prbench-models/src/prbench_models/geom3d/base_controllers.py
+++ b/prbench-models/src/prbench_models/geom3d/base_controllers.py
@@ -46,7 +46,7 @@ class BasePlaceController(
         """Initialize the base place controller."""
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target, self._target_table = objects
         self._current_params: np.ndarray | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None

--- a/prbench-models/src/prbench_models/geom3d/ground3d/parameterized_skills.py
+++ b/prbench-models/src/prbench_models/geom3d/ground3d/parameterized_skills.py
@@ -86,7 +86,7 @@ class GroundPickController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._current_params: np.ndarray | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None
@@ -326,7 +326,7 @@ class GroundPlaceController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._current_params: np.ndarray | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None

--- a/prbench-models/src/prbench_models/geom3d/motion3d/parameterized_skills.py
+++ b/prbench-models/src/prbench_models/geom3d/motion3d/parameterized_skills.py
@@ -49,7 +49,7 @@ class GroundMoveToTargetController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._current_params: JointPositions | None = None
         self._current_plan: list[JointPositions] | None = None

--- a/prbench-models/src/prbench_models/geom3d/obstruction3d/parameterized_skills.py
+++ b/prbench-models/src/prbench_models/geom3d/obstruction3d/parameterized_skills.py
@@ -60,7 +60,7 @@ class GroundPickController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._object = objects
         self._current_params: JointPositions | None = None
         self._current_plan: list[JointPositions] | None = None
@@ -306,7 +306,7 @@ class GroundPlaceController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._object = objects
         self._current_params: JointPositions | None = None
         self._current_plan: list[JointPositions] | None = None

--- a/prbench-models/src/prbench_models/geom3d/shelf3d/parameterized_skills.py
+++ b/prbench-models/src/prbench_models/geom3d/shelf3d/parameterized_skills.py
@@ -65,7 +65,7 @@ class GroundPickController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._current_params: np.ndarray | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None

--- a/prbench-models/src/prbench_models/geom3d/transport3d/parameterized_skills.py
+++ b/prbench-models/src/prbench_models/geom3d/transport3d/parameterized_skills.py
@@ -71,7 +71,7 @@ class GroundPickController(
     ) -> None:
         super().__init__(objects)
         self._sim = sim
-        self._joint_infos = sim.robot.arm.joint_infos[:7]
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._current_params: np.ndarray | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None

--- a/pybullet-helpers/src/pybullet_helpers/ikfast/utils.py
+++ b/pybullet-helpers/src/pybullet_helpers/ikfast/utils.py
@@ -72,7 +72,8 @@ def get_ordered_ancestors(robot: SingleArmPyBulletRobot, link: int) -> list[int]
 
     # Mapping of link ID to parent link ID for each link in the robot
     link_to_parent_link: dict[int, int] = {
-        info.jointIndex: info.parentIndex for info in robot.joint_infos
+        info.jointIndex: info.parentIndex
+        for info in robot._joint_infos  # pylint: disable=protected-access
     }
     # Note: it is important to recognize we use the IKFastInfo base and
     # end-effector link information as that was how IKFast was compiled.
@@ -146,7 +147,7 @@ def get_ikfast_joints(
     # Prune out the fixed joints.
     ik_joints = [
         joint_info
-        for joint_info in robot.joint_infos
+        for joint_info in robot._joint_infos  # pylint: disable=protected-access
         if joint_info.jointIndex in ee_ancestors and not joint_info.is_fixed
     ]
     free_joints = [

--- a/pybullet-helpers/src/pybullet_helpers/robots/single_arm.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/single_arm.py
@@ -202,7 +202,7 @@ class SingleArmPyBulletRobot(abc.ABC):
         ]
 
     @cached_property
-    def joint_infos(self) -> list[JointInfo]:
+    def _joint_infos(self) -> list[JointInfo]:
         """Get the joint info for each joint of the robot.
 
         This may be a superset of the arm joints.
@@ -210,10 +210,14 @@ class SingleArmPyBulletRobot(abc.ABC):
         all_joint_ids = get_joints(self.robot_id, self.physics_client_id)
         return get_joint_infos(self.robot_id, all_joint_ids, self.physics_client_id)
 
+    def get_arm_joint_infos(self) -> list[JointInfo]:
+        """Get joint infos for the arm joints."""
+        return get_joint_infos(self.robot_id, self.arm_joints, self.physics_client_id)
+
     @cached_property
     def joint_names(self) -> list[str]:
         """Get the names of all the joints in the robot."""
-        joint_names = [info.jointName for info in self.joint_infos]
+        joint_names = [info.jointName for info in self._joint_infos]
         return joint_names
 
     def joint_from_name(self, joint_name: str) -> int:
@@ -222,7 +226,7 @@ class SingleArmPyBulletRobot(abc.ABC):
 
     def joint_info_from_name(self, joint_name: str) -> JointInfo:
         """Get the joint info for a joint name."""
-        return self.joint_infos[self.joint_from_name(joint_name)]
+        return self._joint_infos[self.joint_from_name(joint_name)]
 
     def link_from_name(self, link_name: str) -> int:
         """Get the link index for a given link name."""
@@ -230,7 +234,7 @@ class SingleArmPyBulletRobot(abc.ABC):
             return BASE_LINK
 
         # In PyBullet, each joint has an associated link.
-        for joint_info in self.joint_infos:
+        for joint_info in self._joint_infos:
             if joint_info.linkName == link_name:
                 return joint_info.jointIndex
         raise ValueError(f"Could not find link {link_name}")
@@ -241,7 +245,7 @@ class SingleArmPyBulletRobot(abc.ABC):
             return self.base_link_name
 
         # In PyBullet, each joint has an associated link.
-        for joint_info in self.joint_infos:
+        for joint_info in self._joint_infos:
             if joint_info.jointIndex == link:
                 return joint_info.linkName
         raise ValueError(f"Could not find link {link}")

--- a/pybullet-helpers/tests/robots/test_panda.py
+++ b/pybullet-helpers/tests/robots/test_panda.py
@@ -37,7 +37,7 @@ def test_panda_pybullet_robot_initial_configuration(panda):
 def test_panda_pybullet_robot_links(panda):
     """Test link utilities on PandaPyBulletRobot."""
     # Tool link is last link in Panda URDF
-    num_links = len(panda.joint_infos)
+    num_links = len(panda._joint_infos)  # pylint: disable=protected-access
     assert panda.tool_link_id == num_links - 1
     assert panda.tool_link_name == "tool_link"
 
@@ -57,7 +57,8 @@ def test_panda_pybullet_robot_joints(panda):
 
     # Check joint infos match expected
     panda_joints = get_joints(panda.robot_id, panda.physics_client_id)
-    assert panda.joint_infos == get_joint_infos(
+    # pylint: disable-next=protected-access
+    assert panda._joint_infos == get_joint_infos(
         panda.robot_id, panda_joints, panda.physics_client_id
     )
 


### PR DESCRIPTION
all of the instances of `sim.robot.arm.joint_infos[:7]` were incorrect -- `.joint_infos` confusingly includes fixed joints, so the first joint was a fixed joint, not joint1 of the robot arm.