### PR TITLE
Support z height for cupboard regions

### DIFF
--- a/prbench/src/prbench/envs/dynamic3d/objects/fixtures.py
+++ b/prbench/src/prbench/envs/dynamic3d/objects/fixtures.py
@@ -799,7 +799,8 @@ class Cupboard(MujocoFixture):
                 else:
                     raise ValueError(
                         f"Each region range must have 4 or 6 values "
-                        f"[x_start, y_start, x_end, y_end] or [x_start, y_start, z_start, x_end, y_end, z_end], "
+                        f"[x_start, y_start, x_end, y_end] or "
+                        f"[x_start, y_start, z_start, x_end, y_end, z_end], "
                         f"got {len(region_range)} for region '{region_name}'"
                     )
 


### PR DESCRIPTION
Default height of shelf region when no z bounds are specified:

```
        "cupboard_shelf_0_region": {
            "target": "cupboard_1",
            "shelf": 0,
            "ranges": [[-0.2, -0.1, 0.2, 0.1]],
            "yaw_ranges": [[0, 360]],
            "rgba": [0.8, 0.1, 0.1, 0.3]
        }
```

<img width="1120" height="966" alt="image" src="https://github.com/user-attachments/assets/40c2c668-3b81-493b-bb2d-bf8cd0902e50" />


Specified z height of 5cm for shelf region:

```
        "cupboard_shelf_0_region": {
            "target": "cupboard_1",
            "shelf": 0,
            "ranges": [[-0.2, -0.1, 0, 0.2, 0.1, 0.05]],
            "yaw_ranges": [[0, 360]],
            "rgba": [0.8, 0.1, 0.1, 0.3]
        }
```
<img width="1100" height="1118" alt="image" src="https://github.com/user-attachments/assets/2a99bb4e-105d-4a31-868a-27d29f425d1d" />
