### PR TITLE
add environment-agnostic Flask backend for bilevel planning visualizer

### DIFF
--- a/bilevel-planning/pyproject.toml
+++ b/bilevel-planning/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
    "networkx",
    "types-networkx",
    "gymnasium",
+   "flask",
+   "flask-cors",
+   "pillow",
 ]
 
 [project.optional-dependencies]

--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -1,5 +1,7 @@
 """Bilevel planning graphs: primarily for visualization, analysis, debugging."""
 
+import json
+import pickle
 from pathlib import Path
 from typing import Callable, Generic, Hashable, TypeVar
 
@@ -28,6 +30,9 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
     def __init__(self) -> None:
         self.states: list[_X] = []
         self._state_ids: set[int] = set()  # prevent duplicates
+        self._state_id_to_state: dict[int, _X] = (
+            {}
+        )  # reverse lookup: id -> state, todo: remove _state_ids
         self.abstract_states: list[_S] = []
         self.action_edges: list[tuple[_X, _U, _X]] = []
         self._action_edge_ids: set[int] = set()  # prevent duplicates
@@ -47,6 +52,7 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
             return
         self.states.append(state)
         self._state_ids.add(state_id)
+        self._state_id_to_state[state_id] = state
         return
 
     def add_action_edge(self, state: _X, action: _U, next_state: _X) -> None:
@@ -58,7 +64,9 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         self.action_edges.append(transition)
         self._action_edge_ids.add(transition_id)
         next_state_id = self._state_to_id(next_state)
-        self._state_id_to_parent[next_state_id] = (state, action)
+        # Only set parent if not already set (preserve first path found)
+        if next_state_id not in self._state_id_to_parent:
+            self._state_id_to_parent[next_state_id] = (state, action)
         return
 
     def add_abstract_state_node(self, abstract_state: _S) -> None:
@@ -66,6 +74,7 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         if abstract_state in self.abstract_states:
             return
         self.abstract_states.append(abstract_state)
+
         return
 
     def add_abstract_action_edge(
@@ -108,6 +117,7 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         state = states[idx]
         return state
 
+    # Could be made more efficient with .append() followed by .reverse().
     def extract_plan(self, final_state: _X) -> Plan:
         """Follow backpointers from final state and create a plan."""
         x_plan: list[_X] = [final_state]
@@ -124,6 +134,13 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
     def _state_to_id(self, state: _X) -> int:
         """Get an integer ID for a state that is in the graph."""
         return consistent_hash(state)
+
+    def _id_to_state(self, state_id: int) -> _X | None:
+        """Get a state from its integer ID.
+
+        Returns None if not found.
+        """
+        return self._state_id_to_state.get(state_id)
 
     def _abstract_state_to_id(self, abstract_state: _S) -> int:
         """Get an integer ID for an abstract state that is in the graph."""
@@ -285,3 +302,554 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
             blit=False,
         )
         anim.save(save_path, writer="pillow")
+
+    def _build_graph_structure(
+        self,
+        final_state: _X | None = None,
+        abstract_state_color: str = "tab:purple",
+        state_color: str = "tab:blue",
+        plan_color: str = "tab:green",
+        node_size: int = 50,
+        state_abstractor_edge_color: str = "gray",
+        action_edge_color: str = "black",
+        abstract_action_edge_color: str = "black",
+        node_alpha: float = 0.7,
+        edge_alpha: float = 0.7,
+        n_intermediate_per_side: int = 0,
+    ) -> tuple[nx.DiGraph, dict[str, tuple[float, float, float]], dict]:
+        """Build the graph structure for visualization.
+
+        Returns:
+            G: NetworkX DiGraph with nodes and edges
+            pos: Dictionary mapping node IDs to (x, y, z) positions
+            metadata: Dictionary with plan_nodes, start_node, goal_node, z_top, z_bottom
+
+        Planned follow-ups (tracked on this helper because this is the only
+        call site; see also the comments at each individual concern):
+          * Fold this method into ``export_graph_for_web``. The split exists
+            for no reason — nothing else calls ``_build_graph_structure``.
+          * Drop the styling parameters. Colors and sizes are presentation
+            concerns that belong in the frontend, not in the export.
+          * Remove the ``n_intermediate_per_side`` knob. It defaults to 0, so
+            the interpolation branch below is dead code today, and deciding
+            how many intermediate nodes to show should happen in the viewer.
+          * Replace the force-directed layout with a hierarchical layer
+            assignment (BFS from roots) for DAG-shaped graphs.
+        """
+
+        G: nx.DiGraph = nx.DiGraph()
+        pos: dict[str, tuple[float, float, float]] = {}
+        metadata: dict = {}
+
+        # Analyze graph topology to identify critical nodes to keep
+        # for visualization purposes
+        adj: dict[int, set[int]] = {}  # state_id -> list of next state_ids
+        rev_adj: dict[int, set[int]] = {}  # state_id -> list of prev state_ids
+
+        for source_state, _, target_state in self.action_edges:
+            uid = self._state_to_id(source_state)
+            vid = self._state_to_id(target_state)
+
+            adj.setdefault(uid, set()).add(vid)
+            rev_adj.setdefault(vid, set()).add(uid)
+
+        # Identify Plan Nodes
+        plan_state_ids = set()
+        if final_state is not None:
+            plan = self.extract_plan(final_state)
+            for state in plan.states:
+                plan_state_ids.add(self._state_to_id(state))
+
+        # Track which concrete nodes have mapping to abstract nodes
+        state_to_abstract = {}
+        for x, s in self.state_abstractor_edges:
+            state_to_abstract[self._state_to_id(x)] = self._abstract_state_to_id(s)
+
+        # Determine Kept Nodes
+        kept_state_ids = set()
+
+        for state in self.states:
+            sid = self._state_to_id(state)
+            in_d = len(rev_adj.get(sid, set()))
+            out_d = len(adj.get(sid, set()))
+
+            # Non-critical nodes: indegree = 1 AND outdegree = 1
+            # i.e., intermediate nodes that represent motion planning steps
+            is_critical = (
+                in_d == 0  # Root
+                or out_d == 0  # Leaf
+                or out_d > 1  # Branch
+                or in_d > 1  # Merge
+                or sid in state_to_abstract  # Has abstract mapping
+            )
+
+            if is_critical:
+                kept_state_ids.add(sid)
+
+        # Build layout graph with only critical nodes
+        # Then we'll add back some pruned nodes later by interpolating along edges
+        G_layout: nx.DiGraph = nx.DiGraph()
+
+        # Record pruned segments for interpolation later
+        # Ex: if critical nodes A, D pass through intermediate pruned nodes B, C
+        # then forward_segments[(A, D)] = [B, C]
+        forward_segments: dict[tuple[int, int], list[int]] = {}
+
+        for sid in kept_state_ids:
+            G_layout.add_node(f"x:{sid}")
+
+        # Stitch edges of the kept nodes together, and record the
+        # intermediate pruned nodes along the way for later interpolation
+        for sid in kept_state_ids:
+            children: set[int] = adj.get(sid, set())
+            for child_id in children:
+                curr = child_id
+                path: list[int] = []
+                visited: set[int] = set()
+                # Traverse down pruned nodes (degree-1 chains)
+                while (
+                    curr not in kept_state_ids and curr in adj and curr not in visited
+                ):
+                    visited.add(curr)
+                    path.append(curr)
+                    next_nodes = adj[curr]
+                    if not next_nodes:
+                        break
+                    # curr = next_nodes[0]
+                    curr = next(iter(next_nodes))  # Move to the next node
+
+                if curr in kept_state_ids:
+                    G_layout.add_edge(f"x:{sid}", f"x:{curr}")
+                    forward_segments[(sid, curr)] = path
+
+        # Run layout on concrete nodes. spring_layout is a force-directed
+        # placement: good enough to draw the graph without pulling in the
+        # graphviz C library, but less readable than a hierarchical top-down
+        # DAG layout. A follow-up can replace this with a BFS-based layer
+        # assignment for DAG-shaped graphs.
+        layout_pos: dict[str, tuple[float, float]] = {
+            n: (float(xy[0]), float(xy[1]))
+            for n, xy in nx.spring_layout(G_layout, seed=0).items()
+        }
+
+        # Post-process layout: center and scale into a [-10, 10] box.
+        #
+        # Planned follow-up: the aspect-ratio stretching below is a hack
+        # calibrated against graphviz "dot" output and is only loosely
+        # meaningful for a force-directed layout. When we switch to a
+        # hierarchical layer layout, this whole block should be replaced
+        # with a single uniform scale-to-box, and the frontend should own
+        # any display-time aspect handling.
+        if layout_pos:
+            xs = [p[0] for p in layout_pos.values()]
+            ys = [p[1] for p in layout_pos.values()]
+
+            min_x, max_x = min(xs), max(xs)
+            min_y, max_y = min(ys), max(ys)
+
+            width = max_x - min_x if max_x != min_x else 1.0
+            height = max_y - min_y if max_y != min_y else 1.0
+
+            center_x = (min_x + max_x) / 2.0
+            center_y = (min_y + max_y) / 2.0
+
+            target_aspect = 1.5
+            current_aspect = width / height
+
+            y_scale = 1.0
+            if current_aspect > target_aspect:
+                y_scale = current_aspect / target_aspect
+
+            max_dim = max(width, height * y_scale)
+            scale_factor = 20.0 / max_dim if max_dim > 0 else 1.0
+
+            for nid, (layout_x, layout_y) in layout_pos.items():
+                new_x = (layout_x - center_x) * scale_factor
+                new_y = (layout_y - center_y) * y_scale * scale_factor
+                layout_pos[nid] = (new_x, new_y)
+
+        # Construct Final G and pos
+        # First, add all critical (kept) concrete nodes with their layout positions
+        for sid in kept_state_ids:
+            nid = f"x:{sid}"
+            if nid in layout_pos:
+                pos[nid] = (layout_pos[nid][0], layout_pos[nid][1], 0.0)
+                G.add_node(nid, type="concrete")
+
+        # For each stitched edge between critical nodes, optionally add
+        # a bounded number of intermediate nodes that are evenly spread along
+        # the original chain between the endpoints, and interpolate positions
+        # along the segment.
+        #
+        # Planned follow-up: this loop is gated on ``n_intermediate_per_side``
+        # which defaults to 0, so in practice the interpolation branch never
+        # runs. Either wire the knob through as an actual feature or delete
+        # it. The viewer is a better place to decide how much of the pruned
+        # chain to surface, since the user can pan/zoom.
+        for u, v in G_layout.edges():
+            u_sid = int(u.split(":")[1])
+            v_sid = int(v.split(":")[1])
+
+            full_path = forward_segments.get((u_sid, v_sid), [])
+
+            # Select up to n_intermediate_per_side nodes, evenly distributed
+            # along the chain from u_sid to v_sid.
+            selected: list[int] = []
+            if full_path:
+                k = min(n_intermediate_per_side, len(full_path))
+                if k == len(full_path):
+                    selected = full_path[:]
+                else:
+                    step = len(full_path) / (k + 1)
+                    used: set[int] = set()
+                    for i in range(1, k + 1):
+                        idx = int(round(i * step)) - 1
+                        idx = max(0, min(idx, len(full_path) - 1))
+                        mid_sid = full_path[idx]
+                        if mid_sid not in used:
+                            used.add(mid_sid)
+                            selected.append(mid_sid)
+
+            # Build the visualization sequence: [u, selected..., v]
+            seq: list[int] = [u_sid] + selected + [v_sid]
+
+            # Interpolate positions along the line from u to v
+            ux, uy = layout_pos[u]
+            vx, vy = layout_pos[v]
+            z = 0.0
+            segments = max(len(seq) - 1, 1)
+
+            for i, sid in enumerate(seq):
+                nid = f"x:{sid}"
+                if nid not in pos:
+                    t = i / segments
+                    interp_x = ux + t * (vx - ux)
+                    interp_y = uy + t * (vy - uy)
+                    pos[nid] = (interp_x, interp_y, z)
+                    G.add_node(nid, type="concrete")
+
+            # Add edges along the expanded sequence
+            for a, b in zip(seq[:-1], seq[1:]):
+                G.add_edge(f"x:{a}", f"x:{b}", type="action")
+
+        # Compute time indices for rendered nodes only
+        # Map underlying state_id -> rendered node id ("x:{state_id}")
+        rendered_state_to_node: dict[int, str] = {}
+        for nid in G.nodes:
+            if isinstance(nid, str) and nid.startswith("x:"):
+                try:
+                    sid = int(nid.split(":")[1])
+                except (IndexError, ValueError):
+                    continue
+                rendered_state_to_node[sid] = nid
+
+        node_time_index: dict[str, int] = {}
+        current_index = 1
+        # Iterate over states in insertion order; assign indices only to rendered ones
+        for state in self.states:
+            sid = self._state_to_id(state)
+            rendered_nid = rendered_state_to_node.get(sid)
+            if rendered_nid is None:
+                continue
+            node_time_index[rendered_nid] = current_index
+            current_index += 1
+
+        if node_time_index:
+            min_time = 1
+            max_time = current_index - 1
+        else:
+            min_time = None
+            max_time = None
+
+        # Metadata
+
+        # z_top, z_bottom previously used to visualize abstract nodes on a
+        # separate plane. They are currently only used for plotly z-axis range,
+        # and kept in case abstract nodes are added back to rendering.
+        metadata["z_top"] = 1.0
+        metadata["z_bottom"] = 0.0
+
+        # node information
+        metadata["plan_nodes"] = []
+        metadata["abstract_plan_nodes"] = []
+        metadata["start_node"] = None
+        metadata["goal_node"] = None
+        metadata["state_to_abstract_id"] = state_to_abstract
+        # order in which filtered nodes were added to bpg
+        metadata["node_time_index"] = node_time_index
+
+        # timeline index range (used for slider range in plotly)
+        metadata["min_time"] = min_time
+        metadata["max_time"] = max_time
+
+        # Pass through colors/sizes for export
+        metadata["node_size"] = node_size
+        metadata["edge_alpha"] = edge_alpha
+
+        # coloring/visualization data
+        metadata["plan_color"] = plan_color
+        metadata["state_color"] = state_color
+        metadata["abstract_state_color"] = abstract_state_color
+        metadata["state_abstractor_edge_color"] = state_abstractor_edge_color
+        metadata["action_edge_color"] = action_edge_color
+        metadata["abstract_action_edge_color"] = abstract_action_edge_color
+        metadata["node_alpha"] = node_alpha
+
+        if final_state is not None:
+            # Only include plan nodes that were kept
+            plan_nodes = []
+            for s in self.extract_plan(final_state).states:
+                sid = self._state_to_id(s)
+                if sid in kept_state_ids:
+                    plan_nodes.append(f"x:{sid}")
+
+            metadata["plan_nodes"] = plan_nodes
+            if plan_nodes:
+                metadata["start_node"] = plan_nodes[0]
+                metadata["goal_node"] = plan_nodes[-1]
+
+            # Identify abstract plan nodes
+            abstract_plan_nodes = []
+            for x_node in plan_nodes:
+                x_id = int(x_node.split(":")[1])
+                if x_id in state_to_abstract:
+                    s_id = state_to_abstract[x_id]
+                    s_node = f"s:{s_id}"
+                    if s_node not in abstract_plan_nodes:
+                        abstract_plan_nodes.append(s_node)
+            metadata["abstract_plan_nodes"] = abstract_plan_nodes
+
+        return G, pos, metadata
+
+    def export_graph_for_web(
+        self,
+        final_state: _X | None = None,
+        abstract_state_color: str = "tab:purple",
+        state_color: str = "tab:blue",
+        plan_color: str = "tab:green",
+        node_size: int = 50,
+        state_abstractor_edge_color: str = "gray",
+        action_edge_color: str = "black",
+        abstract_action_edge_color: str = "black",
+        node_alpha: float = 0.7,
+        edge_alpha: float = 0.7,
+    ) -> dict:
+        """Export graph structure as JSON-serializable dictionary for web frontend.
+
+        Returns a dictionary with nodes, edges, plan info, and configuration.
+
+        Planned follow-ups:
+          * All of the color/size/alpha parameters should move to the
+            frontend. Styling is a presentation concern and the exporter
+            shouldn't bake it into the payload. The hardcoded matplotlib ->
+            RGB ``color_map`` below is the main reason these parameters
+            exist — once the frontend owns styling, the map disappears.
+          * Fold ``_build_graph_structure`` into this method; it has no
+            other caller.
+          * Consolidate this method and ``export_state_data_pickle`` into a
+            single pickle artifact (see ``export_graph_with_pickle`` for the
+            combined note). The frontend currently has to load a JSON file
+            *and* a pickle path separately, which is awkward.
+        """
+        # Build the graph structure
+        G, pos, metadata = self._build_graph_structure(
+            final_state=final_state,
+            abstract_state_color=abstract_state_color,
+            state_color=state_color,
+            plan_color=plan_color,
+            node_size=node_size,
+            state_abstractor_edge_color=state_abstractor_edge_color,
+            action_edge_color=action_edge_color,
+            abstract_action_edge_color=abstract_action_edge_color,
+            node_alpha=node_alpha,
+            edge_alpha=edge_alpha,
+        )
+
+        # Hardcoded mapping from the five matplotlib color names the caller
+        # is allowed to pass to their CSS ``rgb(...)`` equivalents. Planned
+        # for removal once styling moves to the frontend (see docstring).
+        color_map = {
+            "tab:purple": "rgb(148, 103, 189)",
+            "tab:blue": "rgb(31, 119, 180)",
+            "tab:green": "rgb(44, 160, 44)",
+            "gray": "rgb(128, 128, 128)",
+            "black": "rgb(0, 0, 0)",
+        }
+
+        def convert_color(mpl_color: str) -> str:
+            return color_map.get(mpl_color, mpl_color)
+
+        # Build nodes list
+        nodes = []
+        plan_nodes_set = set(metadata["plan_nodes"])
+        abstract_plan_nodes_set = set(metadata["abstract_plan_nodes"])
+        node_time_index: dict[str, int] = metadata.get("node_time_index", {})
+
+        for node_id, (x, y, z) in pos.items():
+            is_abstract = node_id.startswith("s:")
+            in_plan = node_id in plan_nodes_set
+            in_abstract_plan = node_id in abstract_plan_nodes_set
+
+            # Create node dict first to check for abstract association
+            node_dict = {
+                "id": node_id,
+                "type": "abstract" if is_abstract else "concrete",
+                "position": [x, y, z],
+                "size": metadata["node_size"],
+                "in_plan": in_plan or in_abstract_plan,
+            }
+
+            # Attach time index for rendered concrete nodes
+            if not is_abstract and node_id in node_time_index:
+                node_dict["time_index"] = node_time_index[node_id]
+
+            # Add abstract state ID for concrete nodes (if associated)
+            if not is_abstract and node_id.startswith("x:"):
+                state_id = int(node_id.split(":")[1])
+                if state_id in metadata["state_to_abstract_id"]:
+                    node_dict["abstract_state_id"] = metadata["state_to_abstract_id"][
+                        state_id
+                    ]
+
+            # Color based on node type, plan membership, and abstract association
+            if in_plan:
+                # Plan coloring
+                color = (
+                    "rgb(255, 165, 0)"
+                    if "abstract_state_id" in node_dict
+                    else convert_color(metadata["plan_color"])
+                )
+                alpha = 1.0
+            else:
+                # Non-plan coloring...
+                if node_dict["type"] == "concrete":
+                    color = (
+                        convert_color(metadata["abstract_state_color"])
+                        if "abstract_state_id" in node_dict
+                        else convert_color(metadata["state_color"])
+                    )
+                else:
+                    color = convert_color(metadata["abstract_state_color"])
+                alpha = metadata["node_alpha"]
+
+            node_dict["color"] = color
+            node_dict["alpha"] = alpha
+
+            nodes.append(node_dict)
+
+        # Build edges list
+        edges = []
+        for source, target in G.edges():
+            source_pos = pos[source]
+            target_pos = pos[target]
+            if source_pos[2] != target_pos[2]:
+                edge_type = "abstractor"
+                color = convert_color(metadata["state_abstractor_edge_color"])
+            elif source_pos[2] == metadata["z_bottom"]:
+                edge_type = "action"
+                color = convert_color(metadata["action_edge_color"])
+            else:
+                edge_type = "abstract_action"
+                color = convert_color(metadata["abstract_action_edge_color"])
+
+            edges.append(
+                {
+                    "source": source,
+                    "target": target,
+                    "type": edge_type,
+                    "color": color,
+                    "alpha": metadata["edge_alpha"],
+                }
+            )
+
+        # Build plan info
+        plan_info = {
+            "nodes": metadata["plan_nodes"],
+            "start": metadata["start_node"],
+            "goal": metadata["goal_node"],
+        }
+
+        # Build config
+        config = {
+            "z_top": metadata["z_top"],
+            "z_bottom": metadata["z_bottom"],
+        }
+
+        # Include time index range in config if available
+        if (
+            metadata.get("min_time") is not None
+            and metadata.get("max_time") is not None
+        ):
+            config["min_time"] = metadata["min_time"]
+            config["max_time"] = metadata["max_time"]
+
+        # Build state data dictionary (id -> state repr)
+        # Convert state objects to their string representation for JSON serialization
+        state_data = {}
+        for state in self.states:
+            state_id = self._state_to_id(state)
+            node_id = f"x:{state_id}"
+            # Convert state to string representation for JSON
+            state_data[node_id] = str(state)
+
+        graph_data = {
+            "nodes": nodes,
+            "edges": edges,
+            "plan": plan_info,
+            "config": config,
+            "state_data": state_data,
+        }
+
+        return graph_data
+
+    def export_state_data_pickle(self, pickle_path: Path) -> None:
+        """Export pickled state data dictionary for backend use.
+
+        This saves a dictionary mapping node IDs to actual state objects (not strings).
+        The backend can load this pickle to access the original state representations.
+
+        Planned follow-up: merge this into a single pickle artifact that also
+        contains the graph topology dict. Today the frontend uploads a JSON
+        file and separately tells the backend a pickle path — users have to
+        manage two files for one "visualization." One pickle, served through
+        a ``/api/graph`` endpoint after load, is the target.
+        """
+        # Build state data dictionary with actual state objects
+        state_data_pickle = {}
+        for state in self.states:
+            state_id = self._state_to_id(state)
+            node_id = f"x:{state_id}"
+            # Store the actual state object, not string representation
+            state_data_pickle[node_id] = state
+
+        # Save as pickle
+        with open(pickle_path, "wb") as f:
+            pickle.dump(state_data_pickle, f)
+
+    def export_graph_with_pickle(
+        self,
+        json_path: Path,
+        pickle_path: Path,
+        final_state: _X | None = None,
+        **kwargs,
+    ) -> dict:
+        """Export graph to JSON and pickle state data.
+
+        Planned follow-up: collapse to a single ``export(path)`` method that
+        writes one pickle containing both the graph topology and the state
+        dict. The JSON/pickle split here is a historical accident — JSON
+        can't hold arbitrary Python state objects, so the junior version
+        split the topology (JSON) from the states (pickle). Since the
+        frontend gets the topology from the backend over HTTP anyway, the
+        whole thing can just be one pickle the user loads once.
+        """
+        # Export JSON graph data
+        graph_data = self.export_graph_for_web(final_state=final_state, **kwargs)
+
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(graph_data, f, indent=2)
+
+        # Export pickled state data
+        self.export_state_data_pickle(pickle_path)
+
+        return graph_data

--- a/bilevel-planning/src/bilevel_planning/visualizer/app.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/app.py
@@ -1,0 +1,185 @@
+"""Flask backend for visualizing concrete states from a bilevel planning graph.
+
+This module is environment-agnostic: it does not import or construct any
+simulation environment. Callers supply a ``render_state_fn`` that maps a
+concrete state (as stored in the pickled bilevel planning graph) to an RGB
+image. Launch the webapp by importing ``run_webapp`` from your own script,
+where you own the env construction.
+"""
+
+# pylint: disable=global-statement
+
+import base64
+import io
+import pickle
+import traceback
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+from flask import Flask, jsonify, request
+from flask_cors import CORS  # type: ignore[import-untyped]
+from PIL import Image  # type: ignore[import-untyped]
+
+RenderStateFn = Callable[[Any], np.ndarray]
+
+STATE_DATA: dict = {}
+
+
+def _resolve_pickle_path(
+    pickle_path_str: str, data_dir: Path
+) -> tuple[Path | None, list[str]]:
+    attempted: list[str] = []
+    for candidate in (
+        Path(pickle_path_str),
+        data_dir / pickle_path_str,
+        data_dir / Path(pickle_path_str).name,
+    ):
+        attempted.append(str(candidate))
+        if candidate.exists():
+            return candidate, attempted
+    return None, attempted
+
+
+def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
+    """Build the Flask app with the given state renderer."""
+    app = Flask(__name__)
+    CORS(app)
+
+    @app.route("/api/load_pickle", methods=["POST"])
+    def load_pickle():
+        global STATE_DATA
+        try:
+            data = request.get_json()
+            pickle_path_str = data["pickle_path"]
+            pickle_path, attempted_paths = _resolve_pickle_path(
+                pickle_path_str, data_dir
+            )
+            if pickle_path is None:
+                return (
+                    jsonify(
+                        {
+                            "error": f"Pickle file not found: {pickle_path_str}",
+                            "attempted_paths": attempted_paths,
+                        }
+                    ),
+                    404,
+                )
+
+            with open(pickle_path, "rb") as f:
+                STATE_DATA = pickle.load(f)
+
+            num_states = len(STATE_DATA)
+            node_ids = list(STATE_DATA.keys())[:5]
+            return jsonify(
+                {
+                    "success": True,
+                    "num_states": num_states,
+                    "sample_node_ids": node_ids,
+                    "message": f"Loaded {num_states} states from {pickle_path.name}",
+                    "full_path": str(pickle_path),
+                }
+            )
+
+        except KeyError:
+            return jsonify({"error": "pickle_path is required in request body"}), 400
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return jsonify({"error": str(e), "traceback": traceback.format_exc()}), 500
+
+    @app.route("/api/visualize_state", methods=["POST"])
+    def visualize_state():
+        try:
+            data = request.get_json()
+            if not data:
+                return jsonify({"error": "No JSON data provided"}), 400
+
+            node_id = data.get("node_id")
+            if not node_id:
+                return jsonify({"error": "node_id is required"}), 400
+
+            if not STATE_DATA:
+                return (
+                    jsonify(
+                        {"error": "No state data loaded. Call /api/load_pickle first."}
+                    ),
+                    400,
+                )
+
+            if node_id not in STATE_DATA:
+                return jsonify({"error": f"Node ID not found: {node_id}"}), 404
+
+            state = STATE_DATA[node_id]
+            rgb_array = render_state_fn(state)
+            image = Image.fromarray(np.asarray(rgb_array).astype("uint8"))
+
+            buffer = io.BytesIO()
+            image.save(buffer, format="PNG")
+            buffer.seek(0)
+            img_base64 = base64.b64encode(buffer.read()).decode("utf-8")
+            width, height = image.size
+
+            return jsonify(
+                {
+                    "success": True,
+                    "node_id": node_id,
+                    "image": f"data:image/png;base64,{img_base64}",
+                    "width": width,
+                    "height": height,
+                    "state_str": str(state),
+                }
+            )
+
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return (
+                jsonify({"error": str(e), "traceback": traceback.format_exc()}),
+                500,
+            )
+
+    @app.route("/api/health", methods=["GET"])
+    def health():
+        return jsonify(
+            {
+                "status": "healthy",
+                "state_data_loaded": len(STATE_DATA) > 0,
+                "num_states": len(STATE_DATA),
+            }
+        )
+
+    return app
+
+
+def run_webapp(
+    render_state_fn: RenderStateFn,
+    data_dir: Path | str | None = None,
+    port: int = 5001,
+    debug: bool = True,
+) -> None:
+    """Run the visualization Flask server.
+
+    Callers supply ``render_state_fn``, which takes a concrete state from the
+    loaded pickle and returns an HxWx3 uint8 RGB array. The webapp itself has
+    no knowledge of the underlying environment.
+
+    ``data_dir`` is the directory searched when the frontend requests a pickle
+    by bare filename. Defaults to ``./webapp/data`` under the current working
+    directory.
+
+    Planned follow-ups (tracked here and in related visualizer files):
+      * Replace the JSON + pickle pair with a single pickle artifact and add
+        a ``/api/graph`` endpoint so the frontend fetches the topology from
+        the backend instead of uploading JSON itself.
+      * Add a ``/api/set_renderer`` endpoint that accepts Python source for
+        ``render_state_fn``, ``exec``s it, and caches the resulting callable.
+        Lets users launch the webapp with no bespoke script and write their
+        render function in a browser editor pane. Localhost-only — not for
+        hosted deployment.
+      * Move the React frontend under ``src/bilevel_planning/visualizer/
+        frontend/`` so all visualizer code lives under one name.
+    """
+    resolved_data_dir = (
+        Path(data_dir) if data_dir is not None else Path.cwd() / "webapp" / "data"
+    )
+    app = create_app(render_state_fn, resolved_data_dir)
+    print(f"Starting Flask backend on http://localhost:{port}")
+    print(f"Pickle data directory: {resolved_data_dir}")
+    app.run(debug=debug, port=port)

--- a/bilevel-planning/tests/test_bilevel_planning_graph.py
+++ b/bilevel-planning/tests/test_bilevel_planning_graph.py
@@ -1,5 +1,9 @@
 """Tests for bilevel_planning_graph.py."""
 
+import json
+import pickle
+from pathlib import Path
+
 import numpy as np
 
 from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
@@ -60,3 +64,63 @@ def test_bilevel_planning_graph():
 
     # Uncomment to make GIF.
     # bpg.render_gif(save_path="debug.gif")
+
+
+def _make_small_bpg() -> BilevelPlanningGraph:
+    bpg: BilevelPlanningGraph = BilevelPlanningGraph()
+    states = [np.array([i], dtype=np.int64) for i in range(4)]
+    for s in states:
+        bpg.add_state_node(s)
+    bpg.add_abstract_state_node("start")
+    bpg.add_abstract_state_node("end")
+    bpg.add_state_abstractor_edge(states[0], "start")
+    bpg.add_state_abstractor_edge(states[3], "end")
+    bpg.add_abstract_action_edge("start", "go", "end")
+    for a, b in zip(states[:-1], states[1:]):
+        bpg.add_action_edge(a, "step", b)
+    return bpg
+
+
+def test_export_graph_for_web():
+    """export_graph_for_web returns a JSON-serializable dict with expected keys."""
+    bpg = _make_small_bpg()
+    final_state = bpg.states[-1]
+    graph_data = bpg.export_graph_for_web(final_state=final_state)
+
+    assert set(graph_data.keys()) >= {"nodes", "edges", "plan", "config", "state_data"}
+    # The exporter prunes degree-1 chain nodes; at minimum the start and goal
+    # (both of which have abstract-state mappings) should survive.
+    concrete = [n for n in graph_data["nodes"] if n["type"] == "concrete"]
+    assert len(concrete) >= 2
+    # Round-trip through json to confirm serializability.
+    json.loads(json.dumps(graph_data))
+
+    plan_nodes = graph_data["plan"]["nodes"]
+    assert plan_nodes, "plan should be non-empty when final_state is provided"
+    assert graph_data["plan"]["start"] == plan_nodes[0]
+    assert graph_data["plan"]["goal"] == plan_nodes[-1]
+
+
+def test_export_graph_with_pickle(tmp_path: Path):
+    """export_graph_with_pickle writes a JSON + pickle pair with consistent IDs."""
+    bpg = _make_small_bpg()
+    json_path = tmp_path / "graph.json"
+    pickle_path = tmp_path / "states.pkl"
+    bpg.export_graph_with_pickle(
+        json_path=json_path,
+        pickle_path=pickle_path,
+        final_state=bpg.states[-1],
+    )
+
+    with open(json_path, encoding="utf-8") as f:
+        graph_data = json.load(f)
+    with open(pickle_path, "rb") as f:
+        state_data = pickle.load(f)
+
+    # Every concrete node in the JSON should have a matching state object in
+    # the pickle, and the state objects should be the originals (not strings).
+    concrete_ids = {n["id"] for n in graph_data["nodes"] if n["type"] == "concrete"}
+    assert concrete_ids
+    assert concrete_ids.issubset(set(state_data.keys()))
+    for state in state_data.values():
+        assert isinstance(state, np.ndarray)

--- a/bilevel-planning/tests/visualizer/test_app.py
+++ b/bilevel-planning/tests/visualizer/test_app.py
@@ -1,0 +1,120 @@
+"""Smoke tests for the visualizer Flask backend.
+
+Uses Flask's in-process test client so these tests run inside pytest without starting a
+real server.
+"""
+
+import base64
+import io
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
+from bilevel_planning.visualizer import app as visualizer_app
+from bilevel_planning.visualizer.app import create_app
+
+
+@pytest.fixture(autouse=True)
+def _reset_state_data():
+    """Clear the module-level STATE_DATA cache before each test.
+
+    ``app.py`` stores loaded pickle contents in a module global so the Flask
+    routes can see them across requests. That's fine for a running backend
+    but leaks between tests; reset it so each test starts fresh.
+    """
+    visualizer_app.STATE_DATA = {}
+    yield
+    visualizer_app.STATE_DATA = {}
+
+
+def _constant_color_renderer(state: np.ndarray) -> np.ndarray:
+    """Render each state as a small solid-color patch."""
+    color = np.asarray(state, dtype=np.uint8).reshape(-1)[:3]
+    if color.size < 3:
+        color = np.pad(color, (0, 3 - color.size))
+    return np.broadcast_to(color, (8, 8, 3)).astype(np.uint8)
+
+
+def _write_demo_pickle(tmp_path: Path) -> tuple[Path, list[str]]:
+    """Build a small BPG, export its state pickle, return the path and node ids."""
+    bpg: BilevelPlanningGraph = BilevelPlanningGraph()
+    states = [
+        np.array([220, 40, 40], dtype=np.uint8),
+        np.array([40, 90, 210], dtype=np.uint8),
+        np.array([50, 180, 70], dtype=np.uint8),
+    ]
+    for s in states:
+        bpg.add_state_node(s)
+    bpg.add_abstract_state_node("start")
+    bpg.add_abstract_state_node("end")
+    bpg.add_state_abstractor_edge(states[0], "start")
+    bpg.add_state_abstractor_edge(states[-1], "end")
+    bpg.add_abstract_action_edge("start", "go", "end")
+    for a, b in zip(states[:-1], states[1:]):
+        bpg.add_action_edge(a, "step", b)
+
+    pickle_path = tmp_path / "demo.pkl"
+    bpg.export_state_data_pickle(pickle_path)
+
+    # Load the pickle we just wrote to discover the node ids without
+    # touching BilevelPlanningGraph's private hashing method.
+    with open(pickle_path, "rb") as f:
+        state_data = pickle.load(f)
+    return pickle_path, list(state_data.keys())
+
+
+def test_health_endpoint(tmp_path: Path):
+    """``/api/health`` reports an empty backend before any pickle is loaded."""
+    app = create_app(_constant_color_renderer, data_dir=tmp_path)
+    client = app.test_client()
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "healthy"
+    assert payload["state_data_loaded"] is False
+    assert payload["num_states"] == 0
+
+
+def test_load_and_visualize_roundtrip(tmp_path: Path):
+    """Loading a pickle and visualizing a node returns a decodable PNG."""
+    pickle_path, node_ids = _write_demo_pickle(tmp_path)
+
+    app = create_app(_constant_color_renderer, data_dir=tmp_path)
+    client = app.test_client()
+
+    # Load the pickle by bare filename (exercises data_dir resolution).
+    resp = client.post("/api/load_pickle", json={"pickle_path": pickle_path.name})
+    assert resp.status_code == 200, resp.get_json()
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["num_states"] == len(node_ids)
+
+    # Visualize one of the nodes and confirm the PNG decodes correctly.
+    target = node_ids[0]
+    resp = client.post("/api/visualize_state", json={"node_id": target})
+    assert resp.status_code == 200, resp.get_json()
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["node_id"] == target
+    assert payload["image"].startswith("data:image/png;base64,")
+
+    png_b64 = payload["image"].split(",", 1)[1]
+    image = Image.open(io.BytesIO(base64.b64decode(png_b64)))
+    assert image.size == (8, 8)
+    assert image.mode in ("RGB", "RGBA")
+
+
+def test_visualize_unknown_node_returns_404(tmp_path: Path):
+    """Asking for a node id that isn't in the loaded pickle returns 404."""
+    pickle_path, _ = _write_demo_pickle(tmp_path)
+
+    app = create_app(_constant_color_renderer, data_dir=tmp_path)
+    client = app.test_client()
+    client.post("/api/load_pickle", json={"pickle_path": pickle_path.name})
+
+    resp = client.post("/api/visualize_state", json={"node_id": "x:doesnotexist"})
+    assert resp.status_code == 404


### PR DESCRIPTION
Introduces bilevel_planning.visualizer.app, a Flask backend that takes a caller-supplied render_state_fn and serves three endpoints:

  GET  /api/health          - status + number of loaded states
  POST /api/load_pickle     - load a {node_id: state} pickle by path
  POST /api/visualize_state - render one node as a base64 PNG

The module is env-agnostic by design: it does not import kinder, kindergarden, gymnasium, or any simulation package. Callers own env construction in their own launcher script and pass the resulting render_state_fn to run_webapp(). This keeps bilevel-planning free of sim-package deps and lets any env (or synthetic renderer) plug in.

Adds a [visualizer] optional extra in pyproject.toml for flask, flask-cors, and pillow, and an in-process pytest smoke test that builds a tiny BPG, exports it, loads it via Flask's test client, and verifies a roundtrip PNG for a node. The test is pytest.importorskip-gated so it silently skips when the extra isn't installed.