### PR TITLE
consolidate visualizer JSON+pickle into a single pickle bundle

### DIFF
--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -1,6 +1,5 @@
 """Bilevel planning graphs: primarily for visualization, analysis, debugging."""
 
-import json
 import pickle
 from pathlib import Path
 from typing import Callable, Generic, Hashable, TypeVar
@@ -326,7 +325,7 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
 
         Planned follow-ups (tracked on this helper because this is the only
         call site; see also the comments at each individual concern):
-          * Fold this method into ``export_graph_for_web``. The split exists
+          * Fold this method into ``_build_graph_payload``. The split exists
             for no reason — nothing else calls ``_build_graph_structure``.
           * Drop the styling parameters. Colors and sizes are presentation
             concerns that belong in the frontend, not in the export.
@@ -621,7 +620,7 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
 
         return G, pos, metadata
 
-    def export_graph_for_web(
+    def _build_graph_payload(
         self,
         final_state: _X | None = None,
         abstract_state_color: str = "tab:purple",
@@ -634,9 +633,7 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         node_alpha: float = 0.7,
         edge_alpha: float = 0.7,
     ) -> dict:
-        """Export graph structure as JSON-serializable dictionary for web frontend.
-
-        Returns a dictionary with nodes, edges, plan info, and configuration.
+        """Build the frontend-facing topology dict (nodes, edges, plan, config).
 
         Planned follow-ups:
           * All of the color/size/alpha parameters should move to the
@@ -646,10 +643,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
             exist — once the frontend owns styling, the map disappears.
           * Fold ``_build_graph_structure`` into this method; it has no
             other caller.
-          * Consolidate this method and ``export_state_data_pickle`` into a
-            single pickle artifact (see ``export_graph_with_pickle`` for the
-            combined note). The frontend currently has to load a JSON file
-            *and* a pickle path separately, which is awkward.
         """
         # Build the graph structure
         G, pos, metadata = self._build_graph_structure(
@@ -802,54 +795,33 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
 
         return graph_data
 
-    def export_state_data_pickle(self, pickle_path: Path) -> None:
-        """Export pickled state data dictionary for backend use.
-
-        This saves a dictionary mapping node IDs to actual state objects (not strings).
-        The backend can load this pickle to access the original state representations.
-
-        Planned follow-up: merge this into a single pickle artifact that also
-        contains the graph topology dict. Today the frontend uploads a JSON
-        file and separately tells the backend a pickle path — users have to
-        manage two files for one "visualization." One pickle, served through
-        a ``/api/graph`` endpoint after load, is the target.
-        """
-        # Build state data dictionary with actual state objects
-        state_data_pickle = {}
-        for state in self.states:
-            state_id = self._state_to_id(state)
-            node_id = f"x:{state_id}"
-            # Store the actual state object, not string representation
-            state_data_pickle[node_id] = state
-
-        # Save as pickle
-        with open(pickle_path, "wb") as f:
-            pickle.dump(state_data_pickle, f)
-
-    def export_graph_with_pickle(
+    def export(
         self,
-        json_path: Path,
-        pickle_path: Path,
+        path: Path,
         final_state: _X | None = None,
         **kwargs,
-    ) -> dict:
-        """Export graph to JSON and pickle state data.
+    ) -> None:
+        """Write a single pickle bundling graph topology and state objects.
 
-        Planned follow-up: collapse to a single ``export(path)`` method that
-        writes one pickle containing both the graph topology and the state
-        dict. The JSON/pickle split here is a historical accident — JSON
-        can't hold arbitrary Python state objects, so the junior version
-        split the topology (JSON) from the states (pickle). Since the
-        frontend gets the topology from the backend over HTTP anyway, the
-        whole thing can just be one pickle the user loads once.
+        The resulting pickle is a dict with two keys:
+
+          * ``"graph"``: the frontend-facing topology dict (nodes, edges,
+            plan info, config) produced by ``_build_graph_payload``. The
+            backend serves this through ``GET /api/graph``.
+          * ``"states"``: ``{node_id: state}``, mapping node ids of the form
+            ``"x:<state_id>"`` to the original state objects. The backend
+            indexes into this when rendering a specific node.
+
+        The topology half has string reprs of states under ``state_data`` for
+        display; the real objects live in ``"states"`` so that rendering can
+        reconstruct them without needing to unpickle topology data.
         """
-        # Export JSON graph data
-        graph_data = self.export_graph_for_web(final_state=final_state, **kwargs)
+        graph_payload = self._build_graph_payload(final_state=final_state, **kwargs)
+        states_payload: dict[str, _X] = {}
+        for state in self.states:
+            state_id = self._state_to_id(state)
+            states_payload[f"x:{state_id}"] = state
 
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(graph_data, f, indent=2)
-
-        # Export pickled state data
-        self.export_state_data_pickle(pickle_path)
-
-        return graph_data
+        bundle = {"graph": graph_payload, "states": states_payload}
+        with open(path, "wb") as f:
+            pickle.dump(bundle, f)

--- a/bilevel-planning/src/bilevel_planning/visualizer/app.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/app.py
@@ -23,6 +23,11 @@ from PIL import Image  # type: ignore[import-untyped]
 
 RenderStateFn = Callable[[Any], np.ndarray]
 
+# Backend state. ``GRAPH_DATA`` is the frontend-facing topology dict served
+# by ``/api/graph``; ``STATE_DATA`` maps node ids to the original state
+# objects, indexed into by ``/api/visualize_state``. Both halves come from
+# the same pickle produced by ``BilevelPlanningGraph.export``.
+GRAPH_DATA: dict = {}
 STATE_DATA: dict = {}
 
 
@@ -48,7 +53,7 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
 
     @app.route("/api/load_pickle", methods=["POST"])
     def load_pickle():
-        global STATE_DATA
+        global GRAPH_DATA, STATE_DATA
         try:
             data = request.get_json()
             pickle_path_str = data["pickle_path"]
@@ -67,15 +72,33 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
                 )
 
             with open(pickle_path, "rb") as f:
-                STATE_DATA = pickle.load(f)
+                bundle = pickle.load(f)
+
+            if not (
+                isinstance(bundle, dict) and "graph" in bundle and "states" in bundle
+            ):
+                return (
+                    jsonify(
+                        {
+                            "error": (
+                                "Pickle is not a bilevel-planning visualizer "
+                                "bundle; expected a dict with 'graph' and "
+                                "'states' keys. Regenerate with "
+                                "BilevelPlanningGraph.export()."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+
+            GRAPH_DATA = bundle["graph"]
+            STATE_DATA = bundle["states"]
 
             num_states = len(STATE_DATA)
-            node_ids = list(STATE_DATA.keys())[:5]
             return jsonify(
                 {
                     "success": True,
                     "num_states": num_states,
-                    "sample_node_ids": node_ids,
                     "message": f"Loaded {num_states} states from {pickle_path.name}",
                     "full_path": str(pickle_path),
                 }
@@ -85,6 +108,15 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
             return jsonify({"error": "pickle_path is required in request body"}), 400
         except Exception as e:  # pylint: disable=broad-exception-caught
             return jsonify({"error": str(e), "traceback": traceback.format_exc()}), 500
+
+    @app.route("/api/graph", methods=["GET"])
+    def graph():
+        if not GRAPH_DATA:
+            return (
+                jsonify({"error": "No graph loaded. Call /api/load_pickle first."}),
+                400,
+            )
+        return jsonify(GRAPH_DATA)
 
     @app.route("/api/visualize_state", methods=["POST"])
     def visualize_state():
@@ -140,7 +172,7 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
         return jsonify(
             {
                 "status": "healthy",
-                "state_data_loaded": len(STATE_DATA) > 0,
+                "graph_loaded": bool(GRAPH_DATA),
                 "num_states": len(STATE_DATA),
             }
         )
@@ -164,17 +196,11 @@ def run_webapp(
     by bare filename. Defaults to ``./webapp/data`` under the current working
     directory.
 
-    Planned follow-ups (tracked here and in related visualizer files):
-      * Replace the JSON + pickle pair with a single pickle artifact and add
-        a ``/api/graph`` endpoint so the frontend fetches the topology from
-        the backend instead of uploading JSON itself.
-      * Add a ``/api/set_renderer`` endpoint that accepts Python source for
-        ``render_state_fn``, ``exec``s it, and caches the resulting callable.
-        Lets users launch the webapp with no bespoke script and write their
-        render function in a browser editor pane. Localhost-only — not for
-        hosted deployment.
-      * Move the React frontend under ``src/bilevel_planning/visualizer/
-        frontend/`` so all visualizer code lives under one name.
+    Planned follow-up: add a ``/api/set_renderer`` endpoint that accepts
+    Python source for ``render_state_fn``, ``exec``s it, and caches the
+    resulting callable. Lets users launch the webapp with no bespoke script
+    and write their render function in a browser editor pane.
+    Localhost-only — not for hosted deployment.
     """
     resolved_data_dir = (
         Path(data_dir) if data_dir is not None else Path.cwd() / "webapp" / "data"

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/README.md
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/README.md
@@ -29,8 +29,6 @@ Outputs a static bundle to `dist/`.
 
 ## Planned follow-ups
 
-- Move topology loading to the backend so users upload only one artifact
-  (a single pickle) instead of a JSON + pickle pair.
 - Add an in-browser Python editor pane that defines `render_state_fn`
   and posts it to `/api/set_renderer`, removing the need for a bespoke
   launcher script per environment.

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/App.jsx
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/App.jsx
@@ -22,8 +22,7 @@ function App() {
       if (response.ok) {
         const data = await response.json();
         setBackendStatus('connected');
-        // Update pickle loaded status from backend
-        setPickleLoaded(data.state_data_loaded);
+        setPickleLoaded(data.graph_loaded);
       } else {
         setBackendStatus('error');
         setPickleLoaded(false);
@@ -51,64 +50,50 @@ function App() {
         },
         body: JSON.stringify({ pickle_path: path })
       });
-      
+
       const data = await response.json();
-      
-      if (response.ok) {
-        console.log('Pickle loaded successfully:', data);
-        setPickleLoaded(true);
-        setError(null);
-        alert(`Successfully loaded ${data.num_states} states from ${data.full_path || path}`);
-      } else {
+
+      if (!response.ok) {
         console.error('Error loading pickle:', data.error);
         let errorMsg = `Failed to load pickle: ${data.error}`;
         if (data.attempted_paths) {
           errorMsg += `\nAttempted paths:\n${data.attempted_paths.join('\n')}`;
         }
         setError(errorMsg);
+        setGraphData(null);
+        setPickleLoaded(false);
+        return;
       }
-      
-      // Refresh backend status
+
+      // Backend loaded the bundle; fetch the topology for the viewer.
+      const graphResp = await fetch('http://localhost:5001/api/graph');
+      if (!graphResp.ok) {
+        const graphErr = await graphResp.json();
+        setError(`Failed to fetch graph: ${graphErr.error}`);
+        setGraphData(null);
+        setPickleLoaded(false);
+        return;
+      }
+      const graphJson = await graphResp.json();
+
+      if (!graphJson.nodes || !graphJson.edges || !graphJson.config) {
+        setError('Backend returned a graph with an unexpected shape');
+        setGraphData(null);
+        setPickleLoaded(false);
+        return;
+      }
+
+      console.log(
+        `Loaded ${data.num_states} states; graph has ${graphJson.nodes.length} nodes, ${graphJson.edges.length} edges`
+      );
+      setGraphData(graphJson);
+      setPickleLoaded(true);
+      setError(null);
       await checkBackendHealth();
     } catch (err) {
       console.error('Error loading pickle:', err);
       setError(`Error: ${err.message}`);
     }
-  };
-
-  const handleFileUpload = (event) => {
-    const file = event.target.files[0];
-    if (!file) return;
-
-    console.log('Loading file:', file.name);
-    const reader = new FileReader();
-    
-    reader.onload = (e) => {
-      try {
-        const json = JSON.parse(e.target.result);
-        console.log('Parsed JSON:', json);
-        
-        // Validate the JSON structure
-        if (!json.nodes || !json.edges || !json.config) {
-          throw new Error('Invalid graph data structure');
-        }
-        
-        console.log(`Graph loaded: ${json.nodes.length} nodes, ${json.edges.length} edges`);
-        setGraphData(json);
-        setError(null);
-      } catch (err) {
-        console.error('Error parsing JSON:', err);
-        setError(`Error parsing JSON: ${err.message}`);
-        setGraphData(null);
-      }
-    };
-    
-    reader.onerror = () => {
-      console.error('Error reading file');
-      setError('Error reading file');
-    };
-    
-    reader.readAsText(file);
   };
 
 
@@ -117,15 +102,6 @@ function App() {
       <header style={styles.header}>
         <h1 style={styles.title}>Bilevel Planning Graph Viewer</h1>
         <div style={styles.controls}>
-          <label style={styles.fileLabel}>
-            Load Graph JSON:
-            <input
-              type="file"
-              accept=".json"
-              onChange={handleFileUpload}
-              style={styles.fileInput}
-            />
-          </label>
           <div style={styles.pathInputContainer}>
             <input
               type="text"
@@ -209,20 +185,6 @@ const styles = {
     gap: '15px',
     alignItems: 'center',
     flexWrap: 'wrap',
-  },
-  fileLabel: {
-    cursor: 'pointer',
-    padding: '8px 12px',
-    backgroundColor: '#4CAF50',
-    borderRadius: '4px',
-    fontSize: '14px',
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '8px',
-  },
-  fileInput: {
-    marginLeft: '8px',
-    fontSize: '14px',
   },
   button: {
     padding: '8px 16px',

--- a/bilevel-planning/tests/test_bilevel_planning_graph.py
+++ b/bilevel-planning/tests/test_bilevel_planning_graph.py
@@ -1,6 +1,5 @@
 """Tests for bilevel_planning_graph.py."""
 
-import json
 import pickle
 from pathlib import Path
 
@@ -81,46 +80,34 @@ def _make_small_bpg() -> BilevelPlanningGraph:
     return bpg
 
 
-def test_export_graph_for_web():
-    """export_graph_for_web returns a JSON-serializable dict with expected keys."""
-    bpg = _make_small_bpg()
-    final_state = bpg.states[-1]
-    graph_data = bpg.export_graph_for_web(final_state=final_state)
+def test_export_roundtrip(tmp_path: Path):
+    """``export`` writes a single pickle with a ``graph`` and ``states`` half.
 
-    assert set(graph_data.keys()) >= {"nodes", "edges", "plan", "config", "state_data"}
+    Every concrete node referenced in the topology half should be keyed in the states
+    half, and the stored states should be the originals (not string reprs).
+    """
+    bpg = _make_small_bpg()
+    path = tmp_path / "bundle.pkl"
+    bpg.export(path, final_state=bpg.states[-1])
+
+    with open(path, "rb") as f:
+        bundle = pickle.load(f)
+
+    assert set(bundle.keys()) == {"graph", "states"}
+    graph = bundle["graph"]
+    states = bundle["states"]
+
+    assert set(graph.keys()) >= {"nodes", "edges", "plan", "config", "state_data"}
+
     # The exporter prunes degree-1 chain nodes; at minimum the start and goal
     # (both of which have abstract-state mappings) should survive.
-    concrete = [n for n in graph_data["nodes"] if n["type"] == "concrete"]
-    assert len(concrete) >= 2
-    # Round-trip through json to confirm serializability.
-    json.loads(json.dumps(graph_data))
-
-    plan_nodes = graph_data["plan"]["nodes"]
-    assert plan_nodes, "plan should be non-empty when final_state is provided"
-    assert graph_data["plan"]["start"] == plan_nodes[0]
-    assert graph_data["plan"]["goal"] == plan_nodes[-1]
-
-
-def test_export_graph_with_pickle(tmp_path: Path):
-    """export_graph_with_pickle writes a JSON + pickle pair with consistent IDs."""
-    bpg = _make_small_bpg()
-    json_path = tmp_path / "graph.json"
-    pickle_path = tmp_path / "states.pkl"
-    bpg.export_graph_with_pickle(
-        json_path=json_path,
-        pickle_path=pickle_path,
-        final_state=bpg.states[-1],
-    )
-
-    with open(json_path, encoding="utf-8") as f:
-        graph_data = json.load(f)
-    with open(pickle_path, "rb") as f:
-        state_data = pickle.load(f)
-
-    # Every concrete node in the JSON should have a matching state object in
-    # the pickle, and the state objects should be the originals (not strings).
-    concrete_ids = {n["id"] for n in graph_data["nodes"] if n["type"] == "concrete"}
-    assert concrete_ids
-    assert concrete_ids.issubset(set(state_data.keys()))
-    for state in state_data.values():
+    concrete_ids = {n["id"] for n in graph["nodes"] if n["type"] == "concrete"}
+    assert len(concrete_ids) >= 2
+    assert concrete_ids.issubset(set(states.keys()))
+    for state in states.values():
         assert isinstance(state, np.ndarray)
+
+    plan_nodes = graph["plan"]["nodes"]
+    assert plan_nodes, "plan should be non-empty when final_state is provided"
+    assert graph["plan"]["start"] == plan_nodes[0]
+    assert graph["plan"]["goal"] == plan_nodes[-1]

--- a/bilevel-planning/tests/visualizer/test_app.py
+++ b/bilevel-planning/tests/visualizer/test_app.py
@@ -19,15 +19,17 @@ from bilevel_planning.visualizer.app import create_app
 
 
 @pytest.fixture(autouse=True)
-def _reset_state_data():
-    """Clear the module-level STATE_DATA cache before each test.
+def _reset_module_state():
+    """Clear the module-level caches before each test.
 
-    ``app.py`` stores loaded pickle contents in a module global so the Flask
+    ``app.py`` stores the loaded bundle in two module globals so the Flask
     routes can see them across requests. That's fine for a running backend
-    but leaks between tests; reset it so each test starts fresh.
+    but leaks between tests; reset both so each test starts fresh.
     """
+    visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
     yield
+    visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
 
 
@@ -39,8 +41,8 @@ def _constant_color_renderer(state: np.ndarray) -> np.ndarray:
     return np.broadcast_to(color, (8, 8, 3)).astype(np.uint8)
 
 
-def _write_demo_pickle(tmp_path: Path) -> tuple[Path, list[str]]:
-    """Build a small BPG, export its state pickle, return the path and node ids."""
+def _write_demo_bundle(tmp_path: Path) -> tuple[Path, list[str]]:
+    """Build a small BPG, export the bundle, return the path and node ids."""
     bpg: BilevelPlanningGraph = BilevelPlanningGraph()
     states = [
         np.array([220, 40, 40], dtype=np.uint8),
@@ -57,14 +59,14 @@ def _write_demo_pickle(tmp_path: Path) -> tuple[Path, list[str]]:
     for a, b in zip(states[:-1], states[1:]):
         bpg.add_action_edge(a, "step", b)
 
-    pickle_path = tmp_path / "demo.pkl"
-    bpg.export_state_data_pickle(pickle_path)
+    bundle_path = tmp_path / "demo.pkl"
+    bpg.export(bundle_path, final_state=states[-1])
 
     # Load the pickle we just wrote to discover the node ids without
     # touching BilevelPlanningGraph's private hashing method.
-    with open(pickle_path, "rb") as f:
-        state_data = pickle.load(f)
-    return pickle_path, list(state_data.keys())
+    with open(bundle_path, "rb") as f:
+        bundle = pickle.load(f)
+    return bundle_path, list(bundle["states"].keys())
 
 
 def test_health_endpoint(tmp_path: Path):
@@ -75,23 +77,36 @@ def test_health_endpoint(tmp_path: Path):
     assert resp.status_code == 200
     payload = resp.get_json()
     assert payload["status"] == "healthy"
-    assert payload["state_data_loaded"] is False
+    assert payload["graph_loaded"] is False
     assert payload["num_states"] == 0
 
 
-def test_load_and_visualize_roundtrip(tmp_path: Path):
-    """Loading a pickle and visualizing a node returns a decodable PNG."""
-    pickle_path, node_ids = _write_demo_pickle(tmp_path)
+def test_graph_endpoint_requires_load(tmp_path: Path):
+    """``/api/graph`` returns 400 until a bundle has been loaded."""
+    app = create_app(_constant_color_renderer, data_dir=tmp_path)
+    client = app.test_client()
+    resp = client.get("/api/graph")
+    assert resp.status_code == 400
+
+
+def test_load_graph_and_visualize_roundtrip(tmp_path: Path):
+    """Loading a bundle exposes both the topology and per-node rendering."""
+    bundle_path, node_ids = _write_demo_bundle(tmp_path)
 
     app = create_app(_constant_color_renderer, data_dir=tmp_path)
     client = app.test_client()
 
-    # Load the pickle by bare filename (exercises data_dir resolution).
-    resp = client.post("/api/load_pickle", json={"pickle_path": pickle_path.name})
+    resp = client.post("/api/load_pickle", json={"pickle_path": bundle_path.name})
     assert resp.status_code == 200, resp.get_json()
     payload = resp.get_json()
     assert payload["success"] is True
     assert payload["num_states"] == len(node_ids)
+
+    # After load, /api/graph serves the topology.
+    resp = client.get("/api/graph")
+    assert resp.status_code == 200
+    graph = resp.get_json()
+    assert set(graph.keys()) >= {"nodes", "edges", "plan", "config"}
 
     # Visualize one of the nodes and confirm the PNG decodes correctly.
     target = node_ids[0]
@@ -109,12 +124,24 @@ def test_load_and_visualize_roundtrip(tmp_path: Path):
 
 
 def test_visualize_unknown_node_returns_404(tmp_path: Path):
-    """Asking for a node id that isn't in the loaded pickle returns 404."""
-    pickle_path, _ = _write_demo_pickle(tmp_path)
+    """Asking for a node id that isn't in the loaded bundle returns 404."""
+    bundle_path, _ = _write_demo_bundle(tmp_path)
 
     app = create_app(_constant_color_renderer, data_dir=tmp_path)
     client = app.test_client()
-    client.post("/api/load_pickle", json={"pickle_path": pickle_path.name})
+    client.post("/api/load_pickle", json={"pickle_path": bundle_path.name})
 
     resp = client.post("/api/visualize_state", json={"node_id": "x:doesnotexist"})
     assert resp.status_code == 404
+
+
+def test_load_pickle_rejects_wrong_shape(tmp_path: Path):
+    """A pickle that isn't a ``{'graph':..., 'states':...}`` bundle is rejected."""
+    bad_path = tmp_path / "bad.pkl"
+    with open(bad_path, "wb") as f:
+        pickle.dump({"only_states": {}}, f)
+
+    app = create_app(_constant_color_renderer, data_dir=tmp_path)
+    client = app.test_client()
+    resp = client.post("/api/load_pickle", json={"pickle_path": bad_path.name})
+    assert resp.status_code == 400


### PR DESCRIPTION
Previously the visualizer split its payload across two files: a JSON file with the graph topology (nodes, edges, plan, config) and a pickle file with {node_id: state} for rendering. The frontend had to upload the JSON itself and separately tell the backend which pickle to load, so a single 'visualization' meant managing two files.

This change collapses both halves into one pickle containing {'graph': <topology dict>, 'states': <{node_id: state}>}, replaces the two-method export API with a single BilevelPlanningGraph.export(path), adds a GET /api/graph endpoint that serves the topology after /api/load_pickle, and drops the 'Load Graph JSON' file picker from the React frontend in favor of fetching the topology from the backend.

Also renames the internal helper export_graph_for_web to _build_graph_payload (it's no longer a public entry point), drops the unused 'import json' from bilevel_planning_graph.py, and adds backend tests for /api/graph and for the 'bundle has the wrong shape' rejection path.