### PR TITLE
add browser-side Python renderer and universal visualizer entrypoint

### DIFF
--- a/bilevel-planning/src/bilevel_planning/visualizer/__main__.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/__main__.py
@@ -1,0 +1,58 @@
+"""Universal entry point for the bilevel planning visualizer backend.
+
+Usage:
+
+    python -m bilevel_planning.visualizer [--data-dir PATH] [--port N] [--no-debug]
+
+Boots the Flask backend with no renderer installed. Use the browser UI
+(or a direct ``POST /api/set_renderer``) to supply the Python source for
+``render_state`` once the server is up. See ``bilevel_planning.visualizer.app``
+for details on the security model.
+"""
+
+import argparse
+
+from bilevel_planning.visualizer.app import run_webapp
+
+
+def main() -> None:
+    """Parse CLI args and launch the visualizer backend."""
+    parser = argparse.ArgumentParser(
+        prog="python -m bilevel_planning.visualizer",
+        description=(
+            "Run the bilevel planning visualizer backend. The renderer is "
+            "installed at runtime via POST /api/set_renderer from the browser."
+        ),
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        help=(
+            "Directory searched when the frontend requests a pickle by bare "
+            "filename. Defaults to ./webapp/data under the current working "
+            "directory."
+        ),
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5001,
+        help="Port to bind the Flask server to (default: 5001).",
+    )
+    parser.add_argument(
+        "--no-debug",
+        action="store_true",
+        help="Disable Flask's debug mode (auto-reload + verbose errors).",
+    )
+    args = parser.parse_args()
+
+    run_webapp(
+        render_state_fn=None,
+        data_dir=args.data_dir,
+        port=args.port,
+        debug=not args.no_debug,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bilevel-planning/src/bilevel_planning/visualizer/app.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/app.py
@@ -1,10 +1,24 @@
 """Flask backend for visualizing concrete states from a bilevel planning graph.
 
-This module is environment-agnostic: it does not import or construct any
-simulation environment. Callers supply a ``render_state_fn`` that maps a
-concrete state (as stored in the pickled bilevel planning graph) to an RGB
-image. Launch the webapp by importing ``run_webapp`` from your own script,
-where you own the env construction.
+Environment-agnostic: the backend never imports a simulation package. A
+caller-supplied ``render_state_fn`` maps a concrete state (as stored in the
+pickled bilevel planning graph) to an RGB image. There are two ways to
+supply it:
+
+1. Pass one directly when calling ``run_webapp`` from your own Python
+   script. Useful when the environment is expensive to construct and you
+   want to warm it up before the server starts.
+
+2. Launch with no render fn (``python -m bilevel_planning.visualizer``)
+   and POST Python source to ``/api/set_renderer`` from the browser. The
+   backend ``exec``s the source, expects a callable named ``render_state``
+   to land in the namespace, and caches it for subsequent
+   ``/api/visualize_state`` requests.
+
+Security: ``/api/set_renderer`` runs arbitrary Python in the backend
+process. The server binds to ``127.0.0.1`` so only local clients can reach
+it. Do not put this behind a reverse proxy exposing it to untrusted
+networks.
 """
 
 # pylint: disable=global-statement
@@ -25,10 +39,18 @@ RenderStateFn = Callable[[Any], np.ndarray]
 
 # Backend state. ``GRAPH_DATA`` is the frontend-facing topology dict served
 # by ``/api/graph``; ``STATE_DATA`` maps node ids to the original state
-# objects, indexed into by ``/api/visualize_state``. Both halves come from
-# the same pickle produced by ``BilevelPlanningGraph.export``.
+# objects, indexed into by ``/api/visualize_state``. Both come from the
+# same pickle produced by ``BilevelPlanningGraph.export``. ``RENDER_FN`` is
+# the current render callable, either injected at construction time or
+# installed later via ``/api/set_renderer``.
 GRAPH_DATA: dict = {}
 STATE_DATA: dict = {}
+RENDER_FN: RenderStateFn | None = None
+
+# Name the exec'd source must bind to for ``/api/set_renderer`` to pick it
+# up. Keeping this a constant makes the browser template and the backend
+# agree without hardcoding duplicate strings.
+RENDERER_ENTRYPOINT = "render_state"
 
 
 def _resolve_pickle_path(
@@ -46,8 +68,19 @@ def _resolve_pickle_path(
     return None, attempted
 
 
-def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
-    """Build the Flask app with the given state renderer."""
+def create_app(
+    render_state_fn: RenderStateFn | None,
+    data_dir: Path,
+) -> Flask:
+    """Build the Flask app.
+
+    If ``render_state_fn`` is None, the app boots without a renderer and
+    ``/api/visualize_state`` returns 400 until one is installed via
+    ``/api/set_renderer``.
+    """
+    global RENDER_FN
+    RENDER_FN = render_state_fn
+
     app = Flask(__name__)
     CORS(app)
 
@@ -118,6 +151,61 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
             )
         return jsonify(GRAPH_DATA)
 
+    @app.route("/api/set_renderer", methods=["POST"])
+    def set_renderer():
+        """Install a user-supplied ``render_state`` callable from Python source.
+
+        Request body: ``{"source": "<python source code>"}``. The source is
+        exec'd in a fresh namespace and must bind a callable named
+        ``render_state`` that takes one argument (a state from the loaded
+        pickle) and returns an HxWx3 uint8 RGB array.
+        """
+        global RENDER_FN
+        try:
+            data = request.get_json()
+            if not data or "source" not in data:
+                return (
+                    jsonify({"error": "Request body must include a 'source' field."}),
+                    400,
+                )
+            source = data["source"]
+
+            namespace: dict[str, Any] = {}
+            try:
+                # pylint: disable=exec-used
+                exec(source, namespace)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                return (
+                    jsonify(
+                        {
+                            "error": f"Renderer source failed to execute: {exc}",
+                            "traceback": traceback.format_exc(),
+                        }
+                    ),
+                    400,
+                )
+
+            candidate = namespace.get(RENDERER_ENTRYPOINT)
+            if not callable(candidate):
+                return (
+                    jsonify(
+                        {
+                            "error": (
+                                f"Source must define a callable named "
+                                f"'{RENDERER_ENTRYPOINT}' taking a single "
+                                f"state argument."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+
+            RENDER_FN = candidate
+            return jsonify({"success": True})
+
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return jsonify({"error": str(e), "traceback": traceback.format_exc()}), 500
+
     @app.route("/api/visualize_state", methods=["POST"])
     def visualize_state():
         try:
@@ -137,11 +225,25 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
                     400,
                 )
 
+            if RENDER_FN is None:
+                return (
+                    jsonify(
+                        {
+                            "error": (
+                                "No renderer installed. POST Python source "
+                                "to /api/set_renderer or pass render_state_fn "
+                                "to run_webapp()."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+
             if node_id not in STATE_DATA:
                 return jsonify({"error": f"Node ID not found: {node_id}"}), 404
 
             state = STATE_DATA[node_id]
-            rgb_array = render_state_fn(state)
+            rgb_array = RENDER_FN(state)
             image = Image.fromarray(np.asarray(rgb_array).astype("uint8"))
 
             buffer = io.BytesIO()
@@ -174,6 +276,7 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
                 "status": "healthy",
                 "graph_loaded": bool(GRAPH_DATA),
                 "num_states": len(STATE_DATA),
+                "renderer_set": RENDER_FN is not None,
             }
         )
 
@@ -181,31 +284,28 @@ def create_app(render_state_fn: RenderStateFn, data_dir: Path) -> Flask:
 
 
 def run_webapp(
-    render_state_fn: RenderStateFn,
+    render_state_fn: RenderStateFn | None = None,
     data_dir: Path | str | None = None,
     port: int = 5001,
     debug: bool = True,
 ) -> None:
-    """Run the visualization Flask server.
+    """Run the visualization Flask server on localhost.
 
-    Callers supply ``render_state_fn``, which takes a concrete state from the
-    loaded pickle and returns an HxWx3 uint8 RGB array. The webapp itself has
-    no knowledge of the underlying environment.
+    If ``render_state_fn`` is None, the server boots without a renderer and
+    the user must install one via ``POST /api/set_renderer`` before any
+    ``/api/visualize_state`` request will succeed.
 
-    ``data_dir`` is the directory searched when the frontend requests a pickle
-    by bare filename. Defaults to ``./webapp/data`` under the current working
-    directory.
+    ``data_dir`` is the directory searched when the frontend requests a
+    pickle by bare filename. Defaults to ``./webapp/data`` under the
+    current working directory.
 
-    Planned follow-up: add a ``/api/set_renderer`` endpoint that accepts
-    Python source for ``render_state_fn``, ``exec``s it, and caches the
-    resulting callable. Lets users launch the webapp with no bespoke script
-    and write their render function in a browser editor pane.
-    Localhost-only — not for hosted deployment.
+    Binds to ``127.0.0.1`` — the ``/api/set_renderer`` endpoint runs
+    arbitrary Python and must not be reachable from outside the host.
     """
     resolved_data_dir = (
         Path(data_dir) if data_dir is not None else Path.cwd() / "webapp" / "data"
     )
     app = create_app(render_state_fn, resolved_data_dir)
-    print(f"Starting Flask backend on http://localhost:{port}")
+    print(f"Starting Flask backend on http://127.0.0.1:{port}")
     print(f"Pickle data directory: {resolved_data_dir}")
-    app.run(debug=debug, port=port)
+    app.run(debug=debug, port=port, host="127.0.0.1")

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/README.md
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/README.md
@@ -27,8 +27,18 @@ npm run build
 
 Outputs a static bundle to `dist/`.
 
-## Planned follow-ups
+## Installing a renderer
 
-- Add an in-browser Python editor pane that defines `render_state_fn`
-  and posts it to `/api/set_renderer`, removing the need for a bespoke
-  launcher script per environment.
+The visualizer won't display state images until the backend has a
+`render_state` callable. Two ways to supply one:
+
+- **Browser**: expand the "Python renderer" pane in the header, edit the
+  source, and click "Apply renderer". The source is POSTed to
+  `/api/set_renderer` and `exec`'d in the backend process, so any package
+  installed in the backend's Python environment is importable. Runs
+  arbitrary Python locally — don't expose the backend to untrusted
+  networks.
+- **Launcher script**: call `bilevel_planning.visualizer.app.run_webapp`
+  from your own Python with `render_state_fn=<your callable>`. Useful
+  when the environment is expensive to construct and you want it ready
+  before the server boots.

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/App.jsx
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/App.jsx
@@ -1,12 +1,24 @@
 import React, { useState } from 'react';
 import { GraphViewer3D } from './components/GraphViewer3D';
 
+const DEFAULT_RENDERER_SOURCE = `# Define a callable named render_state(state) that returns an
+# HxWx3 uint8 numpy array. Any package in the backend's Python
+# environment can be imported.
+import numpy as np
+
+def render_state(state):
+    return np.full((256, 256, 3), 128, dtype=np.uint8)
+`;
+
 function App() {
   const [graphData, setGraphData] = useState(null);
   const [error, setError] = useState(null);
   const [backendStatus, setBackendStatus] = useState('unknown');
   const [pickleLoaded, setPickleLoaded] = useState(false);
   const [picklePath, setPicklePath] = useState('');
+  const [rendererSource, setRendererSource] = useState(DEFAULT_RENDERER_SOURCE);
+  const [rendererSet, setRendererSet] = useState(false);
+  const [rendererStatus, setRendererStatus] = useState(null);
 
   // Check backend health on mount and periodically
   React.useEffect(() => {
@@ -23,13 +35,38 @@ function App() {
         const data = await response.json();
         setBackendStatus('connected');
         setPickleLoaded(data.graph_loaded);
+        setRendererSet(data.renderer_set);
       } else {
         setBackendStatus('error');
         setPickleLoaded(false);
+        setRendererSet(false);
       }
     } catch (err) {
       setBackendStatus('disconnected');
       setPickleLoaded(false);
+      setRendererSet(false);
+    }
+  };
+
+  const handleApplyRenderer = async () => {
+    setRendererStatus(null);
+    try {
+      const response = await fetch('http://localhost:5001/api/set_renderer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: rendererSource }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setRendererStatus({ ok: false, message: data.error || 'Failed to install renderer' });
+        setRendererSet(false);
+        return;
+      }
+      setRendererStatus({ ok: true, message: 'Renderer installed.' });
+      setRendererSet(true);
+    } catch (err) {
+      setRendererStatus({ ok: false, message: `Error: ${err.message}` });
+      setRendererSet(false);
     }
   };
 
@@ -116,8 +153,8 @@ function App() {
               disabled={backendStatus !== 'connected'}
               title="Tip: Right-click file in Finder, Copy as Pathname, then paste here"
             />
-            <button 
-              onClick={handleLoadPickleByPath} 
+            <button
+              onClick={handleLoadPickleByPath}
               style={{...styles.button, backgroundColor: '#9C27B0'}}
               disabled={backendStatus !== 'connected'}
               title="Load pickle file from path"
@@ -126,15 +163,51 @@ function App() {
             </button>
           </div>
         </div>
+        <details style={styles.rendererDetails}>
+          <summary style={styles.rendererSummary}>
+            Python renderer {rendererSet ? '(installed)' : '(not installed)'}
+          </summary>
+          <div style={styles.rendererPane}>
+            <textarea
+              value={rendererSource}
+              onChange={(e) => setRendererSource(e.target.value)}
+              style={styles.rendererTextarea}
+              spellCheck={false}
+              disabled={backendStatus !== 'connected'}
+            />
+            <div style={styles.rendererControls}>
+              <button
+                onClick={handleApplyRenderer}
+                style={{...styles.button, backgroundColor: '#4CAF50'}}
+                disabled={backendStatus !== 'connected'}
+              >
+                Apply renderer
+              </button>
+              {rendererStatus && (
+                <span
+                  style={{
+                    ...styles.rendererStatus,
+                    color: rendererStatus.ok ? '#4CAF50' : '#f44336',
+                  }}
+                >
+                  {rendererStatus.message}
+                </span>
+              )}
+            </div>
+          </div>
+        </details>
         {error && (
           <div style={styles.error}>
             {error}
           </div>
         )}
       </header>
-      
+
       <main style={styles.main}>
-        <GraphViewer3D graphData={graphData} pickleLoaded={pickleLoaded} />
+        <GraphViewer3D
+          graphData={graphData}
+          pickleLoaded={pickleLoaded && rendererSet}
+        />
       </main>
     </div>
   );
@@ -225,6 +298,41 @@ const styles = {
     color: 'white',
     borderRadius: '4px',
     fontSize: '14px',
+  },
+  rendererDetails: {
+    marginTop: '10px',
+    fontSize: '13px',
+  },
+  rendererSummary: {
+    cursor: 'pointer',
+    padding: '4px 0',
+    userSelect: 'none',
+  },
+  rendererPane: {
+    marginTop: '8px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  rendererTextarea: {
+    width: '100%',
+    minHeight: '140px',
+    padding: '10px',
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    fontSize: '13px',
+    color: 'white',
+    backgroundColor: '#1a1d24',
+    border: '1px solid #444',
+    borderRadius: '4px',
+    resize: 'vertical',
+  },
+  rendererControls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  rendererStatus: {
+    fontSize: '13px',
   },
   main: {
     flex: 1,

--- a/bilevel-planning/tests/visualizer/test_app.py
+++ b/bilevel-planning/tests/visualizer/test_app.py
@@ -22,15 +22,18 @@ from bilevel_planning.visualizer.app import create_app
 def _reset_module_state():
     """Clear the module-level caches before each test.
 
-    ``app.py`` stores the loaded bundle in two module globals so the Flask
-    routes can see them across requests. That's fine for a running backend
-    but leaks between tests; reset both so each test starts fresh.
+    ``app.py`` stores the loaded bundle and the current renderer in module
+    globals so the Flask routes can see them across requests. That's fine
+    for a running backend but leaks between tests; reset all three so each
+    test starts fresh.
     """
     visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
+    visualizer_app.RENDER_FN = None
     yield
     visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
+    visualizer_app.RENDER_FN = None
 
 
 def _constant_color_renderer(state: np.ndarray) -> np.ndarray:
@@ -79,6 +82,15 @@ def test_health_endpoint(tmp_path: Path):
     assert payload["status"] == "healthy"
     assert payload["graph_loaded"] is False
     assert payload["num_states"] == 0
+    assert payload["renderer_set"] is True
+
+
+def test_health_reports_no_renderer_when_none_installed(tmp_path: Path):
+    """Booting with ``render_state_fn=None`` leaves the renderer unset."""
+    app = create_app(None, data_dir=tmp_path)
+    client = app.test_client()
+    payload = client.get("/api/health").get_json()
+    assert payload["renderer_set"] is False
 
 
 def test_graph_endpoint_requires_load(tmp_path: Path):
@@ -145,3 +157,57 @@ def test_load_pickle_rejects_wrong_shape(tmp_path: Path):
     client = app.test_client()
     resp = client.post("/api/load_pickle", json={"pickle_path": bad_path.name})
     assert resp.status_code == 400
+
+
+def test_set_renderer_installs_callable_from_source(tmp_path: Path):
+    """Posting Python source to ``/api/set_renderer`` makes visualization work."""
+    bundle_path, node_ids = _write_demo_bundle(tmp_path)
+
+    # Boot with no renderer.
+    app = create_app(None, data_dir=tmp_path)
+    client = app.test_client()
+    client.post("/api/load_pickle", json={"pickle_path": bundle_path.name})
+
+    # Without a renderer, visualization is 400.
+    resp = client.post("/api/visualize_state", json={"node_id": node_ids[0]})
+    assert resp.status_code == 400
+
+    # Install a renderer via source.
+    source = (
+        "import numpy as np\n"
+        "def render_state(state):\n"
+        "    return np.zeros((4, 4, 3), dtype=np.uint8)\n"
+    )
+    resp = client.post("/api/set_renderer", json={"source": source})
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["success"] is True
+
+    # Health now reports the renderer is set.
+    assert client.get("/api/health").get_json()["renderer_set"] is True
+
+    # Visualization now works.
+    resp = client.post("/api/visualize_state", json={"node_id": node_ids[0]})
+    assert resp.status_code == 200
+    assert resp.get_json()["image"].startswith("data:image/png;base64,")
+
+
+def test_set_renderer_rejects_source_without_entrypoint(tmp_path: Path):
+    """Source that doesn't define ``render_state`` is rejected with 400."""
+    app = create_app(None, data_dir=tmp_path)
+    client = app.test_client()
+    resp = client.post("/api/set_renderer", json={"source": "x = 1\n"})
+    assert resp.status_code == 400
+    assert "render_state" in resp.get_json()["error"]
+
+
+def test_set_renderer_rejects_broken_source(tmp_path: Path):
+    """Source that raises during ``exec`` is rejected with 400 plus traceback."""
+    app = create_app(None, data_dir=tmp_path)
+    client = app.test_client()
+    resp = client.post(
+        "/api/set_renderer", json={"source": "raise RuntimeError('nope')\n"}
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert "nope" in payload["error"]
+    assert "traceback" in payload


### PR DESCRIPTION
Removes the need for a bespoke launcher script per environment. Two new supply paths for render_state_fn:

1. python -m bilevel_planning.visualizer (new __main__.py) boots the backend with no renderer. The user then POSTs Python source to /api/set_renderer, which execs it and installs the resulting 'render_state' callable. The frontend's new 'Python renderer' pane is a textarea + 'Apply renderer' button that does exactly this.

2. run_webapp(render_state_fn=<callable>, ...) still works for scripts that want to preload a heavy env before the server starts.

/api/visualize_state returns 400 until a renderer is installed, and /api/health reports 'renderer_set'. run_webapp now binds to 127.0.0.1 explicitly to keep the arbitrary-exec surface off any external network.

Adds four new backend tests: renderer installed via source, source missing the entrypoint, source raising during exec, and health reporting renderer_set=false when booted without one.