### PR TITLE
make the visualizer renderer browser-only

### DIFF
--- a/bilevel-planning/src/bilevel_planning/visualizer/__main__.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/__main__.py
@@ -4,11 +4,11 @@ Usage:
 
     python -m bilevel_planning.visualizer [--port N] [--no-debug]
 
-Boots the Flask backend with no renderer installed and serves the built
-React frontend at the same port. Open the printed URL in a browser, click
-**Load Pickle**, then expand the **Python renderer** pane and apply your
-``render_state`` source. See ``bilevel_planning.visualizer.app`` for the
-security model.
+Boots the Flask backend and serves the built React frontend at the same
+port. Open the printed URL in a browser, paste your ``render_state``
+source into the **Python renderer** pane and apply it, then upload a
+pickle bundle. See ``bilevel_planning.visualizer.app`` for the security
+model.
 """
 
 import argparse
@@ -21,9 +21,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         prog="python -m bilevel_planning.visualizer",
         description=(
-            "Run the bilevel planning visualizer. The renderer is installed "
-            "at runtime via the browser's 'Python renderer' pane (or via a "
-            "direct POST to /api/set_renderer)."
+            "Run the bilevel planning visualizer. The renderer is supplied "
+            "at runtime from the browser's 'Python renderer' pane."
         ),
     )
     parser.add_argument(
@@ -39,11 +38,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    run_webapp(
-        render_state_fn=None,
-        port=args.port,
-        debug=not args.no_debug,
-    )
+    run_webapp(port=args.port, debug=not args.no_debug)
 
 
 if __name__ == "__main__":

--- a/bilevel-planning/src/bilevel_planning/visualizer/app.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/app.py
@@ -18,7 +18,17 @@ it. Do not put this behind a reverse proxy exposing it to untrusted
 networks.
 """
 
-# pylint: disable=global-statement
+# pylint: disable=global-statement,wrong-import-position,wrong-import-order
+
+# Force matplotlib onto a non-interactive backend before any code path
+# (including the user's exec'd renderer source) can import pyplot. Flask
+# handles requests on worker threads, and on macOS the default 'MacOSX'
+# backend refuses to create figures off the main thread. Has to happen
+# before the rest of the imports in case any of them transitively import
+# matplotlib.
+import matplotlib
+
+matplotlib.use("Agg")
 
 import base64
 import io

--- a/bilevel-planning/src/bilevel_planning/visualizer/app.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/app.py
@@ -1,24 +1,16 @@
 """Flask backend for visualizing concrete states from a bilevel planning graph.
 
-Environment-agnostic: the backend never imports a simulation package. A
-caller-supplied ``render_state_fn`` maps a concrete state (as stored in the
-pickled bilevel planning graph) to an RGB image. There are two ways to
-supply it:
-
-1. Pass one directly when calling ``run_webapp`` from your own Python
-   script. Useful when the environment is expensive to construct and you
-   want to warm it up before the server starts.
-
-2. Launch with no render fn (``python -m bilevel_planning.visualizer``)
-   and POST Python source to ``/api/set_renderer`` from the browser. The
-   backend ``exec``s the source, expects a callable named ``render_state``
-   to land in the namespace, and caches it for subsequent
-   ``/api/visualize_state`` requests.
+Environment-agnostic: the backend never imports a simulation package. The
+user POSTs Python source to ``/api/set_renderer`` from the browser; the
+backend ``exec``s the source, expects a callable named ``render_state`` to
+land in the namespace, and caches it for subsequent ``/api/visualize_state``
+requests.
 
 The same Flask process also serves the built React frontend at ``/``, so
-users only need one terminal: launch the backend, open the browser. The
-frontend bundle lives at ``visualizer/frontend/dist/`` and must be built
-once with ``npm ci && npm run build`` from the ``frontend/`` directory.
+the visualizer runs as a single ``python -m bilevel_planning.visualizer``
+invocation. The frontend bundle lives at ``visualizer/frontend/dist/`` and
+must be built once with ``npm ci && npm run build`` from the
+``frontend/`` directory.
 
 Security: ``/api/set_renderer`` runs arbitrary Python in the backend
 process. The server binds to ``127.0.0.1`` so only local clients can reach
@@ -46,8 +38,7 @@ RenderStateFn = Callable[[Any], np.ndarray]
 # by ``/api/graph``; ``STATE_DATA`` maps node ids to the original state
 # objects, indexed into by ``/api/visualize_state``. Both come from the
 # same pickle uploaded via ``/api/load_pickle``. ``RENDER_FN`` is the
-# current render callable, either injected at construction time or
-# installed later via ``/api/set_renderer``.
+# render callable supplied at runtime via ``/api/set_renderer``.
 GRAPH_DATA: dict = {}
 STATE_DATA: dict = {}
 RENDER_FN: RenderStateFn | None = None
@@ -62,15 +53,14 @@ RENDERER_ENTRYPOINT = "render_state"
 FRONTEND_DIST_DIR = Path(__file__).parent / "frontend" / "dist"
 
 
-def create_app(render_state_fn: RenderStateFn | None) -> Flask:
+def create_app() -> Flask:
     """Build the Flask app.
 
-    If ``render_state_fn`` is None, the app boots without a renderer and
-    ``/api/visualize_state`` returns 400 until one is installed via
-    ``/api/set_renderer``.
+    The app boots with no renderer; ``/api/visualize_state`` returns 400
+    until the user supplies one via ``/api/set_renderer``.
     """
     global RENDER_FN
-    RENDER_FN = render_state_fn
+    RENDER_FN = None
 
     app = Flask(__name__)
     CORS(app)
@@ -227,9 +217,9 @@ def create_app(render_state_fn: RenderStateFn | None) -> Flask:
                     jsonify(
                         {
                             "error": (
-                                "No renderer installed. POST Python source "
-                                "to /api/set_renderer or pass render_state_fn "
-                                "to run_webapp()."
+                                "No renderer is ready. Apply a render_state "
+                                "function from the browser's Python renderer "
+                                "pane first."
                             ),
                         }
                     ),
@@ -273,7 +263,7 @@ def create_app(render_state_fn: RenderStateFn | None) -> Flask:
                 "status": "healthy",
                 "graph_loaded": bool(GRAPH_DATA),
                 "num_states": len(STATE_DATA),
-                "renderer_set": RENDER_FN is not None,
+                "renderer_ready": RENDER_FN is not None,
             }
         )
 
@@ -309,17 +299,13 @@ def create_app(render_state_fn: RenderStateFn | None) -> Flask:
     return app
 
 
-def run_webapp(
-    render_state_fn: RenderStateFn | None = None,
-    port: int = 5001,
-    debug: bool = True,
-) -> None:
+def run_webapp(port: int = 5001, debug: bool = True) -> None:
     """Run the visualization Flask server on localhost.
 
-    If ``render_state_fn`` is None, the server boots without a renderer
-    and the user must install one via ``POST /api/set_renderer`` (the
-    browser's "Python renderer" pane does this for them) before any
-    ``/api/visualize_state`` request will succeed.
+    The server boots with no renderer; the user supplies one through the
+    browser's "Python renderer" pane (which posts source to
+    ``/api/set_renderer``) before any ``/api/visualize_state`` request can
+    succeed.
 
     The same process serves the React frontend at ``/`` from
     ``visualizer/frontend/dist/``, so a single ``python -m
@@ -329,7 +315,7 @@ def run_webapp(
     Binds to ``127.0.0.1`` — the ``/api/set_renderer`` endpoint runs
     arbitrary Python and must not be reachable from outside the host.
     """
-    app = create_app(render_state_fn)
+    app = create_app()
     print(f"Starting visualizer on http://127.0.0.1:{port}")
     if not FRONTEND_DIST_DIR.exists():
         print(

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/README.md
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/README.md
@@ -17,8 +17,8 @@ npm run build
 ```
 
 This produces `dist/`, which the Python backend serves as static files.
-After this, users only ever run `python -m bilevel_planning.visualizer`
-(or `run_webapp` from a script). No npm process is needed at runtime.
+After this, users only ever run `python -m bilevel_planning.visualizer`.
+No npm process is needed at runtime.
 
 ## Frontend development mode
 
@@ -33,18 +33,16 @@ Vite serves on `http://localhost:3000` and proxies `/api/*` to the
 Python backend on `http://localhost:5001`. Run the backend separately
 in another terminal while you're iterating.
 
-## Installing a renderer
+## Supplying the renderer
 
-The visualizer won't display state images until the backend has a
-`render_state` callable. Two ways to supply one:
+The visualizer won't display state images until you give the backend a
+`render_state` callable. The header has a **Python renderer** pane
+(expanded by default) with a textarea — edit the source so
+`render_state(state)` returns an HxWx3 uint8 RGB array, then click
+**Apply renderer**. The source is POSTed to `/api/set_renderer` and
+`exec`'d in the backend process, so any package installed in the
+backend's Python environment is importable.
 
-- **Browser**: expand the "Python renderer" pane in the header, edit the
-  source, and click "Apply renderer". The source is POSTed to
-  `/api/set_renderer` and `exec`'d in the backend process, so any package
-  installed in the backend's Python environment is importable. Runs
-  arbitrary Python locally — don't expose the backend to untrusted
-  networks.
-- **Launcher script**: call `bilevel_planning.visualizer.app.run_webapp`
-  from your own Python with `render_state_fn=<your callable>`. Useful
-  when the environment is expensive to construct and you want it ready
-  before the server boots.
+The arbitrary-`exec` surface is the reason the backend binds to
+`127.0.0.1`. Don't put it behind a reverse proxy exposing it to untrusted
+networks.

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/App.jsx
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/App.jsx
@@ -17,7 +17,7 @@ function App() {
   const [pickleLoaded, setPickleLoaded] = useState(false);
   const [pickleFilename, setPickleFilename] = useState(null);
   const [rendererSource, setRendererSource] = useState(DEFAULT_RENDERER_SOURCE);
-  const [rendererSet, setRendererSet] = useState(false);
+  const [rendererReady, setRendererReady] = useState(false);
   const [rendererStatus, setRendererStatus] = useState(null);
 
   // Check backend health on mount and periodically
@@ -34,16 +34,16 @@ function App() {
         const data = await response.json();
         setBackendStatus('connected');
         setPickleLoaded(data.graph_loaded);
-        setRendererSet(data.renderer_set);
+        setRendererReady(data.renderer_ready);
       } else {
         setBackendStatus('error');
         setPickleLoaded(false);
-        setRendererSet(false);
+        setRendererReady(false);
       }
     } catch (err) {
       setBackendStatus('disconnected');
       setPickleLoaded(false);
-      setRendererSet(false);
+      setRendererReady(false);
     }
   };
 
@@ -57,15 +57,15 @@ function App() {
       });
       const data = await response.json();
       if (!response.ok) {
-        setRendererStatus({ ok: false, message: data.error || 'Failed to install renderer' });
-        setRendererSet(false);
+        setRendererStatus({ ok: false, message: data.error || 'Failed to apply renderer' });
+        setRendererReady(false);
         return;
       }
-      setRendererStatus({ ok: true, message: 'Renderer installed.' });
-      setRendererSet(true);
+      setRendererStatus({ ok: true, message: 'Renderer ready.' });
+      setRendererReady(true);
     } catch (err) {
       setRendererStatus({ ok: false, message: `Error: ${err.message}` });
-      setRendererSet(false);
+      setRendererReady(false);
     }
   };
 
@@ -142,11 +142,16 @@ function App() {
             <span style={styles.pickleStatus}>Loaded: {pickleFilename}</span>
           )}
         </div>
-        <details style={styles.rendererDetails}>
+        <details style={styles.rendererDetails} open>
           <summary style={styles.rendererSummary}>
-            Python renderer {rendererSet ? '(installed)' : '(not installed)'}
+            Python renderer {rendererReady ? '(ready)' : '(not set)'}
           </summary>
           <div style={styles.rendererPane}>
+            <p style={styles.rendererHint}>
+              Edit the Python below so <code>render_state(state)</code> turns
+              a state from your pickle into an HxWx3 uint8 RGB array, then
+              click <strong>Apply renderer</strong>.
+            </p>
             <textarea
               value={rendererSource}
               onChange={(e) => setRendererSource(e.target.value)}
@@ -185,7 +190,7 @@ function App() {
       <main style={styles.main}>
         <GraphViewer3D
           graphData={graphData}
-          pickleLoaded={pickleLoaded && rendererSet}
+          pickleLoaded={pickleLoaded && rendererReady}
         />
       </main>
     </div>
@@ -269,6 +274,12 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     gap: '8px',
+  },
+  rendererHint: {
+    margin: 0,
+    fontSize: '12px',
+    color: '#aaa',
+    lineHeight: 1.4,
   },
   rendererTextarea: {
     width: '100%',

--- a/bilevel-planning/tests/visualizer/test_app.py
+++ b/bilevel-planning/tests/visualizer/test_app.py
@@ -17,6 +17,18 @@ from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
 from bilevel_planning.visualizer import app as visualizer_app
 from bilevel_planning.visualizer.app import create_app
 
+# Source for a renderer the test client can post to /api/set_renderer; turns
+# the (3,) state arrays from _build_demo_bundle_bytes into a small solid-color
+# patch so the PNG round-trip is easy to assert against.
+RENDERER_SOURCE = """
+import numpy as np
+def render_state(state):
+    color = np.asarray(state, dtype=np.uint8).reshape(-1)[:3]
+    if color.size < 3:
+        color = np.pad(color, (0, 3 - color.size))
+    return np.broadcast_to(color, (8, 8, 3)).astype(np.uint8)
+"""
+
 
 @pytest.fixture(autouse=True)
 def _reset_module_state():
@@ -34,14 +46,6 @@ def _reset_module_state():
     visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
     visualizer_app.RENDER_FN = None
-
-
-def _constant_color_renderer(state: np.ndarray) -> np.ndarray:
-    """Render each state as a small solid-color patch."""
-    color = np.asarray(state, dtype=np.uint8).reshape(-1)[:3]
-    if color.size < 3:
-        color = np.pad(color, (0, 3 - color.size))
-    return np.broadcast_to(color, (8, 8, 3)).astype(np.uint8)
 
 
 def _build_demo_bundle_bytes(tmp_path: Path) -> tuple[bytes, list[str]]:
@@ -77,9 +81,13 @@ def _upload_bundle(client, bundle_bytes: bytes, filename: str = "demo.pkl"):
     )
 
 
+def _apply_renderer(client, source: str = RENDERER_SOURCE):
+    return client.post("/api/set_renderer", json={"source": source})
+
+
 def test_health_endpoint():
-    """``/api/health`` reports an empty backend before any pickle is loaded."""
-    app = create_app(_constant_color_renderer)
+    """``/api/health`` reports an empty backend at boot."""
+    app = create_app()
     client = app.test_client()
     resp = client.get("/api/health")
     assert resp.status_code == 200
@@ -87,30 +95,22 @@ def test_health_endpoint():
     assert payload["status"] == "healthy"
     assert payload["graph_loaded"] is False
     assert payload["num_states"] == 0
-    assert payload["renderer_set"] is True
-
-
-def test_health_reports_no_renderer_when_none_installed():
-    """Booting with ``render_state_fn=None`` leaves the renderer unset."""
-    app = create_app(None)
-    client = app.test_client()
-    payload = client.get("/api/health").get_json()
-    assert payload["renderer_set"] is False
+    assert payload["renderer_ready"] is False
 
 
 def test_graph_endpoint_requires_load():
     """``/api/graph`` returns 400 until a bundle has been loaded."""
-    app = create_app(_constant_color_renderer)
+    app = create_app()
     client = app.test_client()
     resp = client.get("/api/graph")
     assert resp.status_code == 400
 
 
-def test_load_graph_and_visualize_roundtrip(tmp_path: Path):
-    """Uploading a bundle exposes both the topology and per-node rendering."""
+def test_load_graph_apply_renderer_and_visualize_roundtrip(tmp_path: Path):
+    """Upload a bundle, apply a renderer, and render a node end-to-end."""
     bundle_bytes, node_ids = _build_demo_bundle_bytes(tmp_path)
 
-    app = create_app(_constant_color_renderer)
+    app = create_app()
     client = app.test_client()
 
     resp = _upload_bundle(client, bundle_bytes)
@@ -120,14 +120,23 @@ def test_load_graph_and_visualize_roundtrip(tmp_path: Path):
     assert payload["num_states"] == len(node_ids)
     assert payload["filename"] == "demo.pkl"
 
-    # After load, /api/graph serves the topology.
+    # /api/graph serves the topology after load.
     resp = client.get("/api/graph")
     assert resp.status_code == 200
     graph = resp.get_json()
     assert set(graph.keys()) >= {"nodes", "edges", "plan", "config"}
 
-    # Visualize one of the nodes and confirm the PNG decodes correctly.
+    # Visualization fails until a renderer is applied.
     target = node_ids[0]
+    resp = client.post("/api/visualize_state", json={"node_id": target})
+    assert resp.status_code == 400
+
+    # Apply a renderer; health flips renderer_ready.
+    resp = _apply_renderer(client)
+    assert resp.status_code == 200, resp.get_json()
+    assert client.get("/api/health").get_json()["renderer_ready"] is True
+
+    # Visualization now succeeds and the PNG decodes.
     resp = client.post("/api/visualize_state", json={"node_id": target})
     assert resp.status_code == 200, resp.get_json()
     payload = resp.get_json()
@@ -145,9 +154,10 @@ def test_visualize_unknown_node_returns_404(tmp_path: Path):
     """Asking for a node id that isn't in the loaded bundle returns 404."""
     bundle_bytes, _ = _build_demo_bundle_bytes(tmp_path)
 
-    app = create_app(_constant_color_renderer)
+    app = create_app()
     client = app.test_client()
     _upload_bundle(client, bundle_bytes)
+    _apply_renderer(client)
 
     resp = client.post("/api/visualize_state", json={"node_id": "x:doesnotexist"})
     assert resp.status_code == 404
@@ -157,7 +167,7 @@ def test_load_pickle_rejects_wrong_shape():
     """A pickle that isn't a ``{'graph':..., 'states':...}`` bundle is rejected."""
     bad_bytes = pickle.dumps({"only_states": {}})
 
-    app = create_app(_constant_color_renderer)
+    app = create_app()
     client = app.test_client()
     resp = _upload_bundle(client, bad_bytes, filename="bad.pkl")
     assert resp.status_code == 400
@@ -165,47 +175,15 @@ def test_load_pickle_rejects_wrong_shape():
 
 def test_load_pickle_rejects_missing_file_field():
     """A POST without a 'file' multipart field is rejected with 400."""
-    app = create_app(_constant_color_renderer)
+    app = create_app()
     client = app.test_client()
     resp = client.post("/api/load_pickle", data={}, content_type="multipart/form-data")
     assert resp.status_code == 400
 
 
-def test_set_renderer_installs_callable_from_source(tmp_path: Path):
-    """Posting Python source to ``/api/set_renderer`` makes visualization work."""
-    bundle_bytes, node_ids = _build_demo_bundle_bytes(tmp_path)
-
-    # Boot with no renderer.
-    app = create_app(None)
-    client = app.test_client()
-    _upload_bundle(client, bundle_bytes)
-
-    # Without a renderer, visualization is 400.
-    resp = client.post("/api/visualize_state", json={"node_id": node_ids[0]})
-    assert resp.status_code == 400
-
-    # Install a renderer via source.
-    source = (
-        "import numpy as np\n"
-        "def render_state(state):\n"
-        "    return np.zeros((4, 4, 3), dtype=np.uint8)\n"
-    )
-    resp = client.post("/api/set_renderer", json={"source": source})
-    assert resp.status_code == 200, resp.get_json()
-    assert resp.get_json()["success"] is True
-
-    # Health now reports the renderer is set.
-    assert client.get("/api/health").get_json()["renderer_set"] is True
-
-    # Visualization now works.
-    resp = client.post("/api/visualize_state", json={"node_id": node_ids[0]})
-    assert resp.status_code == 200
-    assert resp.get_json()["image"].startswith("data:image/png;base64,")
-
-
 def test_set_renderer_rejects_source_without_entrypoint():
     """Source that doesn't define ``render_state`` is rejected with 400."""
-    app = create_app(None)
+    app = create_app()
     client = app.test_client()
     resp = client.post("/api/set_renderer", json={"source": "x = 1\n"})
     assert resp.status_code == 400
@@ -214,7 +192,7 @@ def test_set_renderer_rejects_source_without_entrypoint():
 
 def test_set_renderer_rejects_broken_source():
     """Source that raises during ``exec`` is rejected with 400 plus traceback."""
-    app = create_app(None)
+    app = create_app()
     client = app.test_client()
     resp = client.post(
         "/api/set_renderer", json={"source": "raise RuntimeError('nope')\n"}


### PR DESCRIPTION
The two-supply-paths design (programmatic run_webapp(render_state_fn=...)
plus browser /api/set_renderer) was confusing for users and added test
surface no one was using. Drop the programmatic path entirely:

* create_app() and run_webapp() no longer accept a render_state_fn
  parameter. The backend boots with no renderer; the only way to
  install one is from the browser pane.
* /api/health field renamed from 'renderer_set' to 'renderer_ready'
  ('installed' implied a setup step that doesn't match a runtime exec).
* The frontend's 'Python renderer' pane is now open by default so the
  user sees the editable source on first load. The label reads
  'Python renderer (ready)' / '(not set)'. The success status reads
  'Renderer ready.' A short hint above the textarea explains what
  render_state should return.
* Drop the now-redundant 'no renderer at boot' health test and merge
  the load-and-visualize roundtrip into a single test that also
  exercises /api/set_renderer.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>