### PR TITLE
add BPG examples directory with a minimal two-state example

### DIFF
--- a/bilevel-planning/examples/README.md
+++ b/bilevel-planning/examples/README.md
@@ -1,0 +1,93 @@
+# Bilevel Planning Graph Examples
+
+Runnable Python scripts that build small `BilevelPlanningGraph` (BPG)
+objects and export them for use with the
+[visualizer](../src/bilevel_planning/visualizer/). They exist to show
+what a BPG actually *is*, unclouded by the planner and environment
+machinery you'd normally need to produce one.
+
+## What's a bilevel planning graph?
+
+A BPG is a record of the state space a bilevel planner searches through
+as it produces a plan. "Bilevel" means two layers:
+
+- **Concrete states** are low-level world states (continuous values,
+  object poses, joint angles). The planner's trajectory sampler moves
+  between them via **concrete action edges**.
+- **Abstract states** are high-level descriptions of those world states
+  (typically a set of true predicates like `(OnTable block)`,
+  `(HandEmpty robot)`). The planner's abstract plan generator moves
+  between them via **abstract action edges** (often PDDL operators).
+
+A **state-abstractor edge** connects a concrete state to the abstract
+state it satisfies — each concrete state groups into one abstract
+state. A concrete action edge represents a low-level transition; an
+abstract action edge represents a high-level skill or operator.
+
+A `BilevelPlanningGraph` holds all five pieces:
+
+| method                       | adds                                  |
+| ---                          | ---                                   |
+| `add_state_node`             | a concrete state                      |
+| `add_abstract_state_node`    | an abstract state                     |
+| `add_action_edge`            | a concrete transition (state, u, s')  |
+| `add_abstract_action_edge`   | an abstract transition (S, A, S')     |
+| `add_state_abstractor_edge`  | concrete → abstract grouping          |
+
+Real planners (e.g. `SesamePlanner`) build this graph incrementally as
+they search. Once built, you can:
+
+- Call `bpg.extract_plan(final_state)` to walk back from a goal state
+  and recover the concrete state/action sequence.
+- Call `bpg.export(path, final_state=...)` to dump the whole graph plus
+  the concrete state objects to a single pickle. The
+  `bilevel_planning.visualizer` serves that pickle to a browser-based
+  3D viewer.
+
+The examples in this directory build the graph by hand, so you can see
+exactly what goes in and what comes out without a planner in the loop.
+
+## Running the examples
+
+From the `bilevel-planning/` directory:
+
+```bash
+python examples/simple_two_state.py
+```
+
+Each example prints a summary of the graph it built and writes a
+pickle bundle to `examples/data/`. To view one in the visualizer:
+
+```bash
+python -m bilevel_planning.visualizer
+```
+
+Open http://localhost:5001, paste the snippet below into the **Python
+renderer** pane, click **Apply renderer**, then upload the `.pkl` from
+`examples/data/`. The snippet maps each concrete state `(i,)` to a
+solid color along a red-to-green gradient, so clicking through the
+chain `c0 -> c1 -> c2 -> c3 -> c4` walks visibly from red to green:
+
+```python
+import numpy as np
+
+def render_state(state):
+    # The example concrete states are single-int tuples like (0,), (1,),
+    # ..., (4,). Map the index to a color along a red -> green gradient.
+    (index,) = state
+    t = index / 4.0
+    color = np.array([int(255 * (1 - t)), int(255 * t), 0], dtype=np.uint8)
+    return np.broadcast_to(color, (256, 256, 3)).astype(np.uint8)
+```
+
+The point of these examples is the graph structure, not the imagery —
+the render above exists just to make it visually obvious which node
+you're clicking.
+
+## Examples
+
+- **`simple_two_state.py`** — the smallest interesting BPG. Two
+  abstract states (`before`, `after`) connected by one abstract action
+  (`transition`), and a five-step concrete chain where the first four
+  states ground out `before` and the fifth grounds out `after`. A good
+  first read for what each `add_*` method does.

--- a/bilevel-planning/examples/simple_two_state.py
+++ b/bilevel-planning/examples/simple_two_state.py
@@ -1,0 +1,73 @@
+"""Build a minimal two-abstract-state bilevel planning graph.
+
+Topology:
+
+  abstract:  "before" ---transition---> "after"
+                 |                         |
+                 v                         v
+  concrete:  c0 -> c1 -> c2 -> c3 -> c4
+
+The first four concrete states abstract to "before"; the fifth abstracts
+to "after". The concrete chain is a single path of ``step`` actions. The
+abstract layer has a single ``transition`` action from ``before`` to
+``after``.
+
+Running this script writes a visualizer bundle to
+``bilevel-planning/examples/data/simple_two_state.pkl`` which you can
+load in the ``bilevel_planning.visualizer``.
+"""
+
+from pathlib import Path
+
+from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
+
+
+def build_simple_two_state_bpg() -> BilevelPlanningGraph:
+    """Construct the example BPG described in the module docstring."""
+    bpg: BilevelPlanningGraph = BilevelPlanningGraph()
+
+    # Abstract layer: two states and one action connecting them.
+    bpg.add_abstract_state_node("before")
+    bpg.add_abstract_state_node("after")
+    bpg.add_abstract_action_edge("before", "transition", "after")
+
+    # Concrete layer: five states on a line, indexed by a single int.
+    concrete_states = [(i,) for i in range(5)]
+    for cs in concrete_states:
+        bpg.add_state_node(cs)
+
+    # Ground the first four to "before" and the fifth to "after".
+    for cs in concrete_states[:4]:
+        bpg.add_state_abstractor_edge(cs, "before")
+    bpg.add_state_abstractor_edge(concrete_states[4], "after")
+
+    # Concrete action chain: c0 -> c1 -> c2 -> c3 -> c4.
+    for src, dst in zip(concrete_states[:-1], concrete_states[1:]):
+        bpg.add_action_edge(src, "step", dst)
+
+    return bpg
+
+
+def main() -> None:
+    """Build the BPG, print a summary, and export a visualizer bundle."""
+    bpg = build_simple_two_state_bpg()
+    goal = (4,)
+
+    print("Simple two-state BPG:")
+    print(f"  concrete states:        {len(bpg.states)}")
+    print(f"  abstract states:        {len(bpg.abstract_states)}")
+    print(f"  concrete action edges:  {len(bpg.action_edges)}")
+    print(f"  abstract action edges:  {len(bpg.abstract_action_edges)}")
+    print(f"  state-abstractor edges: {len(bpg.state_abstractor_edges)}")
+
+    plan = bpg.extract_plan(goal)
+    print(f"  extracted plan:         {len(plan.actions)} actions")
+
+    out_path = Path(__file__).parent / "data" / "simple_two_state.pkl"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    bpg.export(out_path, final_state=goal)
+    print(f"\nWrote visualizer bundle to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds bilevel-planning/examples/ with a README explainer covering what a bilevel planning graph is (concrete vs abstract states, the three edge types, extract_plan, export) and a first runnable example:

simple_two_state.py builds by hand a BPG with two abstract states (before, after) connected by one abstract action (transition), and a five-step concrete chain where the first four concrete states abstract to 'before' and the fifth abstracts to 'after'. Running it prints a summary of the graph and writes a visualizer bundle to examples/data/simple_two_state.pkl for loading in
bilevel_planning.visualizer.

The examples sit at the package top level (sibling of src/, tests/), stay out of the wheel, and are meant as a by-hand teaching reference for what each BilevelPlanningGraph add_* method does — unclouded by the planner machinery that normally builds these graphs.