### PR TITLE
move visualizer styling from backend export to the frontend

### DIFF
--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -305,15 +305,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
     def _build_graph_structure(
         self,
         final_state: _X | None = None,
-        abstract_state_color: str = "tab:purple",
-        state_color: str = "tab:blue",
-        plan_color: str = "tab:green",
-        node_size: int = 50,
-        state_abstractor_edge_color: str = "gray",
-        action_edge_color: str = "black",
-        abstract_action_edge_color: str = "black",
-        node_alpha: float = 0.7,
-        edge_alpha: float = 0.7,
         n_intermediate_per_side: int = 0,
     ) -> tuple[nx.DiGraph, dict[str, tuple[float, float, float]], dict]:
         """Build the graph structure for visualization.
@@ -327,8 +318,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         call site; see also the comments at each individual concern):
           * Fold this method into ``_build_graph_payload``. The split exists
             for no reason — nothing else calls ``_build_graph_structure``.
-          * Drop the styling parameters. Colors and sizes are presentation
-            concerns that belong in the frontend, not in the export.
           * Remove the ``n_intermediate_per_side`` knob. It defaults to 0, so
             the interpolation branch below is dead code today, and deciding
             how many intermediate nodes to show should happen in the viewer.
@@ -581,19 +570,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         metadata["min_time"] = min_time
         metadata["max_time"] = max_time
 
-        # Pass through colors/sizes for export
-        metadata["node_size"] = node_size
-        metadata["edge_alpha"] = edge_alpha
-
-        # coloring/visualization data
-        metadata["plan_color"] = plan_color
-        metadata["state_color"] = state_color
-        metadata["abstract_state_color"] = abstract_state_color
-        metadata["state_abstractor_edge_color"] = state_abstractor_edge_color
-        metadata["action_edge_color"] = action_edge_color
-        metadata["abstract_action_edge_color"] = abstract_action_edge_color
-        metadata["node_alpha"] = node_alpha
-
         if final_state is not None:
             # Only include plan nodes that were kept
             plan_nodes = []
@@ -620,83 +596,42 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
 
         return G, pos, metadata
 
-    def _build_graph_payload(
-        self,
-        final_state: _X | None = None,
-        abstract_state_color: str = "tab:purple",
-        state_color: str = "tab:blue",
-        plan_color: str = "tab:green",
-        node_size: int = 50,
-        state_abstractor_edge_color: str = "gray",
-        action_edge_color: str = "black",
-        abstract_action_edge_color: str = "black",
-        node_alpha: float = 0.7,
-        edge_alpha: float = 0.7,
-    ) -> dict:
+    def _build_graph_payload(self, final_state: _X | None = None) -> dict:
         """Build the frontend-facing topology dict (nodes, edges, plan, config).
 
-        Planned follow-ups:
-          * All of the color/size/alpha parameters should move to the
-            frontend. Styling is a presentation concern and the exporter
-            shouldn't bake it into the payload. The hardcoded matplotlib ->
-            RGB ``color_map`` below is the main reason these parameters
-            exist — once the frontend owns styling, the map disappears.
-          * Fold ``_build_graph_structure`` into this method; it has no
-            other caller.
+        The payload carries graph topology and plan membership only. The
+        frontend chooses colors, sizes, and alphas from ``node.type`` (the
+        ``"concrete"`` / ``"abstract"`` distinction), ``node.in_plan``, and
+        ``edge.type`` (``"action"`` / ``"abstractor"`` / ``"abstract_action"``).
+
+        Planned follow-up: fold ``_build_graph_structure`` into this method;
+        it has no other caller.
         """
-        # Build the graph structure
-        G, pos, metadata = self._build_graph_structure(
-            final_state=final_state,
-            abstract_state_color=abstract_state_color,
-            state_color=state_color,
-            plan_color=plan_color,
-            node_size=node_size,
-            state_abstractor_edge_color=state_abstractor_edge_color,
-            action_edge_color=action_edge_color,
-            abstract_action_edge_color=abstract_action_edge_color,
-            node_alpha=node_alpha,
-            edge_alpha=edge_alpha,
-        )
+        G, pos, metadata = self._build_graph_structure(final_state=final_state)
 
-        # Hardcoded mapping from the five matplotlib color names the caller
-        # is allowed to pass to their CSS ``rgb(...)`` equivalents. Planned
-        # for removal once styling moves to the frontend (see docstring).
-        color_map = {
-            "tab:purple": "rgb(148, 103, 189)",
-            "tab:blue": "rgb(31, 119, 180)",
-            "tab:green": "rgb(44, 160, 44)",
-            "gray": "rgb(128, 128, 128)",
-            "black": "rgb(0, 0, 0)",
-        }
-
-        def convert_color(mpl_color: str) -> str:
-            return color_map.get(mpl_color, mpl_color)
-
-        # Build nodes list
-        nodes = []
         plan_nodes_set = set(metadata["plan_nodes"])
         abstract_plan_nodes_set = set(metadata["abstract_plan_nodes"])
         node_time_index: dict[str, int] = metadata.get("node_time_index", {})
 
+        nodes = []
         for node_id, (x, y, z) in pos.items():
             is_abstract = node_id.startswith("s:")
-            in_plan = node_id in plan_nodes_set
-            in_abstract_plan = node_id in abstract_plan_nodes_set
+            in_plan = node_id in plan_nodes_set or node_id in abstract_plan_nodes_set
 
-            # Create node dict first to check for abstract association
-            node_dict = {
+            node_dict: dict = {
                 "id": node_id,
                 "type": "abstract" if is_abstract else "concrete",
                 "position": [x, y, z],
-                "size": metadata["node_size"],
-                "in_plan": in_plan or in_abstract_plan,
+                "in_plan": in_plan,
             }
 
-            # Attach time index for rendered concrete nodes
+            # Attach time index for rendered concrete nodes.
             if not is_abstract and node_id in node_time_index:
                 node_dict["time_index"] = node_time_index[node_id]
 
-            # Add abstract state ID for concrete nodes (if associated)
+            # Attach the owning abstract state id for concrete nodes that
+            # have a state-abstractor edge, so the frontend can highlight
+            # abstract groupings.
             if not is_abstract and node_id.startswith("x:"):
                 state_id = int(node_id.split(":")[1])
                 if state_id in metadata["state_to_abstract_id"]:
@@ -704,56 +639,21 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
                         state_id
                     ]
 
-            # Color based on node type, plan membership, and abstract association
-            if in_plan:
-                # Plan coloring
-                color = (
-                    "rgb(255, 165, 0)"
-                    if "abstract_state_id" in node_dict
-                    else convert_color(metadata["plan_color"])
-                )
-                alpha = 1.0
-            else:
-                # Non-plan coloring...
-                if node_dict["type"] == "concrete":
-                    color = (
-                        convert_color(metadata["abstract_state_color"])
-                        if "abstract_state_id" in node_dict
-                        else convert_color(metadata["state_color"])
-                    )
-                else:
-                    color = convert_color(metadata["abstract_state_color"])
-                alpha = metadata["node_alpha"]
-
-            node_dict["color"] = color
-            node_dict["alpha"] = alpha
-
             nodes.append(node_dict)
 
-        # Build edges list
+        # Build edges list. The type lets the frontend pick styling.
         edges = []
         for source, target in G.edges():
             source_pos = pos[source]
             target_pos = pos[target]
             if source_pos[2] != target_pos[2]:
                 edge_type = "abstractor"
-                color = convert_color(metadata["state_abstractor_edge_color"])
             elif source_pos[2] == metadata["z_bottom"]:
                 edge_type = "action"
-                color = convert_color(metadata["action_edge_color"])
             else:
                 edge_type = "abstract_action"
-                color = convert_color(metadata["abstract_action_edge_color"])
 
-            edges.append(
-                {
-                    "source": source,
-                    "target": target,
-                    "type": edge_type,
-                    "color": color,
-                    "alpha": metadata["edge_alpha"],
-                }
-            )
+            edges.append({"source": source, "target": target, "type": edge_type})
 
         # Build plan info
         plan_info = {

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/components/GraphViewer3D.jsx
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/components/GraphViewer3D.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import Plot from 'react-plotly.js';
-import { jsonToPlotlyTraces, getPlotlyLayout, getPlotlyConfig } from '../utils/plotlyHelpers';
+import { applyDefaultStyles, jsonToPlotlyTraces, getPlotlyLayout, getPlotlyConfig } from '../utils/plotlyHelpers';
 
 export function GraphViewer3D({ graphData, pickleLoaded = false }) {
   const [selectedNode, setSelectedNode] = useState(null);
@@ -179,8 +179,10 @@ export function GraphViewer3D({ graphData, pickleLoaded = false }) {
     try {
       console.log('Rendering graph with data:', graphData);
       
-      // Create working copy to apply overlays wo modifying original data
-      let graphDataCopy = graphData;
+      // The backend payload only carries topology and plan membership;
+      // assign default colors/sizes/alphas here so overlays below can
+      // mutate them without the backend caring.
+      let graphDataCopy = applyDefaultStyles(graphData);
       
       // Apply time-based coloring overlay (if timeline info available)
       if (currentTime !== null) {

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/utils/plotlyHelpers.js
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/utils/plotlyHelpers.js
@@ -1,7 +1,82 @@
+// Default node/edge styling. The backend exports only topology and plan
+// membership; the frontend owns presentation.
+const NODE_COLORS = {
+  planAbstractAssoc: 'rgb(255, 165, 0)', // orange: plan + in an abstract group
+  planSimple:        'rgb(44, 160, 44)', // green:  plan + no abstract group
+  abstractAssoc:     'rgb(148, 103, 189)', // purple: concrete + in abstract group
+  concreteSimple:    'rgb(31, 119, 180)', // blue:   concrete + no abstract group
+  abstract:          'rgb(148, 103, 189)', // purple: abstract state nodes
+};
+
+const NODE_SIZE_PLAN = 12;
+const NODE_SIZE_DEFAULT = 10;
+const NODE_ALPHA_PLAN = 1.0;
+const NODE_ALPHA_DEFAULT = 0.7;
+
+const EDGE_COLORS = {
+  action:          'rgb(0, 0, 0)',
+  abstractor:      'rgb(128, 128, 128)',
+  abstract_action: 'rgb(0, 0, 0)',
+};
+const EDGE_ALPHA = 0.7;
+
+function defaultNodeStyle(node) {
+  const inPlan = Boolean(node.in_plan);
+  const hasAbstractAssoc = node.abstract_state_id !== undefined;
+  let color;
+  if (node.type === 'abstract') {
+    color = NODE_COLORS.abstract;
+  } else if (inPlan && hasAbstractAssoc) {
+    color = NODE_COLORS.planAbstractAssoc;
+  } else if (inPlan) {
+    color = NODE_COLORS.planSimple;
+  } else if (hasAbstractAssoc) {
+    color = NODE_COLORS.abstractAssoc;
+  } else {
+    color = NODE_COLORS.concreteSimple;
+  }
+  return {
+    color,
+    size: inPlan ? NODE_SIZE_PLAN : NODE_SIZE_DEFAULT,
+    alpha: inPlan ? NODE_ALPHA_PLAN : NODE_ALPHA_DEFAULT,
+  };
+}
+
+function defaultEdgeStyle(edge) {
+  return {
+    color: EDGE_COLORS[edge.type] || 'rgb(0, 0, 0)',
+    alpha: EDGE_ALPHA,
+  };
+}
+
+/**
+ * Attach default color/size/alpha to every node and edge of ``graphData``.
+ *
+ * Returns a shallow copy. The backend payload only carries topology
+ * and plan membership; all styling decisions live here so they can be
+ * changed without a backend release.
+ *
+ * @param {Object} graphData - topology from the visualizer backend.
+ * @returns {Object} a styled copy safe to mutate further (e.g. time overlay).
+ */
+export function applyDefaultStyles(graphData) {
+  const styledNodes = graphData.nodes.map(node => ({
+    ...node,
+    ...defaultNodeStyle(node),
+  }));
+  const styledEdges = graphData.edges.map(edge => ({
+    ...edge,
+    ...defaultEdgeStyle(edge),
+  }));
+  return { ...graphData, nodes: styledNodes, edges: styledEdges };
+}
+
 /**
  * Convert graph JSON data to Plotly traces for 3D visualization.
- * 
- * @param {Object} graphData - The graph data from export_graph_for_web()
+ *
+ * Expects ``graphData`` to have been styled by ``applyDefaultStyles``.
+ *
+ * @param {Object} graphData - styled graph data.
  * @returns {Array} Array of Plotly trace objects
  */
 export function jsonToPlotlyTraces(graphData) {
@@ -30,7 +105,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: planAssocNodes.map(n => n.position[1]),
       z: planAssocNodes.map(n => n.position[2]),
       marker: {
-        size: planAssocNodes.map(n => n.size / 4),
+        size: planAssocNodes.map(n => n.size),
         color: planAssocNodes.map(n => n.color),
         opacity: 1.0,
         line: { width: 2, color: 'white' },
@@ -51,7 +126,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: planSimpleNodes.map(n => n.position[1]),
       z: planSimpleNodes.map(n => n.position[2]),
       marker: {
-        size: planSimpleNodes.map(n => n.size / 4),
+        size: planSimpleNodes.map(n => n.size),
         color: planSimpleNodes.map(n => n.color),
         opacity: 1.0,
         line: { width: 2, color: 'white' },
@@ -71,7 +146,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: concreteAssocNodes.map(n => n.position[1]),
       z: concreteAssocNodes.map(n => n.position[2]),
       marker: {
-        size: concreteAssocNodes.map(n => n.size / 5),
+        size: concreteAssocNodes.map(n => n.size),
         color: concreteAssocNodes.map(n => n.color),
         opacity: concreteAssocNodes.map(n => n.alpha),
       },
@@ -91,7 +166,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: concreteSimpleNodes.map(n => n.position[1]),
       z: concreteSimpleNodes.map(n => n.position[2]),
       marker: {
-        size: concreteSimpleNodes.map(n => n.size / 5),
+        size: concreteSimpleNodes.map(n => n.size),
         color: concreteSimpleNodes.map(n => n.color),
         opacity: concreteSimpleNodes.map(n => n.alpha),
       },


### PR DESCRIPTION
The BilevelPlanningGraph web export used to take 9 styling parameters (abstract_state_color, state_color, plan_color, node_size, state_abstractor_edge_color, action_edge_color,
abstract_action_edge_color, node_alpha, edge_alpha), bake them into metadata, translate matplotlib color names to CSS rgb(...) via a hardcoded 5-entry table, and emit node.color / node.alpha / node.size / edge.color / edge.alpha on the payload. That's presentation data that belongs in the frontend.

This PR deletes all nine parameters and the color_map from _build_graph_payload and _build_graph_structure. The emitted node dict now carries {id, type, position, in_plan, (time_index), (abstract_state_id)}; the edge dict carries {source, target, type}. The matplotlib-based render_gif path is untouched — it still owns its own styling.

On the frontend, plotlyHelpers.js gains an applyDefaultStyles helper that walks the payload and attaches default color/size/alpha based on node.type + in_plan + abstract_state_id for nodes, and edge.type for edges. GraphViewer3D calls it once at the top of its render effect so the existing time-overlay logic (which mutates node.color) keeps working unchanged against the styled copy.