### PR TITLE
show abstract states in the visualizer

### DIFF
--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -520,6 +520,40 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
             for a, b in zip(seq[:-1], seq[1:]):
                 G.add_edge(f"x:{a}", f"x:{b}", type="action")
 
+        # Add abstract state nodes on the z_top plane. Each abstract node
+        # is placed at the xy centroid of the kept concrete nodes that
+        # group under it; abstract states with no kept concrete members
+        # fall back to the origin.
+        z_top_value = 1.0
+        abstract_members: dict[int, list[str]] = {}
+        for cid, aid in state_to_abstract.items():
+            if cid in kept_state_ids:
+                abstract_members.setdefault(aid, []).append(f"x:{cid}")
+
+        for abstract_idx in range(len(self.abstract_states)):
+            abs_nid = f"s:{abstract_idx}"
+            members = abstract_members.get(abstract_idx, [])
+            if members:
+                xs = [pos[m][0] for m in members]
+                ys = [pos[m][1] for m in members]
+                cx = sum(xs) / len(xs)
+                cy = sum(ys) / len(ys)
+            else:
+                cx, cy = 0.0, 0.0
+            pos[abs_nid] = (cx, cy, z_top_value)
+            G.add_node(abs_nid, type="abstract")
+
+        # State-abstractor edges: concrete -> abstract, crossing the z planes.
+        for cid, aid in state_to_abstract.items():
+            if cid in kept_state_ids:
+                G.add_edge(f"x:{cid}", f"s:{aid}", type="abstractor")
+
+        # Abstract action edges: abstract -> abstract on the z_top plane.
+        for src_abs, _action, dst_abs in self.abstract_action_edges:
+            src_idx = self._abstract_state_to_id(src_abs)
+            dst_idx = self._abstract_state_to_id(dst_abs)
+            G.add_edge(f"s:{src_idx}", f"s:{dst_idx}", type="abstract_action")
+
         # Compute time indices for rendered nodes only
         # Map underlying state_id -> rendered node id ("x:{state_id}")
         rendered_state_to_node: dict[int, str] = {}
@@ -551,10 +585,9 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
 
         # Metadata
 
-        # z_top, z_bottom previously used to visualize abstract nodes on a
-        # separate plane. They are currently only used for plotly z-axis range,
-        # and kept in case abstract nodes are added back to rendering.
-        metadata["z_top"] = 1.0
+        # z_top holds the abstract-state plane; z_bottom the concrete plane.
+        # The frontend's plotly layout reads these for the zaxis range.
+        metadata["z_top"] = z_top_value
         metadata["z_bottom"] = 0.0
 
         # node information

--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -305,15 +305,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
     def _build_graph_structure(
         self,
         final_state: _X | None = None,
-        abstract_state_color: str = "tab:purple",
-        state_color: str = "tab:blue",
-        plan_color: str = "tab:green",
-        node_size: int = 50,
-        state_abstractor_edge_color: str = "gray",
-        action_edge_color: str = "black",
-        abstract_action_edge_color: str = "black",
-        node_alpha: float = 0.7,
-        edge_alpha: float = 0.7,
         n_intermediate_per_side: int = 0,
     ) -> tuple[nx.DiGraph, dict[str, tuple[float, float, float]], dict]:
         """Build the graph structure for visualization.
@@ -327,8 +318,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         call site; see also the comments at each individual concern):
           * Fold this method into ``_build_graph_payload``. The split exists
             for no reason — nothing else calls ``_build_graph_structure``.
-          * Drop the styling parameters. Colors and sizes are presentation
-            concerns that belong in the frontend, not in the export.
           * Remove the ``n_intermediate_per_side`` knob. It defaults to 0, so
             the interpolation branch below is dead code today, and deciding
             how many intermediate nodes to show should happen in the viewer.
@@ -581,19 +570,6 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         metadata["min_time"] = min_time
         metadata["max_time"] = max_time
 
-        # Pass through colors/sizes for export
-        metadata["node_size"] = node_size
-        metadata["edge_alpha"] = edge_alpha
-
-        # coloring/visualization data
-        metadata["plan_color"] = plan_color
-        metadata["state_color"] = state_color
-        metadata["abstract_state_color"] = abstract_state_color
-        metadata["state_abstractor_edge_color"] = state_abstractor_edge_color
-        metadata["action_edge_color"] = action_edge_color
-        metadata["abstract_action_edge_color"] = abstract_action_edge_color
-        metadata["node_alpha"] = node_alpha
-
         if final_state is not None:
             # Only include plan nodes that were kept
             plan_nodes = []
@@ -620,83 +596,42 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
 
         return G, pos, metadata
 
-    def _build_graph_payload(
-        self,
-        final_state: _X | None = None,
-        abstract_state_color: str = "tab:purple",
-        state_color: str = "tab:blue",
-        plan_color: str = "tab:green",
-        node_size: int = 50,
-        state_abstractor_edge_color: str = "gray",
-        action_edge_color: str = "black",
-        abstract_action_edge_color: str = "black",
-        node_alpha: float = 0.7,
-        edge_alpha: float = 0.7,
-    ) -> dict:
+    def _build_graph_payload(self, final_state: _X | None = None) -> dict:
         """Build the frontend-facing topology dict (nodes, edges, plan, config).
 
-        Planned follow-ups:
-          * All of the color/size/alpha parameters should move to the
-            frontend. Styling is a presentation concern and the exporter
-            shouldn't bake it into the payload. The hardcoded matplotlib ->
-            RGB ``color_map`` below is the main reason these parameters
-            exist — once the frontend owns styling, the map disappears.
-          * Fold ``_build_graph_structure`` into this method; it has no
-            other caller.
+        The payload carries graph topology and plan membership only. The
+        frontend chooses colors, sizes, and alphas from ``node.type`` (the
+        ``"concrete"`` / ``"abstract"`` distinction), ``node.in_plan``, and
+        ``edge.type`` (``"action"`` / ``"abstractor"`` / ``"abstract_action"``).
+
+        Planned follow-up: fold ``_build_graph_structure`` into this method;
+        it has no other caller.
         """
-        # Build the graph structure
-        G, pos, metadata = self._build_graph_structure(
-            final_state=final_state,
-            abstract_state_color=abstract_state_color,
-            state_color=state_color,
-            plan_color=plan_color,
-            node_size=node_size,
-            state_abstractor_edge_color=state_abstractor_edge_color,
-            action_edge_color=action_edge_color,
-            abstract_action_edge_color=abstract_action_edge_color,
-            node_alpha=node_alpha,
-            edge_alpha=edge_alpha,
-        )
+        G, pos, metadata = self._build_graph_structure(final_state=final_state)
 
-        # Hardcoded mapping from the five matplotlib color names the caller
-        # is allowed to pass to their CSS ``rgb(...)`` equivalents. Planned
-        # for removal once styling moves to the frontend (see docstring).
-        color_map = {
-            "tab:purple": "rgb(148, 103, 189)",
-            "tab:blue": "rgb(31, 119, 180)",
-            "tab:green": "rgb(44, 160, 44)",
-            "gray": "rgb(128, 128, 128)",
-            "black": "rgb(0, 0, 0)",
-        }
-
-        def convert_color(mpl_color: str) -> str:
-            return color_map.get(mpl_color, mpl_color)
-
-        # Build nodes list
-        nodes = []
         plan_nodes_set = set(metadata["plan_nodes"])
         abstract_plan_nodes_set = set(metadata["abstract_plan_nodes"])
         node_time_index: dict[str, int] = metadata.get("node_time_index", {})
 
+        nodes = []
         for node_id, (x, y, z) in pos.items():
             is_abstract = node_id.startswith("s:")
-            in_plan = node_id in plan_nodes_set
-            in_abstract_plan = node_id in abstract_plan_nodes_set
+            in_plan = node_id in plan_nodes_set or node_id in abstract_plan_nodes_set
 
-            # Create node dict first to check for abstract association
-            node_dict = {
+            node_dict: dict = {
                 "id": node_id,
                 "type": "abstract" if is_abstract else "concrete",
                 "position": [x, y, z],
-                "size": metadata["node_size"],
-                "in_plan": in_plan or in_abstract_plan,
+                "in_plan": in_plan,
             }
 
-            # Attach time index for rendered concrete nodes
+            # Attach time index for rendered concrete nodes.
             if not is_abstract and node_id in node_time_index:
                 node_dict["time_index"] = node_time_index[node_id]
 
-            # Add abstract state ID for concrete nodes (if associated)
+            # Attach the owning abstract state id for concrete nodes that
+            # have a state-abstractor edge, so the frontend can highlight
+            # abstract groupings.
             if not is_abstract and node_id.startswith("x:"):
                 state_id = int(node_id.split(":")[1])
                 if state_id in metadata["state_to_abstract_id"]:
@@ -704,56 +639,21 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
                         state_id
                     ]
 
-            # Color based on node type, plan membership, and abstract association
-            if in_plan:
-                # Plan coloring
-                color = (
-                    "rgb(255, 165, 0)"
-                    if "abstract_state_id" in node_dict
-                    else convert_color(metadata["plan_color"])
-                )
-                alpha = 1.0
-            else:
-                # Non-plan coloring...
-                if node_dict["type"] == "concrete":
-                    color = (
-                        convert_color(metadata["abstract_state_color"])
-                        if "abstract_state_id" in node_dict
-                        else convert_color(metadata["state_color"])
-                    )
-                else:
-                    color = convert_color(metadata["abstract_state_color"])
-                alpha = metadata["node_alpha"]
-
-            node_dict["color"] = color
-            node_dict["alpha"] = alpha
-
             nodes.append(node_dict)
 
-        # Build edges list
+        # Build edges list. The type lets the frontend pick styling.
         edges = []
         for source, target in G.edges():
             source_pos = pos[source]
             target_pos = pos[target]
             if source_pos[2] != target_pos[2]:
                 edge_type = "abstractor"
-                color = convert_color(metadata["state_abstractor_edge_color"])
             elif source_pos[2] == metadata["z_bottom"]:
                 edge_type = "action"
-                color = convert_color(metadata["action_edge_color"])
             else:
                 edge_type = "abstract_action"
-                color = convert_color(metadata["abstract_action_edge_color"])
 
-            edges.append(
-                {
-                    "source": source,
-                    "target": target,
-                    "type": edge_type,
-                    "color": color,
-                    "alpha": metadata["edge_alpha"],
-                }
-            )
+            edges.append({"source": source, "target": target, "type": edge_type})
 
         # Build plan info
         plan_info = {

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/components/GraphViewer3D.jsx
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/components/GraphViewer3D.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import Plot from 'react-plotly.js';
-import { jsonToPlotlyTraces, getPlotlyLayout, getPlotlyConfig } from '../utils/plotlyHelpers';
+import { applyDefaultStyles, jsonToPlotlyTraces, getPlotlyLayout, getPlotlyConfig } from '../utils/plotlyHelpers';
 
 export function GraphViewer3D({ graphData, pickleLoaded = false }) {
   const [selectedNode, setSelectedNode] = useState(null);
@@ -179,8 +179,10 @@ export function GraphViewer3D({ graphData, pickleLoaded = false }) {
     try {
       console.log('Rendering graph with data:', graphData);
       
-      // Create working copy to apply overlays wo modifying original data
-      let graphDataCopy = graphData;
+      // The backend payload only carries topology and plan membership;
+      // assign default colors/sizes/alphas here so overlays below can
+      // mutate them without the backend caring.
+      let graphDataCopy = applyDefaultStyles(graphData);
       
       // Apply time-based coloring overlay (if timeline info available)
       if (currentTime !== null) {

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/utils/plotlyHelpers.js
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/utils/plotlyHelpers.js
@@ -1,7 +1,82 @@
+// Default node/edge styling. The backend exports only topology and plan
+// membership; the frontend owns presentation.
+const NODE_COLORS = {
+  planAbstractAssoc: 'rgb(255, 165, 0)', // orange: plan + in an abstract group
+  planSimple:        'rgb(44, 160, 44)', // green:  plan + no abstract group
+  abstractAssoc:     'rgb(148, 103, 189)', // purple: concrete + in abstract group
+  concreteSimple:    'rgb(31, 119, 180)', // blue:   concrete + no abstract group
+  abstract:          'rgb(148, 103, 189)', // purple: abstract state nodes
+};
+
+const NODE_SIZE_PLAN = 12;
+const NODE_SIZE_DEFAULT = 10;
+const NODE_ALPHA_PLAN = 1.0;
+const NODE_ALPHA_DEFAULT = 0.7;
+
+const EDGE_COLORS = {
+  action:          'rgb(0, 0, 0)',
+  abstractor:      'rgb(128, 128, 128)',
+  abstract_action: 'rgb(0, 0, 0)',
+};
+const EDGE_ALPHA = 0.7;
+
+function defaultNodeStyle(node) {
+  const inPlan = Boolean(node.in_plan);
+  const hasAbstractAssoc = node.abstract_state_id !== undefined;
+  let color;
+  if (node.type === 'abstract') {
+    color = NODE_COLORS.abstract;
+  } else if (inPlan && hasAbstractAssoc) {
+    color = NODE_COLORS.planAbstractAssoc;
+  } else if (inPlan) {
+    color = NODE_COLORS.planSimple;
+  } else if (hasAbstractAssoc) {
+    color = NODE_COLORS.abstractAssoc;
+  } else {
+    color = NODE_COLORS.concreteSimple;
+  }
+  return {
+    color,
+    size: inPlan ? NODE_SIZE_PLAN : NODE_SIZE_DEFAULT,
+    alpha: inPlan ? NODE_ALPHA_PLAN : NODE_ALPHA_DEFAULT,
+  };
+}
+
+function defaultEdgeStyle(edge) {
+  return {
+    color: EDGE_COLORS[edge.type] || 'rgb(0, 0, 0)',
+    alpha: EDGE_ALPHA,
+  };
+}
+
+/**
+ * Attach default color/size/alpha to every node and edge of ``graphData``.
+ *
+ * Returns a shallow copy. The backend payload only carries topology
+ * and plan membership; all styling decisions live here so they can be
+ * changed without a backend release.
+ *
+ * @param {Object} graphData - topology from the visualizer backend.
+ * @returns {Object} a styled copy safe to mutate further (e.g. time overlay).
+ */
+export function applyDefaultStyles(graphData) {
+  const styledNodes = graphData.nodes.map(node => ({
+    ...node,
+    ...defaultNodeStyle(node),
+  }));
+  const styledEdges = graphData.edges.map(edge => ({
+    ...edge,
+    ...defaultEdgeStyle(edge),
+  }));
+  return { ...graphData, nodes: styledNodes, edges: styledEdges };
+}
+
 /**
  * Convert graph JSON data to Plotly traces for 3D visualization.
- * 
- * @param {Object} graphData - The graph data from export_graph_for_web()
+ *
+ * Expects ``graphData`` to have been styled by ``applyDefaultStyles``.
+ *
+ * @param {Object} graphData - styled graph data.
  * @returns {Array} Array of Plotly trace objects
  */
 export function jsonToPlotlyTraces(graphData) {
@@ -30,7 +105,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: planAssocNodes.map(n => n.position[1]),
       z: planAssocNodes.map(n => n.position[2]),
       marker: {
-        size: planAssocNodes.map(n => n.size / 4),
+        size: planAssocNodes.map(n => n.size),
         color: planAssocNodes.map(n => n.color),
         opacity: 1.0,
         line: { width: 2, color: 'white' },
@@ -51,7 +126,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: planSimpleNodes.map(n => n.position[1]),
       z: planSimpleNodes.map(n => n.position[2]),
       marker: {
-        size: planSimpleNodes.map(n => n.size / 4),
+        size: planSimpleNodes.map(n => n.size),
         color: planSimpleNodes.map(n => n.color),
         opacity: 1.0,
         line: { width: 2, color: 'white' },
@@ -71,7 +146,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: concreteAssocNodes.map(n => n.position[1]),
       z: concreteAssocNodes.map(n => n.position[2]),
       marker: {
-        size: concreteAssocNodes.map(n => n.size / 5),
+        size: concreteAssocNodes.map(n => n.size),
         color: concreteAssocNodes.map(n => n.color),
         opacity: concreteAssocNodes.map(n => n.alpha),
       },
@@ -91,7 +166,7 @@ export function jsonToPlotlyTraces(graphData) {
       y: concreteSimpleNodes.map(n => n.position[1]),
       z: concreteSimpleNodes.map(n => n.position[2]),
       marker: {
-        size: concreteSimpleNodes.map(n => n.size / 5),
+        size: concreteSimpleNodes.map(n => n.size),
         color: concreteSimpleNodes.map(n => n.color),
         opacity: concreteSimpleNodes.map(n => n.alpha),
       },

--- a/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/utils/plotlyHelpers.js
+++ b/bilevel-planning/src/bilevel_planning/visualizer/frontend/src/utils/plotlyHelpers.js
@@ -83,17 +83,19 @@ export function jsonToPlotlyTraces(graphData) {
   console.log('Converting graph to Plotly traces...');
   const traces = [];
   
-  // Concrete nodes categorization
-  const planAssocNodes = graphData.nodes.filter(n => n.in_plan && n.abstract_state_id !== undefined);
-  const planSimpleNodes = graphData.nodes.filter(n => n.in_plan && n.abstract_state_id === undefined);
-  const concreteAssocNodes = graphData.nodes.filter(n => !n.in_plan && n.type === 'concrete' && n.abstract_state_id !== undefined);
-  const concreteSimpleNodes = graphData.nodes.filter(n => !n.in_plan && n.type === 'concrete' && n.abstract_state_id === undefined);
-  
-  console.log(`Node counts: 
+  // Categorize concrete and abstract nodes for separate Plotly traces.
+  const planAssocNodes = graphData.nodes.filter(n => n.type === 'concrete' && n.in_plan && n.abstract_state_id !== undefined);
+  const planSimpleNodes = graphData.nodes.filter(n => n.type === 'concrete' && n.in_plan && n.abstract_state_id === undefined);
+  const concreteAssocNodes = graphData.nodes.filter(n => n.type === 'concrete' && !n.in_plan && n.abstract_state_id !== undefined);
+  const concreteSimpleNodes = graphData.nodes.filter(n => n.type === 'concrete' && !n.in_plan && n.abstract_state_id === undefined);
+  const abstractNodes = graphData.nodes.filter(n => n.type === 'abstract');
+
+  console.log(`Node counts:
     Plan (Assoc): ${planAssocNodes.length}
     Plan (Simple): ${planSimpleNodes.length}
     Concrete (Assoc): ${concreteAssocNodes.length}
     Concrete (Simple): ${concreteSimpleNodes.length}
+    Abstract: ${abstractNodes.length}
   `);
   
   // Plan Nodes (Abstract Associated) - Orange
@@ -175,14 +177,34 @@ export function jsonToPlotlyTraces(graphData) {
       hovertemplate: '<b>%{customdata}</b><br>Type: Concrete',
     });
   }
+
+  // Abstract state nodes on the z_top plane.
+  if (abstractNodes.length > 0) {
+    traces.push({
+      type: 'scatter3d',
+      mode: 'markers',
+      x: abstractNodes.map(n => n.position[0]),
+      y: abstractNodes.map(n => n.position[1]),
+      z: abstractNodes.map(n => n.position[2]),
+      marker: {
+        size: abstractNodes.map(n => n.size),
+        color: abstractNodes.map(n => n.color),
+        opacity: abstractNodes.map(n => n.alpha),
+        symbol: 'diamond',
+      },
+      customdata: abstractNodes.map(n => n.id),
+      name: 'Abstract States',
+      hovertemplate: '<b>%{customdata}</b><br>Type: Abstract',
+    });
+  }
   
   // Group edges by type
   const edgesByType = {
-    'action': [],
-    // 'abstract_action': [],
-    // 'abstractor': []
+    action: [],
+    abstractor: [],
+    abstract_action: [],
   };
-  
+
   graphData.edges.forEach(edge => {
     if (edgesByType[edge.type]) {
       edgesByType[edge.type].push(edge);
@@ -224,6 +246,10 @@ export function jsonToPlotlyTraces(graphData) {
   // Add edge traces
   const actionTrace = createEdgeTrace(edgesByType.action, 'Actions');
   if (actionTrace) traces.push(actionTrace);
+  const abstractorTrace = createEdgeTrace(edgesByType.abstractor, 'Abstractor');
+  if (abstractorTrace) traces.push(abstractorTrace);
+  const abstractActionTrace = createEdgeTrace(edgesByType.abstract_action, 'Abstract actions');
+  if (abstractActionTrace) traces.push(abstractActionTrace);
 
   console.log(`Total traces created: ${traces.length}`);
   return traces;
@@ -259,7 +285,11 @@ export function getPlotlyLayout(graphData) {
         zeroline: false,
         range: [graphData.config.z_bottom, graphData.config.z_top]
       },
-      aspectmode: 'data',
+      // 'cube' gives each axis equal visual length regardless of data
+      // extent, so the abstract plane (z=z_top) is visibly separated from
+      // the concrete plane (z=z_bottom) even though the xy range is much
+      // wider than [z_bottom, z_top].
+      aspectmode: 'cube',
       bgcolor: 'white',
     },
     clickmode: 'event+select', // Enable click events and selection

--- a/bilevel-planning/tests/test_bilevel_planning_graph.py
+++ b/bilevel-planning/tests/test_bilevel_planning_graph.py
@@ -111,3 +111,17 @@ def test_export_roundtrip(tmp_path: Path):
     assert plan_nodes, "plan should be non-empty when final_state is provided"
     assert graph["plan"]["start"] == plan_nodes[0]
     assert graph["plan"]["goal"] == plan_nodes[-1]
+
+    # Abstract states are emitted as nodes on the z_top plane, with a
+    # state-abstractor edge from each kept concrete node to its abstract
+    # state and an abstract_action edge between the two abstract states.
+    abstract_nodes = [n for n in graph["nodes"] if n["type"] == "abstract"]
+    assert len(abstract_nodes) == 2
+    z_top = graph["config"]["z_top"]
+    for n in abstract_nodes:
+        assert n["position"][2] == z_top
+
+    edge_types = {e["type"] for e in graph["edges"]}
+    assert "action" in edge_types
+    assert "abstractor" in edge_types
+    assert "abstract_action" in edge_types


### PR DESCRIPTION
The exporter used to emit only concrete nodes into the graph payload;
abstract states lived purely in metadata and were only used to color
the concrete nodes that grouped under them. So the user saw a cloud of
concrete nodes in the viewer with no visible abstract layer at all.

This PR puts abstract states back on the z_top plane:

* _build_graph_structure now adds each abstract state to G as
  type='abstract', positioned at the xy centroid of the kept concrete
  nodes that ground into it (or the origin if none are grouped).
* State-abstractor edges (concrete -> abstract, type='abstractor') and
  abstract action edges (abstract -> abstract, type='abstract_action')
  are added to G alongside the existing concrete 'action' edges.
* plotlyHelpers.jsonToPlotlyTraces gains an abstract-node trace
  (diamond markers) and wires up the previously-ignored 'abstractor'
  and 'abstract_action' edge types. The scene uses aspectmode='cube'
  so the z range between z_bottom=0 and z_top=1 is visually separated
  from the much wider xy range.
* defaultNodeStyle/defaultEdgeStyle in plotlyHelpers already had
  entries for 'abstract', 'abstractor', and 'abstract_action' from the
  previous PR, so no styling changes are needed.
* test_bilevel_planning_graph gains assertions that the export
  contains abstract nodes on z_top and all three edge types.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>