### PR TITLE
add SimEnv protocol and real-to-sim-to-real Runner scaffolding

### DIFF
--- a/prpl-utils/src/prpl_utils/real_sim/__init__.py
+++ b/prpl-utils/src/prpl_utils/real_sim/__init__.py
@@ -1,0 +1,13 @@
+"""Real-to-sim-to-real components.
+
+* :class:`Perceiver` lifts real observations into simulator states.
+* :class:`ActionGrounder` lowers simulator actions into real actions.
+* :class:`Runner` ties an :class:`Agent` together with a real environment, a
+  :class:`Perceiver`, and an :class:`ActionGrounder`.
+"""
+
+from prpl_utils.real_sim.action_grounder import ActionGrounder
+from prpl_utils.real_sim.perceiver import Perceiver
+from prpl_utils.real_sim.runner import Runner
+
+__all__ = ["ActionGrounder", "Perceiver", "Runner"]

--- a/prpl-utils/src/prpl_utils/real_sim/action_grounder.py
+++ b/prpl-utils/src/prpl_utils/real_sim/action_grounder.py
@@ -1,0 +1,26 @@
+"""Action grounders map simulator actions to real-environment actions.
+
+An :class:`ActionGrounder` is the dual of a :class:`prpl_utils.perceiver.Perceiver`:
+the perceiver lifts real observations into simulator states, and the grounder lowers
+simulator actions into actions that can be executed in the real environment.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Generic, TypeVar
+
+_SimActType = TypeVar("_SimActType")
+_RealActType = TypeVar("_RealActType")
+_StateType = TypeVar("_StateType")
+
+
+class ActionGrounder(Generic[_SimActType, _RealActType, _StateType], abc.ABC):
+    """Mapping from a simulator action (in context of a state) to a real action."""
+
+    @abc.abstractmethod
+    def __call__(self, sim_action: _SimActType, sim_state: _StateType) -> _RealActType:
+        """Return the real action that executes ``sim_action`` from ``sim_state``."""
+
+
+__all__ = ["ActionGrounder"]

--- a/prpl-utils/src/prpl_utils/real_sim/perceiver.py
+++ b/prpl-utils/src/prpl_utils/real_sim/perceiver.py
@@ -1,0 +1,29 @@
+"""Perceivers map real-environment observations to simulator states.
+
+A :class:`Perceiver` is stateful so that it can track objects, smooth estimates, or
+integrate proprioceptive information across timesteps.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, Generic, TypeVar
+
+_RealObsType = TypeVar("_RealObsType")
+_StateType = TypeVar("_StateType")
+
+
+class Perceiver(Generic[_RealObsType, _StateType], abc.ABC):
+    """Stateful mapping from real observations to simulator states."""
+
+    @abc.abstractmethod
+    def reset(self, obs: _RealObsType, info: dict[str, Any]) -> _StateType:
+        """Reset internal state and return an initial state estimate."""
+
+    @abc.abstractmethod
+    def step(self, obs: _RealObsType, info: dict[str, Any]) -> _StateType:
+        """Update internal state with a new observation and return the state
+        estimate."""
+
+
+__all__ = ["Perceiver"]

--- a/prpl-utils/src/prpl_utils/real_sim/runner.py
+++ b/prpl-utils/src/prpl_utils/real_sim/runner.py
@@ -1,0 +1,107 @@
+"""Driver that runs an agent on a real environment via a simulator state space.
+
+The :class:`Runner` ties together four components:
+
+* a real ``gymnasium.Env`` that produces real observations and consumes real actions,
+* a :class:`prpl_utils.real_sim.perceiver.Perceiver` that converts real observations
+  to simulator states,
+* a :class:`prpl_utils.gym_agent.Agent` that consumes simulator states and produces
+  simulator actions, and
+* a :class:`prpl_utils.real_sim.action_grounder.ActionGrounder` that converts
+  simulator actions to real actions.
+
+The runner deliberately does not touch any simulator. If the agent uses a simulator
+for planning, it owns that simulator and calls ``set_state`` on it as needed.
+Subclasses can override :meth:`on_step` to add visualization or logging.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Generic, TypeVar
+
+import gymnasium
+
+from prpl_utils.gym_agent import Agent
+from prpl_utils.real_sim.action_grounder import ActionGrounder
+from prpl_utils.real_sim.perceiver import Perceiver
+
+_RealObsType = TypeVar("_RealObsType")
+_RealActType = TypeVar("_RealActType")
+_StateType = TypeVar("_StateType")
+_SimActType = TypeVar("_SimActType")
+
+
+class Runner(Generic[_RealObsType, _RealActType, _StateType, _SimActType]):
+    """Run an agent on a real environment via a perceiver and action grounder."""
+
+    def __init__(
+        self,
+        real_env: gymnasium.Env[_RealObsType, _RealActType],
+        perceiver: Perceiver[_RealObsType, _StateType],
+        agent: Agent[_StateType, _SimActType],
+        action_grounder: ActionGrounder[_SimActType, _RealActType, _StateType],
+    ) -> None:
+        self._real_env = real_env
+        self._perceiver = perceiver
+        self._agent = agent
+        self._action_grounder = action_grounder
+        self._last_state: _StateType | None = None
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> _StateType:
+        """Reset the real environment, perceiver, and agent; return the initial
+        state."""
+        real_obs, info = self._real_env.reset(seed=seed, options=options)
+        state = self._perceiver.reset(real_obs, info)
+        self._agent.reset(state, info)
+        self._last_state = state
+        return state
+
+    def step(self) -> tuple[_StateType, float, bool, bool, dict[str, Any]]:
+        """Execute one (agent → ground → env → perceive → update) cycle."""
+        if self._last_state is None:
+            raise RuntimeError("Runner.step() called before Runner.reset()")
+        sim_action = self._agent.step()
+        real_action = self._action_grounder(sim_action, self._last_state)
+        real_obs, reward, terminated, truncated, info = self._real_env.step(real_action)
+        reward = float(reward)
+        state = self._perceiver.step(real_obs, info)
+        self._agent.update(state, reward, terminated or truncated, info)
+        self.on_step(
+            state, sim_action, real_action, reward, terminated, truncated, info
+        )
+        self._last_state = state
+        return state, reward, terminated, truncated, info
+
+    def run(self, max_steps: int) -> float:
+        """Step until termination, truncation, or ``max_steps`` is reached.
+
+        Returns the cumulative reward. Subclass and override :meth:`on_step` (or wrap
+        :meth:`step`) if you need richer trajectory data.
+        """
+        total_reward = 0.0
+        for _ in range(max_steps):
+            _, reward, terminated, truncated, _ = self.step()
+            total_reward += reward
+            if terminated or truncated:
+                break
+        return total_reward
+
+    def on_step(
+        self,
+        state: _StateType,
+        sim_action: _SimActType,
+        real_action: _RealActType,
+        reward: float,
+        terminated: bool,
+        truncated: bool,
+        info: dict[str, Any],
+    ) -> None:
+        """Hook called after each :meth:`step` for logging, viz, etc."""
+
+
+__all__ = ["Runner"]

--- a/prpl-utils/src/prpl_utils/sim_env.py
+++ b/prpl-utils/src/prpl_utils/sim_env.py
@@ -1,0 +1,41 @@
+"""Protocol for simulator environments that support state inspection and setting.
+
+A :class:`SimEnv` extends the usual ``gymnasium.Env`` API with methods for reading,
+writing, and rolling out from arbitrary states. Any class that provides these methods
+will satisfy the protocol structurally; no inheritance is required.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar, runtime_checkable
+
+_StateType = TypeVar("_StateType")
+_ActType_contra = TypeVar("_ActType_contra", contravariant=True)
+
+
+@runtime_checkable
+class SimEnv(Protocol[_StateType, _ActType_contra]):
+    """A simulator environment with state-setting and one-step planning helpers."""
+
+    def get_state(self) -> _StateType:
+        """Return the current environment state."""
+
+    def set_state(self, state: _StateType) -> None:
+        """Overwrite the environment state."""
+
+    def get_transition(
+        self, state: _StateType, action: _ActType_contra
+    ) -> tuple[_StateType, float, bool]:
+        """Return ``(next_state, reward, terminated)`` from ``state`` taking
+        ``action``."""
+
+    def get_next_state(self, state: _StateType, action: _ActType_contra) -> _StateType:
+        """Return the next state from ``state`` taking ``action``."""
+
+    def get_reward_and_done(
+        self, state: _StateType, action: _ActType_contra
+    ) -> tuple[float, bool]:
+        """Return ``(reward, terminated)`` from ``state`` taking ``action``."""
+
+
+__all__ = ["SimEnv"]

--- a/prpl-utils/tests/real_sim/test_action_grounder.py
+++ b/prpl-utils/tests/real_sim/test_action_grounder.py
@@ -1,0 +1,19 @@
+"""Tests for the ActionGrounder base class."""
+
+from __future__ import annotations
+
+from prpl_utils.real_sim import ActionGrounder
+
+
+class _OffsetGrounder(ActionGrounder[int, int, int]):
+    """Real action is the sim action shifted by the current state."""
+
+    def __call__(self, sim_action: int, sim_state: int) -> int:
+        return sim_action + sim_state
+
+
+def test_action_grounder_uses_state_context() -> None:
+    """The grounder receives the current state and can use it to map actions."""
+    grounder = _OffsetGrounder()
+    assert grounder(2, 10) == 12
+    assert grounder(-3, 5) == 2

--- a/prpl-utils/tests/real_sim/test_perceiver.py
+++ b/prpl-utils/tests/real_sim/test_perceiver.py
@@ -1,0 +1,33 @@
+"""Tests for the Perceiver base class."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prpl_utils.real_sim import Perceiver
+
+
+class _CountingPerceiver(Perceiver[int, tuple[int, int]]):
+    """Returns (obs, steps_since_reset)."""
+
+    def __init__(self) -> None:
+        self._steps = 0
+
+    def reset(self, obs: int, info: dict[str, Any]) -> tuple[int, int]:
+        del info
+        self._steps = 0
+        return obs, self._steps
+
+    def step(self, obs: int, info: dict[str, Any]) -> tuple[int, int]:
+        del info
+        self._steps += 1
+        return obs, self._steps
+
+
+def test_perceiver_reset_and_step() -> None:
+    """Reset() returns an initial estimate and step() advances internal state."""
+    perceiver = _CountingPerceiver()
+    assert perceiver.reset(7, {}) == (7, 0)
+    assert perceiver.step(8, {}) == (8, 1)
+    assert perceiver.step(9, {}) == (9, 2)
+    assert perceiver.reset(0, {}) == (0, 0)

--- a/prpl-utils/tests/real_sim/test_runner.py
+++ b/prpl-utils/tests/real_sim/test_runner.py
@@ -1,0 +1,175 @@
+"""Tests for the real-to-sim Runner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import gymnasium
+import pytest
+from gymnasium import spaces
+
+from prpl_utils.gym_agent import Agent
+from prpl_utils.real_sim import ActionGrounder, Perceiver, Runner
+
+
+class _CountingRealEnv(gymnasium.Env[int, int]):
+    """A toy env whose obs is a counter incremented on every step."""
+
+    observation_space: spaces.Discrete = spaces.Discrete(1_000_000)
+    action_space: spaces.Discrete = spaces.Discrete(1_000_000)
+
+    def __init__(self, max_steps: int = 5) -> None:
+        self._t = 0
+        self._max_steps = max_steps
+        self.last_real_action: int | None = None
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        super().reset(seed=seed)
+        del options
+        self._t = 0
+        self.last_real_action = None
+        return self._t, {}
+
+    def step(self, action: int) -> tuple[int, float, bool, bool, dict[str, Any]]:
+        self.last_real_action = action
+        self._t += 1
+        terminated = self._t >= self._max_steps
+        return self._t, 1.0, terminated, False, {"t": self._t}
+
+    def render(self) -> None:
+        """No-op renderer for this toy env."""
+        return None
+
+
+class _PassThroughPerceiver(Perceiver[int, int]):
+    """Sim state is just the real obs (so we can trace it end-to-end)."""
+
+    def reset(self, obs: int, info: dict[str, Any]) -> int:
+        del info
+        return obs
+
+    def step(self, obs: int, info: dict[str, Any]) -> int:
+        del info
+        return obs
+
+
+class _ConstantAgent(Agent[int, int]):
+    """Always returns the same sim action."""
+
+    def __init__(self, seed: int, action: int) -> None:
+        super().__init__(seed)
+        self._action = action
+
+    def _get_action(self) -> int:
+        return self._action
+
+
+class _AddStateGrounder(ActionGrounder[int, int, int]):
+    """Real action = sim action + current state, to verify state context flows."""
+
+    def __call__(self, sim_action: int, sim_state: int) -> int:
+        return sim_action + sim_state
+
+
+def test_runner_step_before_reset_raises() -> None:
+    """Step() before reset() must raise to surface programmer errors."""
+    runner = Runner(
+        _CountingRealEnv(),
+        _PassThroughPerceiver(),
+        _ConstantAgent(seed=0, action=1),
+        _AddStateGrounder(),
+    )
+    with pytest.raises(RuntimeError):
+        runner.step()
+
+
+def test_runner_single_step_threads_state_through() -> None:
+    """A single step routes the state through perceiver, agent, and grounder."""
+    real_env = _CountingRealEnv(max_steps=10)
+    runner = Runner(
+        real_env,
+        _PassThroughPerceiver(),
+        _ConstantAgent(seed=0, action=3),
+        _AddStateGrounder(),
+    )
+    initial_state = runner.reset(seed=0)
+    assert initial_state == 0
+    state, reward, terminated, truncated, info = runner.step()
+    # The grounder added the state-at-decision (0) to the sim action (3).
+    assert real_env.last_real_action == 3
+    assert state == 1
+    assert reward == 1.0
+    assert terminated is False
+    assert truncated is False
+    assert info == {"t": 1}
+
+
+def test_runner_run_stops_on_termination() -> None:
+    """Run() exits early when the environment terminates."""
+    real_env = _CountingRealEnv(max_steps=3)
+    runner = Runner(
+        real_env,
+        _PassThroughPerceiver(),
+        _ConstantAgent(seed=0, action=0),
+        _AddStateGrounder(),
+    )
+    runner.reset(seed=0)
+    total_reward = runner.run(max_steps=100)
+    assert total_reward == 3.0
+    assert real_env.last_real_action is not None
+
+
+def test_runner_run_respects_max_steps() -> None:
+    """Run() exits after max_steps even if the env hasn't terminated."""
+    real_env = _CountingRealEnv(max_steps=1000)
+    runner = Runner(
+        real_env,
+        _PassThroughPerceiver(),
+        _ConstantAgent(seed=0, action=0),
+        _AddStateGrounder(),
+    )
+    runner.reset(seed=0)
+    total_reward = runner.run(max_steps=4)
+    assert total_reward == 4.0
+
+
+def test_runner_on_step_hook_is_called() -> None:
+    """on_step is invoked once per step and receives the threaded action context."""
+    real_env = _CountingRealEnv(max_steps=3)
+    seen: list[tuple[int, int, int, float, bool, bool]] = []
+
+    class _RecordingRunner(Runner[int, int, int, int]):
+        """A Runner that records every on_step call for inspection."""
+
+        def on_step(
+            self,
+            state: int,
+            sim_action: int,
+            real_action: int,
+            reward: float,
+            terminated: bool,
+            truncated: bool,
+            info: dict[str, Any],
+        ) -> None:
+            del info
+            seen.append((state, sim_action, real_action, reward, terminated, truncated))
+
+    runner = _RecordingRunner(
+        real_env,
+        _PassThroughPerceiver(),
+        _ConstantAgent(seed=0, action=2),
+        _AddStateGrounder(),
+    )
+    runner.reset(seed=0)
+    runner.run(max_steps=10)
+    assert len(seen) == 3
+    # Grounder adds state-at-decision to sim_action (2): 0->2, 1->3, 2->4.
+    assert seen[0][2] == 2
+    assert seen[1][2] == 3
+    assert seen[2][2] == 4
+    assert seen[-1][4] is True

--- a/prpl-utils/tests/test_sim_env.py
+++ b/prpl-utils/tests/test_sim_env.py
@@ -1,0 +1,70 @@
+"""Tests for the SimEnv protocol."""
+
+from __future__ import annotations
+
+from prpl_utils.sim_env import SimEnv
+
+
+class _CompleteSim:
+    """A class that implements every SimEnv method."""
+
+    def __init__(self) -> None:
+        self._state = 0
+
+    def get_state(self) -> int:
+        """Return the current state."""
+        return self._state
+
+    def set_state(self, state: int) -> None:
+        """Overwrite the current state."""
+        self._state = state
+
+    def get_transition(self, state: int, action: int) -> tuple[int, float, bool]:
+        """Return next state, reward, and terminated for a hypothetical transition."""
+        next_state = state + action
+        return next_state, float(action), next_state >= 10
+
+    def get_next_state(self, state: int, action: int) -> int:
+        """Return only the next state."""
+        return self.get_transition(state, action)[0]
+
+    def get_reward_and_done(self, state: int, action: int) -> tuple[float, bool]:
+        """Return only reward and terminated."""
+        _, reward, done = self.get_transition(state, action)
+        return reward, done
+
+
+class _PartialSim:
+    """Missing get_transition and friends, so should not satisfy SimEnv."""
+
+    def get_state(self) -> int:
+        """Return a dummy state."""
+        return 0
+
+    def set_state(self, state: int) -> None:
+        """Ignore the state for this stub."""
+
+
+def test_complete_sim_satisfies_protocol() -> None:
+    """A class with every SimEnv method passes isinstance(env, SimEnv)."""
+    env = _CompleteSim()
+    assert isinstance(env, SimEnv)
+
+
+def test_partial_sim_does_not_satisfy_protocol() -> None:
+    """Missing planning methods fail the runtime protocol check."""
+    env = _PartialSim()
+    assert not isinstance(env, SimEnv)
+
+
+def test_planning_methods_round_trip() -> None:
+    """get_state/set_state and the planning helpers behave consistently."""
+    env: SimEnv[int, int] = _CompleteSim()
+    env.set_state(3)
+    assert env.get_state() == 3
+    next_state, reward, terminated = env.get_transition(3, 4)
+    assert next_state == 7
+    assert reward == 4.0
+    assert terminated is False
+    assert env.get_next_state(3, 4) == 7
+    assert env.get_reward_and_done(3, 8) == (8.0, True)


### PR DESCRIPTION
## Summary
- Add `prpl_utils.sim_env.SimEnv` — a structural `Protocol` with `get_state`/`set_state` plus one-step planning helpers (`get_transition`, `get_next_state`, `get_reward_and_done`). Kinder envs constructed with `allow_state_access=True` already satisfy it, so no kinder changes are needed.
- Add `prpl_utils.real_sim` package with three abstractions for the real-to-sim-to-real loop: `Perceiver` (real obs to sim state, stateful), `ActionGrounder` (sim action plus sim state to real action), and `Runner` (ties together a real `gymnasium.Env`, a `Perceiver`, an `Agent`, and an `ActionGrounder`).
- The `Runner` deliberately does not touch any simulator. If the agent needs a sim for planning, it owns the sim and calls `set_state` on it itself.

## Test plan
- [x] ./run_ci_checks.sh clean (mypy, pylint, pytest — 28 passed, 1 skipped)
- [ ] Wire up a real consumer (adapt KinDERGroundPerceiver to the new Perceiver ABC) before next week experiments

Generated with Claude Code
