### PR TITLE
bump prpl-utils to 0.0.6

### DIFF
--- a/prpl-utils/pyproject.toml
+++ b/prpl-utils/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prpl_utils"
-version = "0.0.5"
+version = "0.0.6"
 description = "Common Python utilities for the Princeton Robot Planning and Learning lab."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump `prpl-utils` from 0.0.5 to 0.0.6 (already published to PyPI).

## Test plan
- [x] `uv build` succeeds
- [x] `uv publish` succeeds
