### PR TITLE
bump prpl-utils to 0.0.7

### DIFF
--- a/prpl-utils/pyproject.toml
+++ b/prpl-utils/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prpl_utils"
-version = "0.0.6"
+version = "0.0.7"
 description = "Common Python utilities for the Princeton Robot Planning and Learning lab."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cuts a 0.0.7 release of `prpl_utils` so that downstream packages — [kinder-baselines#65](https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/65) and [prpl-tidybot#41](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-tidybot/pull/41) — can import the new `PlanningAgent` / `PlanExecutor` symbols added by #470 from pypi.

Mirrors the form of [#469](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono/pull/469): a one-line version bump in `prpl-utils/pyproject.toml`, nothing else.

After this merges, manually publish to pypi per the README:

```bash
cd prpl-utils
rm -rf dist/ build/ src/*.egg-info/
export UV_PUBLISH_TOKEN=pypi-...
uv build
uv publish dist/*
```

## Test plan

- [x] CI on this branch (no behavioral changes; same tests as #470 should pass).
- [ ] Confirm `prpl_utils==0.0.7` is installable from pypi after the manual publish step.
