### PR TITLE
add Dexmate Vega 1U robot to pybullet-helpers

### DIFF
--- a/pybullet-helpers/pyproject.toml
+++ b/pybullet-helpers/pyproject.toml
@@ -63,5 +63,6 @@ module = [
     "pybullet.*",
     "pybullet_utils.*",
     "scipy.*",
+    "dexmate_urdf",
 ]
 ignore_missing_imports = true

--- a/pybullet-helpers/pyproject.toml
+++ b/pybullet-helpers/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
    "gymnasium>=0.29.1",
    "scipy==1.14.0",
    "hello-robot-stretch-urdf",
+   "dexmate-urdf>=0.8.3",
    "prpl_utils>=0.0.1",
 ]
 

--- a/pybullet-helpers/src/pybullet_helpers/robots/__init__.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/__init__.py
@@ -3,6 +3,7 @@
 from typing import Type
 
 from pybullet_helpers.robots.assistive_human import AssistiveHumanPyBulletRobot
+from pybullet_helpers.robots.dexmate_vega import DexmateVega1UPyBulletRobot
 from pybullet_helpers.robots.fetch import FetchPyBulletRobot
 from pybullet_helpers.robots.human import (
     LeftArmHumanPyBulletRobot,
@@ -35,6 +36,7 @@ _BUILT_IN_ROBOT_CLASSES: list[Type[SingleArmPyBulletRobot]] = [
     RightLegHumanPyBulletRobot,
     LeftLegHumanPyBulletRobot,
     SpotPyBulletRobot,
+    DexmateVega1UPyBulletRobot,
 ]
 
 _BUILT_IN_MOBILE_ROBOT_CLASSES: list[Type[SingleArmPyBulletMobileManipulator]] = [

--- a/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
@@ -1,0 +1,73 @@
+"""Dexmate Vega humanoid robots."""
+
+import re
+from pathlib import Path
+
+from dexmate_urdf import get_robot_path
+
+from pybullet_helpers.joint import JointPositions
+from pybullet_helpers.robots.single_arm import SingleArmPyBulletRobot
+
+
+class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
+    """Dexmate Vega 1U humanoid; the left arm is exposed as the actuated arm.
+
+    The kinematic chain from base to the left end-effector includes the prismatic
+    Lift, the torso_flip revolute joint, and the seven left arm joints
+    L_arm_j1..L_arm_j7.
+    """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dexmate-vega-1u"
+
+    @property
+    def default_urdf_path(self) -> Path:
+        # PyBullet can't load the .glb meshes shipped with dexmate-urdf, so we
+        # rewrite the URDF to point at the .obj collision meshes from vega_1
+        # (which exist for the head and arm links) and strip the visual/collision
+        # blocks for base/lift/torso_flip (which have no .obj alternative).
+        robot_dir = get_robot_path("humanoid", "vega_1u")
+        original_path = robot_dir / "vega_1u.urdf"
+        urdf_str = original_path.read_text(encoding="utf-8")
+        urdf_str = re.sub(
+            r'\.\./vega_1/meshes/visual/([^"]+)\.glb',
+            r"../vega_1/meshes/collision/\1.obj",
+            urdf_str,
+        )
+        urdf_str = re.sub(
+            r"\s*<(visual|collision)>\s*<origin[^/]*/>\s*<geometry>\s*"
+            r'<mesh filename="meshes/visual/[^"]+\.glb"\s*/>\s*'
+            r"</geometry>\s*</\1>",
+            "",
+            urdf_str,
+        )
+        # The collision OBJs have no MTL, so without a URDF material PyBullet
+        # renders them pure black. Inject a neutral gray into every <visual>.
+        material_xml = (
+            '<material name="dexmate_vega_default">'
+            '<color rgba="0.75 0.75 0.78 1.0"/>'
+            "</material>"
+        )
+        urdf_str = re.sub(
+            r"(</geometry>)(\s*</visual>)",
+            r"\1" + material_xml + r"\2",
+            urdf_str,
+        )
+        # Write next to the original so the relative mesh paths still resolve.
+        new_path = original_path.parent / "vega_1u-PYBULLET-HELPERS.urdf"
+        new_path.write_text(urdf_str, encoding="utf-8")
+        return new_path
+
+    @property
+    def default_home_joint_positions(self) -> JointPositions:
+        # Lift, torso_flip, L_arm_j1..L_arm_j7 — all zeros are within limits.
+        return [0.0] * 9
+
+    @property
+    def end_effector_name(self) -> str:
+        return "L_ee_j0"
+
+    @property
+    def tool_link_name(self) -> str:
+        return "L_ee"

--- a/pybullet-helpers/tests/robots/test_dexmate_vega.py
+++ b/pybullet-helpers/tests/robots/test_dexmate_vega.py
@@ -1,0 +1,30 @@
+"""Tests for the Dexmate Vega robot."""
+
+import numpy as np
+
+from pybullet_helpers.robots.dexmate_vega import DexmateVega1UPyBulletRobot
+
+
+def test_dexmate_vega_1u_robot(physics_client_id):
+    """Tests for DexmateVega1UPyBulletRobot."""
+    robot = DexmateVega1UPyBulletRobot(physics_client_id)
+    assert robot.get_name() == "dexmate-vega-1u"
+    assert robot.arm_joint_names == [
+        "Lift",
+        "torso_flip",
+        "L_arm_j1",
+        "L_arm_j2",
+        "L_arm_j3",
+        "L_arm_j4",
+        "L_arm_j5",
+        "L_arm_j6",
+        "L_arm_j7",
+    ]
+    assert np.allclose(robot.action_space.low, robot.joint_lower_limits)
+    assert np.allclose(robot.action_space.high, robot.joint_upper_limits)
+    # Moving each joint to its midpoint produces an EE pose within reach
+    # (forward_kinematics doesn't raise).
+    for i in range(len(robot.arm_joints)):
+        q = list(robot.home_joint_positions)
+        q[i] = 0.5 * (robot.joint_lower_limits[i] + robot.joint_upper_limits[i])
+        robot.forward_kinematics(q)


### PR DESCRIPTION
## Summary

- Adds the Dexmate Vega 1U humanoid to pybullet-helpers, sourced from the [`dexmate-urdf`](https://pypi.org/project/dexmate-urdf/) pip package (now a dependency).
- Exposed as a `SingleArmPyBulletRobot` under the name `dexmate-vega-1u`, with the left arm as the actuated chain: `Lift` (prismatic), `torso_flip`, and `L_arm_j1..L_arm_j7` — 9 joints, ending at `L_ee`.
- PyBullet can't load the `.glb` meshes the package ships, so `default_urdf_path` rewrites the URDF in place: visual `.glb` references are swapped to the matching `.obj` collision meshes for head/arm links, and the visual/collision blocks for `base_link` / `lift_link` / `torso_flip_link` (which have no `.obj` alternative) are stripped. A neutral gray `<material>` is injected so the arm doesn't render as pure black.

## Test plan

- [x] `./run_ci_checks.sh` passes (74 tests, +1 new).
- [x] New `tests/robots/test_dexmate_vega.py` checks joint names and that FK over each joint's midpoint runs.
- [x] `python scripts/joint_visualizer.py dexmate-vega-1u` launches the GUI and all 9 sliders actuate the robot.
- [x] Visual inspection of the GUI: arm and head render in gray; base/lift/torso are invisible (no `.obj` for those links — future work to add textured visuals).
