### PR TITLE
add EAIK-based analytic IK for the Dexmate Vega left arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,26 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Install LAPACK BLAS, and OSMESA
+      - name: Install LAPACK BLAS, OSMESA, and Eigen3
+        # Eigen3 is needed by EAIK (analytic IK for the Dexmate Vega arm),
+        # which is a sdist-only PyPI package that compiles from source.
         run: |
           sudo apt-get update
-          sudo apt-get install -y liblapack-dev libblas-dev libosmesa6-dev libgl1 libglx-mesa0
+          sudo apt-get install -y liblapack-dev libblas-dev libosmesa6-dev libgl1 libglx-mesa0 libeigen3-dev
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - name: Install pybullet-helpers Dexmate Vega extra (EAIK)
+        # Pulls in EAIK so the Vega custom IK roundtrip test runs in CI rather
+        # than being skipped. Until upstream EAIK ships binary wheels, this
+        # step requires the libeigen3-dev install above.
+        run: |
+          if [ -f pybullet-helpers/pyproject.toml ]; then
+            cd pybullet-helpers
+            uv pip install -e ".[dexmate-vega]"
+            cd ..
+          fi
       - name: Pre-install IKFast modules
         run: |
           if [ -f pybullet-helpers/scripts/preinstall_ikfast.py ]; then

--- a/pybullet-helpers/README.md
+++ b/pybullet-helpers/README.md
@@ -31,6 +31,9 @@ IKFast is much better, but then you need to compile robot-specific IK models.
 This process needs to be automated further, but here is some guidance:
 1. Install Docker on an Ubuntu machine. (You will only need Ubuntu to compile once; IKFast should work cross-platform.)
 2. Follow the instructions on [pyikfast](https://github.com/cyberbotics/pyikfast).
+   - Prepare a stripped URDF that contains *only* the arm chain you want IK for, rooted at the IK base link, with all `<visual>` and `<collision>` blocks removed (collada_urdf inside the container will otherwise try to load mesh files that may not be present).
+   - For 7-DOF arms, the pyikfast default may pick the shoulder joint as the free joint, which usually fails to solve. Override by running the container with the entrypoint replaced by a script that passes `--freejoint=<wrist_joint_name>` to `openrave.py --database inversekinematics`. The panda convention is to free the last joint (e.g. `panda_joint7`).
+   - IKFast cannot generate closed-form 6D IK for arms without a spherical wrist (three intersecting axes) or three parallel axes — the symbolic engine fails to invert the resulting matrices regardless of free-joint choice. Many research humanoid arms fall in this category; see the Dexmate Vega section below for what we use instead.
 3. Save the `cpp` file that is generated. You won't need the other files.
 4. Make a new directory in this repository inside `third_party/ikfast`. Copy in the `cpp` file and rename it to match the existing examples (e.g., `ikfast_panda_arm.cpp`.)
 5. Modify the `cpp` file in two ways: (1) Add `#include "Python.h"` at the top; (2) add python bindings at the bottom (copy and change the robot name from an existing example like `ikfast_panda_arm.cpp`).
@@ -51,3 +54,21 @@ For consistency with Bullet IK, ensure that the inertial frame of the robot URDF
     <origin xyz="0 0 0" rpy="0 0 0"/>
 </joint>
 ```
+
+## Dexmate Vega 1U
+
+The Vega 1U humanoid arm doesn't have a spherical wrist (its last three joints have cm-scale offsets), so neither IKFast nor EAIK can produce a closed-form 6D solver for it directly. Instead, `DexmateVega1UPyBulletRobot.custom_inverse_kinematics` locks two joints (the elbow `L_arm_j4` and the wrist roll `L_arm_j7`), runs a 2D refinement search over those locked values, and uses EAIK's 5R closed-form solver as the inner loop. The 5R chain after locking matches EAIK's catalog of analytically-solvable structures, and Nelder-Mead on EAIK's least-squares pose residual reliably finds the 1D solvability manifold for arbitrary 6D targets. Typical roundtrip: ~130 ms, sub-µm position error.
+
+This path requires the optional `eaik` dependency:
+
+```
+# macOS:
+brew install eigen
+# Debian/Ubuntu:
+sudo apt install libeigen3-dev
+
+# Then, from the pybullet-helpers directory:
+uv pip install -e ".[dexmate-vega]"
+```
+
+`eaik` is published to PyPI as an sdist only — pip will compile it from C++ during install (~15 s), which requires a C++ toolchain and the Eigen3 headers. Without `eaik` installed, the Vega robot falls back to pybullet's iterative IK (lower quality) and emits a one-time `RuntimeWarning` pointing back to these instructions.

--- a/pybullet-helpers/pyproject.toml
+++ b/pybullet-helpers/pyproject.toml
@@ -63,5 +63,6 @@ module = [
     "pybullet.*",
     "pybullet_utils.*",
     "scipy.*",
+    "dexmate_urdf",
 ]
 ignore_missing_imports = true

--- a/pybullet-helpers/pyproject.toml
+++ b/pybullet-helpers/pyproject.toml
@@ -19,6 +19,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dexmate-vega = [
+    # EAIK enables analytic-quality IK for the Dexmate Vega left arm via
+    # 2D search over EAIK's 5R closed-form solver. The pip package ships
+    # only an sdist, so installing requires a C++ compiler and the Eigen3
+    # headers (macOS: `brew install eigen`; Debian/Ubuntu: `apt install
+    # libeigen3-dev`). Without it, the robot falls back to pybullet's IK.
+    "EAIK>=1.2.1",
+]
 develop = [
     "black",
     "docformatter",
@@ -64,5 +72,6 @@ module = [
     "pybullet_utils.*",
     "scipy.*",
     "dexmate_urdf",
+    "eaik.*",
 ]
 ignore_missing_imports = true

--- a/pybullet-helpers/pyproject.toml
+++ b/pybullet-helpers/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
    "gymnasium>=0.29.1",
    "scipy==1.14.0",
    "hello-robot-stretch-urdf",
+   "dexmate-urdf>=0.8.3",
    "prpl_utils>=0.0.1",
 ]
 

--- a/pybullet-helpers/src/pybullet_helpers/robots/__init__.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/__init__.py
@@ -3,6 +3,7 @@
 from typing import Type
 
 from pybullet_helpers.robots.assistive_human import AssistiveHumanPyBulletRobot
+from pybullet_helpers.robots.dexmate_vega import DexmateVega1UPyBulletRobot
 from pybullet_helpers.robots.fetch import FetchPyBulletRobot
 from pybullet_helpers.robots.human import (
     LeftArmHumanPyBulletRobot,
@@ -35,6 +36,7 @@ _BUILT_IN_ROBOT_CLASSES: list[Type[SingleArmPyBulletRobot]] = [
     RightLegHumanPyBulletRobot,
     LeftLegHumanPyBulletRobot,
     SpotPyBulletRobot,
+    DexmateVega1UPyBulletRobot,
 ]
 
 _BUILT_IN_MOBILE_ROBOT_CLASSES: list[Type[SingleArmPyBulletMobileManipulator]] = [

--- a/pybullet-helpers/src/pybullet_helpers/robots/_dexmate_vega_ik.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/_dexmate_vega_ik.py
@@ -115,7 +115,6 @@ def _best_for_lock(
 def solve_left_arm_ik(
     target_pose: np.ndarray,
     *,
-    seed: np.ndarray | None = None,
     n_grid: int = 20,
     n_refine_seeds: int = 5,
     tol: float = 1e-4,
@@ -123,7 +122,6 @@ def solve_left_arm_ik(
     """Return joint angles (length 7) reaching target_pose, or None if not found.
 
     target_pose: 4x4 homogeneous transform of L_arm_l7 in arm_center frame.
-    seed: ignored for the grid sweep; future versions may bias the grid here.
     """
     if not EAIK_AVAILABLE:
         return None

--- a/pybullet-helpers/src/pybullet_helpers/robots/_dexmate_vega_ik.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/_dexmate_vega_ik.py
@@ -1,0 +1,175 @@
+"""EAIK-based inverse kinematics for the Dexmate Vega left arm.
+
+Vega's wrist joints (L_arm_j5, L_arm_j6, L_arm_j7) are not spherical (their axes are
+several cm apart), so traditional closed-form 6R IK does not apply. With two joints (the
+elbow L_arm_j4 and the wrist roll L_arm_j7) locked, the residual 5R chain matches EAIK's
+catalog of analytically-solvable kinematic classes. To recover the full 7-DOF reach, we
+wrap a 2-D refinement search over the locked values around EAIK's 5R closed-form solver:
+starting from a coarse grid, we use Nelder-Mead to drive EAIK's least-squares pose
+residual to zero, landing on the 1-D solvability manifold.
+
+EAIK is an optional dependency; if it isn't importable, EAIK_AVAILABLE is False and
+callers should fall back to a different IK method.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.optimize import minimize
+
+try:
+    import eaik.pybindings.EAIK as _EAIK  # type: ignore[import-not-found]
+
+    EAIK_AVAILABLE = True
+except ImportError:
+    EAIK_AVAILABLE = False
+
+
+# Joint axes for the 7 left-arm joints, taken directly from the vega_1u URDF's
+# <axis xyz="..."> entries (all parent rpy values are zero, so URDF axes are
+# already expressed in EAIK's convention). Column i is the axis of joint i+1.
+_H = np.array(
+    [
+        [0, 1, 0],  # L_arm_j1
+        [0, 0, 1],  # L_arm_j2
+        [1, 0, 0],  # L_arm_j3
+        [0, 1, 0],  # L_arm_j4
+        [1, 0, 0],  # L_arm_j5
+        [0, 1, 0],  # L_arm_j6
+        [0, 0, 1],  # L_arm_j7
+    ],
+    dtype=np.float64,
+).T
+
+# Joint position offsets (column i is the translation from joint i's frame to
+# joint i+1's frame). Last column is the offset from joint 7 to the IK
+# end-effector frame, which we take to be L_arm_l7 itself (zero offset). Values
+# match the vega_1u URDF's <origin xyz="..."> entries on the left arm.
+_P = np.array(
+    [
+        [0.0, 0.16946, 0.0],  # arm_center -> L_arm_l1
+        [0.04, 0.06, 0.0454],
+        [0.1644, 0.0, -0.043],
+        [0.113, 0.0433, 0.06],
+        [0.1938, -0.0434, -0.04],
+        [0.0762, 0.0319, 0.0],
+        [0.065, -0.032, 0.0319],  # L_arm_l6 -> L_arm_l7
+        [0.0, 0.0, 0.0],  # L_arm_l7 -> EE (identity)
+    ],
+    dtype=np.float64,
+).T
+
+_R6T = np.eye(3)
+
+# Indices into the 7-vector q for the two joints we lock during the EAIK call.
+# L_arm_j4 is the elbow; L_arm_j7 is the final wrist roll. Locking both yields
+# a 5R chain whose structure EAIK identifies as
+# "5R-FOURTH_FITH_INTERSECTING_SECOND_THIRD_INTERSECTING", which is in its
+# catalog of closed-form-solvable classes.
+_LOCK_A = 3
+_LOCK_B = 6
+
+# Joint limits from the URDF, used to clamp the grid and to reject IK
+# candidates that leave the legal range.
+_LOWER = np.array([-3.071, -0.453, -3.071, -3.071, -3.071, -1.396, -1.378])
+_UPPER = np.array([3.071, 1.553, 3.071, 0.244, 3.071, 1.396, 1.117])
+
+
+def _best_for_lock(
+    qa: float, qb: float, target_pose: np.ndarray
+) -> tuple[np.ndarray | None, float]:
+    """Run EAIK with (L_arm_j4=qa, L_arm_j7=qb) locked and return the best solution's
+    joint vector and its pose residual to the target."""
+    robot = _EAIK.Robot(
+        _H, _P, _R6T, [(_LOCK_A, float(qa)), (_LOCK_B, float(qb))], True
+    )
+    sol = robot.calculate_IK(target_pose)
+    candidates = np.asarray(sol.Q)
+    if candidates.size == 0:
+        return None, np.inf
+    if candidates.ndim == 1:
+        candidates = candidates[None, :]
+
+    unlock_mask = np.ones(7, dtype=bool)
+    unlock_mask[_LOCK_A] = False
+    unlock_mask[_LOCK_B] = False
+
+    best_q: np.ndarray | None = None
+    best_res = np.inf
+    for q in candidates:
+        if np.any(q[unlock_mask] < _LOWER[unlock_mask] - 1e-6):
+            continue
+        if np.any(q[unlock_mask] > _UPPER[unlock_mask] + 1e-6):
+            continue
+        pose = robot.fwdkin(q)
+        pos_err = float(np.linalg.norm(pose[:3, 3] - target_pose[:3, 3]))
+        rot_diff = pose[:3, :3].T @ target_pose[:3, :3]
+        rot_err = float(np.arccos(np.clip((np.trace(rot_diff) - 1.0) / 2.0, -1.0, 1.0)))
+        res = pos_err + rot_err
+        if res < best_res:
+            best_res = res
+            best_q = np.asarray(q, dtype=float)
+    return best_q, best_res
+
+
+def solve_left_arm_ik(
+    target_pose: np.ndarray,
+    *,
+    seed: np.ndarray | None = None,
+    n_grid: int = 20,
+    n_refine_seeds: int = 5,
+    tol: float = 1e-4,
+) -> np.ndarray | None:
+    """Return joint angles (length 7) reaching target_pose, or None if not found.
+
+    target_pose: 4x4 homogeneous transform of L_arm_l7 in arm_center frame.
+    seed: ignored for the grid sweep; future versions may bias the grid here.
+    """
+    if not EAIK_AVAILABLE:
+        return None
+
+    target_pose = np.asarray(target_pose, dtype=float)
+
+    # Coarse sweep over (q_elbow, q_wrist_roll). Stay just inside the limits so
+    # we don't waste samples on infeasible boundaries.
+    a_grid = np.linspace(_LOWER[_LOCK_A] + 0.05, _UPPER[_LOCK_A] - 0.05, n_grid)
+    b_grid = np.linspace(_LOWER[_LOCK_B] + 0.05, _UPPER[_LOCK_B] - 0.05, n_grid)
+    grid_results: list[tuple[float, float, float, np.ndarray | None]] = []
+    for qa in a_grid:
+        for qb in b_grid:
+            q, res = _best_for_lock(qa, qb, target_pose)
+            grid_results.append((res, float(qa), float(qb), q))
+    grid_results.sort(key=lambda item: item[0])
+
+    best_res, _, _, best_q = grid_results[0]
+    if best_res < tol:
+        return best_q
+
+    # Local refinement on EAIK's LS residual. The residual is smooth in
+    # (qa, qb) and zero on the 1-D solvability manifold; multi-starting from
+    # the best grid seeds raises the success rate substantially over a single
+    # start.
+    bounds = [(_LOWER[_LOCK_A], _UPPER[_LOCK_A]), (_LOWER[_LOCK_B], _UPPER[_LOCK_B])]
+
+    def objective(x: np.ndarray) -> float:
+        _, residual = _best_for_lock(x[0], x[1], target_pose)
+        return residual
+
+    for _, qa_seed, qb_seed, _ in grid_results[:n_refine_seeds]:
+        opt = minimize(
+            objective,
+            x0=[qa_seed, qb_seed],
+            method="Nelder-Mead",
+            bounds=bounds,
+            options={"xatol": 1e-5, "fatol": 1e-6, "maxiter": 200},
+        )
+        candidate_q, candidate_res = _best_for_lock(opt.x[0], opt.x[1], target_pose)
+        if candidate_res < best_res:
+            best_res = candidate_res
+            best_q = candidate_q
+            if best_res < tol:
+                return best_q
+
+    if best_q is not None and best_res < tol:
+        return best_q
+    return None

--- a/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
@@ -1,20 +1,53 @@
 """Dexmate Vega humanoid robots."""
 
 import re
+import warnings
+from functools import cached_property
 from pathlib import Path
 
+import numpy as np
 from dexmate_urdf import get_robot_path
 
+from pybullet_helpers.geometry import Pose, multiply_poses
 from pybullet_helpers.joint import JointPositions
+from pybullet_helpers.link import get_link_pose, get_relative_link_pose
+from pybullet_helpers.robots import _dexmate_vega_ik as _vega_ik
 from pybullet_helpers.robots.single_arm import SingleArmPyBulletRobot
+
+_EAIK_FALLBACK_WARNED = False
+
+_EAIK_INSTALL_HINT = (
+    "EAIK is not installed; falling back to pybullet's iterative IK, which is "
+    "slower and less accurate for the Vega arm. To enable analytic-quality IK, "
+    "install the [dexmate-vega] extra (requires Eigen3 headers: `brew install "
+    "eigen` on macOS or `apt install libeigen3-dev` on Debian/Ubuntu)."
+)
+
+_LEFT_ARM_JOINT_NAMES = [
+    "L_arm_j1",
+    "L_arm_j2",
+    "L_arm_j3",
+    "L_arm_j4",
+    "L_arm_j5",
+    "L_arm_j6",
+    "L_arm_j7",
+]
 
 
 class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
     """Dexmate Vega 1U humanoid; the left arm is exposed as the actuated arm.
 
-    The kinematic chain from base to the left end-effector includes the prismatic
-    Lift, the torso_flip revolute joint, and the seven left arm joints
-    L_arm_j1..L_arm_j7.
+    Only the 7 left-arm joints (L_arm_j1..L_arm_j7) are part of arm_joints —
+    the prismatic Lift and the torso_flip revolute joint are not actuated by
+    this wrapper; they remain at whatever position pybullet's URDF load left
+    them in (zero by default). This matches the standard humanoid pattern of
+    treating the torso as a fixed offset for arm IK.
+
+    When the optional `eaik` package is installed, custom_inverse_kinematics
+    runs a 2D-search-with-refinement on top of EAIK's 5R closed-form solver,
+    locking L_arm_j4 (elbow) and L_arm_j7 (wrist roll) per inner call. See
+    _dexmate_vega_ik.py for details. Otherwise the framework's pybullet IK is
+    used.
     """
 
     @classmethod
@@ -59,10 +92,17 @@ class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
         new_path.write_text(urdf_str, encoding="utf-8")
         return new_path
 
+    @cached_property
+    def arm_joints(self) -> list[int]:
+        # Expose only the 7 left-arm joints; Lift and torso_flip are excluded.
+        # This matches the kinematic chain EAIK solves for, and is the standard
+        # humanoid pattern where torso/base motions are planned separately from
+        # arm motions.
+        return [self.joint_from_name(n) for n in _LEFT_ARM_JOINT_NAMES]
+
     @property
     def default_home_joint_positions(self) -> JointPositions:
-        # Lift, torso_flip, L_arm_j1..L_arm_j7 — all zeros are within limits.
-        return [0.0] * 9
+        return [0.0] * 7
 
     @property
     def end_effector_name(self) -> str:
@@ -71,3 +111,60 @@ class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
     @property
     def tool_link_name(self) -> str:
         return "L_ee"
+
+    @property
+    def default_inverse_kinematics_method(self) -> str:
+        if _vega_ik.EAIK_AVAILABLE:
+            return "custom"
+        global _EAIK_FALLBACK_WARNED  # pylint: disable=global-statement
+        if not _EAIK_FALLBACK_WARNED:
+            warnings.warn(_EAIK_INSTALL_HINT, RuntimeWarning, stacklevel=2)
+            _EAIK_FALLBACK_WARNED = True
+        return "pybullet"
+
+    @cached_property
+    def _arm_center_link_id(self) -> int:
+        return self.link_from_name("arm_center")
+
+    @cached_property
+    def _l_arm_l7_link_id(self) -> int:
+        return self.link_from_name("L_arm_l7")
+
+    @cached_property
+    def _l_ee_in_l_arm_l7(self) -> Pose:
+        # Fixed transform from L_arm_l7 to L_ee (computed once via pybullet).
+        return get_relative_link_pose(
+            self.robot_id,
+            self.tool_link_id,
+            self._l_arm_l7_link_id,
+            self.physics_client_id,
+        )
+
+    def custom_inverse_kinematics(
+        self,
+        end_effector_pose: Pose,
+        validate: bool = True,
+        best_effort: bool = False,
+        validation_atol: float = 1e-3,
+    ) -> JointPositions | None:
+        if not _vega_ik.EAIK_AVAILABLE:
+            return None
+
+        # Convert the world-frame L_ee target into a L_arm_l7 target expressed
+        # in arm_center's frame, which is what the EAIK solver expects.
+        world_from_arm_center = get_link_pose(
+            self.robot_id, self._arm_center_link_id, self.physics_client_id
+        )
+        target_in_arm_center = multiply_poses(
+            world_from_arm_center.invert(),
+            end_effector_pose,
+            self._l_ee_in_l_arm_l7.invert(),
+        )
+
+        q = _vega_ik.solve_left_arm_ik(
+            target_in_arm_center.to_matrix(),
+            seed=np.asarray(self.get_joint_positions()),
+        )
+        if q is None:
+            return None
+        return [float(v) for v in q]

--- a/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
@@ -5,7 +5,6 @@ import warnings
 from functools import cached_property
 from pathlib import Path
 
-import numpy as np
 from dexmate_urdf import get_robot_path
 
 from pybullet_helpers.geometry import Pose, multiply_poses
@@ -161,10 +160,7 @@ class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
             self._l_ee_in_l_arm_l7.invert(),
         )
 
-        q = _vega_ik.solve_left_arm_ik(
-            target_in_arm_center.to_matrix(),
-            seed=np.asarray(self.get_joint_positions()),
-        )
+        q = _vega_ik.solve_left_arm_ik(target_in_arm_center.to_matrix())
         if q is None:
             return None
         return [float(v) for v in q]

--- a/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
@@ -1,0 +1,73 @@
+"""Dexmate Vega humanoid robots."""
+
+import re
+from pathlib import Path
+
+from dexmate_urdf import get_robot_path
+
+from pybullet_helpers.joint import JointPositions
+from pybullet_helpers.robots.single_arm import SingleArmPyBulletRobot
+
+
+class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
+    """Dexmate Vega 1U humanoid; the left arm is exposed as the actuated arm.
+
+    The kinematic chain from base to the left end-effector includes the prismatic
+    Lift, the torso_flip revolute joint, and the seven left arm joints
+    L_arm_j1..L_arm_j7.
+    """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dexmate-vega-1u"
+
+    @property
+    def default_urdf_path(self) -> Path:
+        # PyBullet can't load the .glb meshes shipped with dexmate-urdf, so we
+        # rewrite the URDF to point at the .obj collision meshes from vega_1
+        # (which exist for the head and arm links) and strip the visual/collision
+        # blocks for base/lift/torso_flip (which have no .obj alternative).
+        robot_dir = get_robot_path("humanoid", "vega_1u")
+        original_path = robot_dir / "vega_1u.urdf"
+        urdf_str = original_path.read_text(encoding="utf-8")
+        urdf_str = re.sub(
+            r'\.\./vega_1/meshes/visual/([^"]+)\.glb',
+            r"../vega_1/meshes/collision/\1.obj",
+            urdf_str,
+        )
+        urdf_str = re.sub(
+            r"\s*<(visual|collision)>\s*<origin[^/]*/>\s*<geometry>\s*"
+            r'<mesh filename="meshes/visual/[^"]+\.glb"\s*/>\s*'
+            r"</geometry>\s*</\1>",
+            "",
+            urdf_str,
+        )
+        # The collision OBJs have no MTL, so without a URDF material PyBullet
+        # renders them pure black. Inject a neutral gray into every <visual>.
+        material_xml = (
+            '<material name="dexmate_vega_default">'
+            '<color rgba="0.75 0.75 0.78 1.0"/>'
+            "</material>"
+        )
+        urdf_str = re.sub(
+            r"(</geometry>)(\s*</visual>)",
+            r"\1" + material_xml + r"\2",
+            urdf_str,
+        )
+        # Write next to the original so the relative mesh paths still resolve.
+        new_path = original_path.parent / "vega_1u-PYBULLET-HELPERS.urdf"
+        new_path.write_text(urdf_str, encoding="utf-8")
+        return new_path
+
+    @property
+    def default_home_joint_positions(self) -> JointPositions:
+        # Lift, torso_flip, L_arm_j1..L_arm_j7 — all zeros are within limits.
+        return [0.0] * 9
+
+    @property
+    def end_effector_name(self) -> str:
+        return "L_ee_j0"
+
+    @property
+    def tool_link_name(self) -> str:
+        return "L_ee"

--- a/pybullet-helpers/tests/robots/test_dexmate_vega.py
+++ b/pybullet-helpers/tests/robots/test_dexmate_vega.py
@@ -1,0 +1,30 @@
+"""Tests for the Dexmate Vega robot."""
+
+import numpy as np
+
+from pybullet_helpers.robots.dexmate_vega import DexmateVega1UPyBulletRobot
+
+
+def test_dexmate_vega_1u_robot(physics_client_id):
+    """Tests for DexmateVega1UPyBulletRobot."""
+    robot = DexmateVega1UPyBulletRobot(physics_client_id)
+    assert robot.get_name() == "dexmate-vega-1u"
+    assert robot.arm_joint_names == [
+        "Lift",
+        "torso_flip",
+        "L_arm_j1",
+        "L_arm_j2",
+        "L_arm_j3",
+        "L_arm_j4",
+        "L_arm_j5",
+        "L_arm_j6",
+        "L_arm_j7",
+    ]
+    assert np.allclose(robot.action_space.low, robot.joint_lower_limits)
+    assert np.allclose(robot.action_space.high, robot.joint_upper_limits)
+    # Moving each joint to its midpoint produces an EE pose within reach
+    # (forward_kinematics doesn't raise).
+    for i in range(len(robot.arm_joints)):
+        q = list(robot.home_joint_positions)
+        q[i] = 0.5 * (robot.joint_lower_limits[i] + robot.joint_upper_limits[i])
+        robot.forward_kinematics(q)

--- a/pybullet-helpers/tests/robots/test_dexmate_vega.py
+++ b/pybullet-helpers/tests/robots/test_dexmate_vega.py
@@ -1,8 +1,20 @@
 """Tests for the Dexmate Vega robot."""
 
-import numpy as np
+import importlib.util
+import warnings
 
+import numpy as np
+import pytest
+
+from pybullet_helpers.inverse_kinematics import (
+    InverseKinematicsError,
+    inverse_kinematics,
+)
+from pybullet_helpers.robots import _dexmate_vega_ik as _vega_ik
+from pybullet_helpers.robots import dexmate_vega
 from pybullet_helpers.robots.dexmate_vega import DexmateVega1UPyBulletRobot
+
+EAIK_INSTALLED = importlib.util.find_spec("eaik") is not None
 
 
 def test_dexmate_vega_1u_robot(physics_client_id):
@@ -10,8 +22,6 @@ def test_dexmate_vega_1u_robot(physics_client_id):
     robot = DexmateVega1UPyBulletRobot(physics_client_id)
     assert robot.get_name() == "dexmate-vega-1u"
     assert robot.arm_joint_names == [
-        "Lift",
-        "torso_flip",
         "L_arm_j1",
         "L_arm_j2",
         "L_arm_j3",
@@ -28,3 +38,50 @@ def test_dexmate_vega_1u_robot(physics_client_id):
         q = list(robot.home_joint_positions)
         q[i] = 0.5 * (robot.joint_lower_limits[i] + robot.joint_upper_limits[i])
         robot.forward_kinematics(q)
+
+
+@pytest.mark.skipif(not EAIK_INSTALLED, reason="EAIK not installed")
+def test_dexmate_vega_1u_ik_roundtrip(physics_client_id):
+    """IK roundtrip: random q -> FK -> custom IK -> FK -> matches."""
+    robot = DexmateVega1UPyBulletRobot(physics_client_id)
+    assert robot.default_inverse_kinematics_method == "custom"
+
+    rng = np.random.default_rng(7)
+    lo = np.array(robot.joint_lower_limits)
+    hi = np.array(robot.joint_upper_limits)
+    n_trials = 5
+    n_success = 0
+    for _ in range(n_trials):
+        q_true = rng.uniform(lo, hi)
+        target = robot.forward_kinematics(q_true.tolist())
+        try:
+            q_sol = inverse_kinematics(
+                robot, target, validate=True, validation_atol=1e-3
+            )
+        except InverseKinematicsError:
+            continue
+        recovered = robot.forward_kinematics(q_sol)
+        pos_err = np.linalg.norm(
+            np.array(recovered.position) - np.array(target.position)
+        )
+        if pos_err < 1e-3:
+            n_success += 1
+    # Allow one failure to absorb the rare Nelder-Mead local-min case.
+    assert (
+        n_success >= n_trials - 1
+    ), f"only {n_success}/{n_trials} IK roundtrips succeeded"
+
+
+def test_dexmate_vega_1u_eaik_fallback_warning(physics_client_id, monkeypatch):
+    """If EAIK is unavailable, the robot falls back to pybullet IK and emits a one-time
+    RuntimeWarning explaining how to install EAIK."""
+    monkeypatch.setattr(_vega_ik, "EAIK_AVAILABLE", False)
+    monkeypatch.setattr(dexmate_vega, "_EAIK_FALLBACK_WARNED", False)
+    robot = DexmateVega1UPyBulletRobot(physics_client_id)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert robot.default_inverse_kinematics_method == "pybullet"
+        assert robot.default_inverse_kinematics_method == "pybullet"  # second call
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert len(runtime_warnings) == 1
+    assert "EAIK" in str(runtime_warnings[0].message)


### PR DESCRIPTION
https://github.com/user-attachments/assets/c1f31059-ed31-4f27-9145-7c372d2432e1

## Summary

Adds analytic-quality inverse kinematics for the Dexmate Vega 1U left arm using a hybrid approach: 2D refinement search wrapped around [EAIK's](https://pypi.org/project/EAIK/) 5R closed-form solver.

### Why a hybrid

Vega's wrist joints (`L_arm_j5`, `L_arm_j6`, `L_arm_j7`) have cm-scale axis offsets — i.e., not a spherical wrist. That means **closed-form 6R IK is structurally impossible** with either IKFast or stock EAIK:

- **IKFast**: I ran pyikfast against the left arm with every choice of free joint (`L_arm_j1`..`L_arm_j7`). Each run failed in OpenRAVE's general `LiWoernleHiller` solver after 10–30 min of symbolic algebra (`CannotSolveError: failed to invert matrix` / `inverse matrix is always singular` / `raghavan roth equations might be too complex`). The polynomial elimination genuinely doesn't terminate for this geometry.
- **EAIK** (single-joint lock): reports `6R-Unknown Kinematic Class` and `has_known_decomposition=False` for every choice. The residual 6R structure (two non-adjacent intersection pairs at `j2∩j3` and `j5∩j6`) isn't in IK-Geo's catalog of closed-form-solvable cases.
- **EAIK** (two-joint lock): with `L_arm_j4` (elbow) and `L_arm_j7` (wrist roll) both locked, the residual 5R chain matches `5R-FOURTH_FITH_INTERSECTING_SECOND_THIRD_INTERSECTING` and EAIK returns exact IK at machine precision. **But** the workspace constraint of fixed (q4, q7) only reaches a 1D submanifold of 6D poses.

To recover full 6D reach, we wrap a 2D search over (q4, q7) around EAIK's 5R solver: starting from a coarse grid, Nelder-Mead drives EAIK's least-squares pose residual to zero, landing on the solvability manifold. Typical roundtrip: **~130 ms, sub-µm position error.** This is essentially what `IK_gen_7_dof.m` in the stereo-sew MATLAB code does, ported to Python.

### Changes

- `_dexmate_vega_ik.py`: standalone IK helper with hardcoded kinematic params for the left arm, EAIK 5R inner solver, and the 2D grid + multi-start Nelder-Mead refinement.
- `dexmate_vega.py`:
  - `arm_joints` trimmed to the 7 `L_arm_jN` joints. Lift and torso_flip are excluded (standard humanoid pattern of planning torso and arm separately).
  - `default_home_joint_positions` now 7 zeros.
  - `default_inverse_kinematics_method` returns `"custom"` when EAIK is importable, `"pybullet"` otherwise; the fallback path emits a one-time `RuntimeWarning` with install instructions so users don't silently get degraded IK.
  - `custom_inverse_kinematics` transforms the world-frame `L_ee` target into an `L_arm_l7` target in `arm_center` frame and dispatches to the helper.
- `test_dexmate_vega.py`: updated expected joint names; added IK roundtrip test (skipped when EAIK isn't installed); added fallback-warning test.
- `pyproject.toml`: new `[dexmate-vega]` optional extra adds `EAIK>=1.2.1`; mypy ignores its missing stubs.
- `README.md`: new Dexmate Vega section explaining the hybrid approach and per-platform install steps.
- `ci.yml`: `unit-tests` job now installs `libeigen3-dev` and the `[dexmate-vega]` extra so the IK roundtrip runs in CI rather than being skipped.

### Follow-up (not in this PR)

EAIK currently ships only an sdist on PyPI, so every install compiles from source and needs Eigen3 headers in the right place. Tracking a future cibuildwheel contribution upstream (filed [an issue](https://github.com/OstermD/EAIK) asking about their roadmap). Once upstream wheels exist we can drop the `libeigen3-dev` step from CI.

## Test plan

- [x] `./run_ci_checks.sh` passes locally (76 tests, +2 over previous PR).
- [x] New `test_dexmate_vega_1u_ik_roundtrip` exercises the EAIK custom IK end-to-end through the framework (5/5 roundtrips succeed at sub-µm precision; allows 1 failure to absorb the rare Nelder-Mead local-min).
- [x] New `test_dexmate_vega_1u_eaik_fallback_warning` verifies the fallback path: when EAIK isn't available, `default_inverse_kinematics_method == "pybullet"` and a single `RuntimeWarning` is emitted on first call.
- [ ] CI unit-tests job verifies `libeigen3-dev` + the `[dexmate-vega]` extra install cleanly on Ubuntu and the IK test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
