### PR TITLE
add robot_id binding to SingleArmPyBulletRobot

### DIFF
--- a/pybullet-helpers/src/pybullet_helpers/robots/single_arm.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/single_arm.py
@@ -37,6 +37,7 @@ class SingleArmPyBulletRobot(abc.ABC):
         home_joint_positions: JointPositions | None = None,
         fixed_base: bool = True,
         custom_urdf_path: Path | None = None,
+        robot_id: int | None = None,
     ) -> None:
         self.physics_client_id = physics_client_id
 
@@ -57,22 +58,31 @@ class SingleArmPyBulletRobot(abc.ABC):
             home_joint_positions or self.default_home_joint_positions
         )
 
-        # Load the robot and set base position and orientation.
-        flags = p.URDF_USE_INERTIA_FROM_FILE
-        if self.self_collision_link_names:
-            flags |= p.URDF_USE_SELF_COLLISION
-            flags |= p.URDF_USE_SELF_COLLISION_EXCLUDE_ALL_PARENTS
-        self.robot_id = p.loadURDF(
-            str(self.urdf_path),
-            basePosition=self._base_pose.position,
-            baseOrientation=self._base_pose.orientation,
-            # Even if the robot has a mobile base, we treat it as static in
-            # pybullet for now and just update the position directly. Otherwise
-            # physics starts to affect the robot base.
-            useFixedBase=True,
-            physicsClientId=self.physics_client_id,
-            flags=flags,
-        )
+        # When robot_id is given, this instance binds to an existing PyBullet
+        # body rather than loading its own URDF. This is used to expose one arm
+        # of a multi-arm robot (e.g. a bimanual robot) as a SingleArmPyBulletRobot
+        # over a shared body. The owner of the body is responsible for loading it
+        # (including any self-collision flags) and for setting the initial pose.
+        self._bound_to_existing_body = robot_id is not None
+        if robot_id is not None:
+            self.robot_id = robot_id
+        else:
+            # Load the robot and set base position and orientation.
+            flags = p.URDF_USE_INERTIA_FROM_FILE
+            if self.self_collision_link_names:
+                flags |= p.URDF_USE_SELF_COLLISION
+                flags |= p.URDF_USE_SELF_COLLISION_EXCLUDE_ALL_PARENTS
+            self.robot_id = p.loadURDF(
+                str(self.urdf_path),
+                basePosition=self._base_pose.position,
+                baseOrientation=self._base_pose.orientation,
+                # Even if the robot has a mobile base, we treat it as static in
+                # pybullet for now and just update the position directly. Otherwise
+                # physics starts to affect the robot base.
+                useFixedBase=True,
+                physicsClientId=self.physics_client_id,
+                flags=flags,
+            )
 
         # Make sure the home joint positions are within limits.
         assert len(self._home_joint_positions) == len(self.joint_lower_limits)
@@ -80,11 +90,17 @@ class SingleArmPyBulletRobot(abc.ABC):
             self._home_joint_positions
         ), "Home joint positions are out of the limit range"
 
-        # Robot initially at home pose.
-        self.set_joints(self.home_joint_positions)
+        # Robot initially at home pose. When bound to an existing body, the owner
+        # controls the initial posture, so we leave the joints as loaded.
+        if not self._bound_to_existing_body:
+            self.set_joints(self.home_joint_positions)
 
         # Give a one-time warning about using IKFast with custom URDFs.
-        if custom_urdf_path is not None and self.ikfast_info() is not None:
+        if (
+            not self._bound_to_existing_body
+            and custom_urdf_path is not None
+            and self.ikfast_info() is not None
+        ):
             print(
                 "WARNING: running IKFast with a custom URDF file may not work "
                 "if the URDF is importantly different from what was used to "

--- a/pybullet-helpers/tests/robots/test_panda.py
+++ b/pybullet-helpers/tests/robots/test_panda.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import numpy as np
+import pybullet as p
 import pytest
 
 from pybullet_helpers.geometry import Pose
@@ -131,3 +132,36 @@ def test_panda_pybullet_robot_inverse_kinematics(panda):
     joint_positions = inverse_kinematics(panda, end_effector_pose=pose, validate=True)
     recovered_pose = panda.forward_kinematics(joint_positions)
     assert np.allclose(recovered_pose.position, pose.position)
+
+
+def test_single_arm_robot_bind_to_existing_body(physics_client_id):
+    """A SingleArmPyBulletRobot can bind to an already-loaded body via robot_id instead
+    of loading its own URDF.
+
+    This is the mechanism that lets a multi-arm robot expose each arm as a
+    SingleArmPyBulletRobot over a single shared PyBullet body.
+    """
+    panda = PandaPyBulletRobot(physics_client_id, control_mode="reset")
+    num_bodies_before = p.getNumBodies(physics_client_id)
+
+    # Put the shared body into a non-home configuration so we can confirm the
+    # bound instance does not reset it during construction.
+    config = list(panda.home_joint_positions)
+    config[0] += 0.3
+    panda.set_joints(config)
+
+    bound = PandaPyBulletRobot(
+        physics_client_id, control_mode="reset", robot_id=panda.robot_id
+    )
+
+    # Binding must not load a new body.
+    assert p.getNumBodies(physics_client_id) == num_bodies_before
+    assert bound.robot_id == panda.robot_id
+    assert bound.arm_joints == panda.arm_joints
+    # The bound instance left the (non-home) configuration untouched.
+    assert np.allclose(bound.get_joint_positions(), config)
+    # Forward kinematics through the bound instance matches the original.
+    assert np.allclose(
+        bound.get_end_effector_pose().position,
+        panda.get_end_effector_pose().position,
+    )


### PR DESCRIPTION
## Summary

Adds an optional `robot_id` parameter to `SingleArmPyBulletRobot.__init__` that lets an instance **bind to an already-loaded PyBullet body** instead of loading its own URDF.

This is foundational infrastructure for the upcoming bimanual Dexmate Vega robot: a multi-arm robot will load a single shared body once, then expose each arm as a `SingleArmPyBulletRobot` (with its own `arm_joints` / end effector) over that shared `robot_id`. Exposing arms this way lets existing consumers — `inverse_kinematics(robot.left_arm, ...)`, `run_motion_planning(robot.left_arm, ...)` — work unchanged.

## Behavior

When `robot_id` is provided:
- skips `p.loadURDF` (and the self-collision flag computation, which is a body-level decision owned by whoever loads the body);
- skips applying `base_pose` and skips the initial `set_joints(home)` reset — the owner of the shared body controls the initial posture;
- skips the IKFast-with-custom-URDF warning.

The home-limits assertion is preserved: it validates each view's home against its own `joint_lower_limits` (derived from its `arm_joints`).

Default behavior (`robot_id=None`) is unchanged.

## Test plan

- [x] `./run_ci_checks.sh` passes locally (77 tests; +1).
- [x] New `test_single_arm_robot_bind_to_existing_body`: binds a second Panda to an existing body and asserts no new body is loaded, `robot_id`/`arm_joints` match, the bound instance leaves a pre-set non-home configuration untouched, and FK agrees with the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
