### PR TITLE
add parallel-jaw gripper and cube-pick test to single-arm Dexmate Vega

### DIFF
--- a/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
+++ b/pybullet-helpers/src/pybullet_helpers/robots/dexmate_vega.py
@@ -1,7 +1,7 @@
 """Dexmate Vega humanoid robots."""
 
-import re
 import warnings
+import xml.etree.ElementTree as ET
 from functools import cached_property
 from pathlib import Path
 
@@ -11,7 +11,7 @@ from pybullet_helpers.geometry import Pose, multiply_poses
 from pybullet_helpers.joint import JointPositions
 from pybullet_helpers.link import get_link_pose, get_relative_link_pose
 from pybullet_helpers.robots import _dexmate_vega_ik as _vega_ik
-from pybullet_helpers.robots.single_arm import SingleArmPyBulletRobot
+from pybullet_helpers.robots.single_arm import FingeredSingleArmPyBulletRobot
 
 _EAIK_FALLBACK_WARNED = False
 
@@ -32,21 +32,78 @@ _LEFT_ARM_JOINT_NAMES = [
     "L_arm_j7",
 ]
 
+# The parallel-jaw gripper has two revolute jaw joints; the URDF mimics j2 off j1,
+# but PyBullet does not enforce <mimic>, so we drive both to the same value.
+_LEFT_GRIPPER_JOINT_NAMES = ["L_gripper_j1", "L_gripper_j2"]
+_GRIPPER_OPEN = 0.0
+_GRIPPER_CLOSED = 0.7854
 
-class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
-    """Dexmate Vega 1U humanoid; the left arm is exposed as the actuated arm.
+_PYBULLET_MATERIAL_NAME = "dexmate_vega_default"
 
-    Only the 7 left-arm joints (L_arm_j1..L_arm_j7) are part of arm_joints —
-    the prismatic Lift and the torso_flip revolute joint are not actuated by
-    this wrapper; they remain at whatever position pybullet's URDF load left
-    them in (zero by default). This matches the standard humanoid pattern of
-    treating the torso as a fixed offset for arm IK.
 
-    When the optional `eaik` package is installed, custom_inverse_kinematics
-    runs a 2D-search-with-refinement on top of EAIK's 5R closed-form solver,
-    locking L_arm_j4 (elbow) and L_arm_j7 (wrist roll) per inner call. See
-    _dexmate_vega_ik.py for details. Otherwise the framework's pybullet IK is
-    used.
+def prepare_pybullet_urdf(
+    robot_dir: Path,
+    urdf_filename: str,
+    mesh_substitutions: dict[str, str] | None = None,
+) -> Path:
+    """Rewrite a dexmate URDF so PyBullet can load it, returning the new path.
+
+    PyBullet cannot read the .glb visual meshes shipped with dexmate-urdf. For each
+    visual/collision mesh that references a .glb, we rewrite it to the sibling collision
+    .obj when one exists on disk, and otherwise drop that visual/collision element (some
+    base/lift/torso/connector links ship only a .glb). A neutral gray material is
+    injected into every remaining visual because the collision OBJs have no MTL and
+    would otherwise render pure black. The output is written next to the original so the
+    relative mesh paths still resolve.
+
+    mesh_substitutions maps substrings to replacements applied to every mesh filename
+    (e.g. swapping one gripper's meshes for another's).
+    """
+    mesh_substitutions = mesh_substitutions or {}
+    original_path = robot_dir / urdf_filename
+    tree = ET.parse(original_path)
+    root = tree.getroot()
+    for link in root.findall("link"):
+        for tag in ("visual", "collision"):
+            for element in list(link.findall(tag)):
+                mesh = element.find("geometry/mesh")
+                if mesh is None:
+                    continue
+                filename = mesh.get("filename", "")
+                for old, new in mesh_substitutions.items():
+                    filename = filename.replace(old, new)
+                if not filename.endswith(".glb"):
+                    mesh.set("filename", filename)
+                    continue
+                obj_rel = filename.replace("/visual/", "/collision/")[:-4] + ".obj"
+                if not (robot_dir / obj_rel).resolve().exists():
+                    link.remove(element)
+                    continue
+                mesh.set("filename", obj_rel)
+                if tag == "visual" and element.find("material") is None:
+                    material = ET.SubElement(element, "material")
+                    material.set("name", _PYBULLET_MATERIAL_NAME)
+                    color = ET.SubElement(material, "color")
+                    color.set("rgba", "0.75 0.75 0.78 1.0")
+    new_path = original_path.parent / (original_path.stem + "-PYBULLET-HELPERS.urdf")
+    tree.write(new_path, encoding="unicode")
+    return new_path
+
+
+class DexmateVega1UPyBulletRobot(FingeredSingleArmPyBulletRobot[float]):
+    """Dexmate Vega 1U humanoid; the left arm with its parallel-jaw gripper is exposed
+    as the actuated arm.
+
+    arm_joints are the 7 left-arm joints (L_arm_j1..L_arm_j7) plus the 2 gripper jaw
+    joints. The prismatic Lift and the torso_flip revolute joint are not actuated by
+    this wrapper; they remain at whatever position pybullet's URDF load left them in
+    (zero by default). This matches the standard humanoid pattern of treating the torso
+    as a fixed offset for arm IK.
+
+    When the optional `eaik` package is installed, custom_inverse_kinematics runs a
+    2D-search-with-refinement on top of EAIK's 5R closed-form solver, locking L_arm_j4
+    (elbow) and L_arm_j7 (wrist roll) per inner call. See _dexmate_vega_ik.py for
+    details. Otherwise the framework's pybullet IK is used.
     """
 
     @classmethod
@@ -55,53 +112,28 @@ class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
 
     @property
     def default_urdf_path(self) -> Path:
-        # PyBullet can't load the .glb meshes shipped with dexmate-urdf, so we
-        # rewrite the URDF to point at the .obj collision meshes from vega_1
-        # (which exist for the head and arm links) and strip the visual/collision
-        # blocks for base/lift/torso_flip (which have no .obj alternative).
-        robot_dir = get_robot_path("humanoid", "vega_1u")
-        original_path = robot_dir / "vega_1u.urdf"
-        urdf_str = original_path.read_text(encoding="utf-8")
-        urdf_str = re.sub(
-            r'\.\./vega_1/meshes/visual/([^"]+)\.glb',
-            r"../vega_1/meshes/collision/\1.obj",
-            urdf_str,
+        # vega_1u_gripper.urdf ships with the DexGripper D (forked fingertips). The
+        # DexGripper S is kinematically identical (same mount, joints, and limits) and
+        # differs only in its meshes, so we swap the mesh paths to use it.
+        return prepare_pybullet_urdf(
+            get_robot_path("humanoid", "vega_1u"),
+            "vega_1u_gripper.urdf",
+            mesh_substitutions={"hands/dexd_gripper/": "hands/dexs_gripper/"},
         )
-        urdf_str = re.sub(
-            r"\s*<(visual|collision)>\s*<origin[^/]*/>\s*<geometry>\s*"
-            r'<mesh filename="meshes/visual/[^"]+\.glb"\s*/>\s*'
-            r"</geometry>\s*</\1>",
-            "",
-            urdf_str,
-        )
-        # The collision OBJs have no MTL, so without a URDF material PyBullet
-        # renders them pure black. Inject a neutral gray into every <visual>.
-        material_xml = (
-            '<material name="dexmate_vega_default">'
-            '<color rgba="0.75 0.75 0.78 1.0"/>'
-            "</material>"
-        )
-        urdf_str = re.sub(
-            r"(</geometry>)(\s*</visual>)",
-            r"\1" + material_xml + r"\2",
-            urdf_str,
-        )
-        # Write next to the original so the relative mesh paths still resolve.
-        new_path = original_path.parent / "vega_1u-PYBULLET-HELPERS.urdf"
-        new_path.write_text(urdf_str, encoding="utf-8")
-        return new_path
 
     @cached_property
     def arm_joints(self) -> list[int]:
-        # Expose only the 7 left-arm joints; Lift and torso_flip are excluded.
-        # This matches the kinematic chain EAIK solves for, and is the standard
-        # humanoid pattern where torso/base motions are planned separately from
-        # arm motions.
-        return [self.joint_from_name(n) for n in _LEFT_ARM_JOINT_NAMES]
+        # The 7 left-arm joints followed by the gripper jaw joints. Lift and torso_flip
+        # are excluded: this matches the kinematic chain EAIK solves for, and the
+        # standard humanoid pattern where torso/base motions are planned separately.
+        arm = [self.joint_from_name(n) for n in _LEFT_ARM_JOINT_NAMES]
+        return arm + self.finger_ids
 
     @property
     def default_home_joint_positions(self) -> JointPositions:
-        return [0.0] * 7
+        return [0.0] * len(_LEFT_ARM_JOINT_NAMES) + self.finger_state_to_joints(
+            self.open_fingers_state
+        )
 
     @property
     def end_effector_name(self) -> str:
@@ -110,6 +142,25 @@ class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
     @property
     def tool_link_name(self) -> str:
         return "L_ee"
+
+    @property
+    def finger_joint_names(self) -> list[str]:
+        return _LEFT_GRIPPER_JOINT_NAMES
+
+    @property
+    def open_fingers_state(self) -> float:
+        return _GRIPPER_OPEN
+
+    @property
+    def closed_fingers_state(self) -> float:
+        return _GRIPPER_CLOSED
+
+    def finger_state_to_joints(self, state: float) -> list[float]:
+        return [state, state]
+
+    def joints_to_finger_state(self, joint_positions: list[float]) -> float:
+        assert len(joint_positions) == 2
+        return joint_positions[0]
 
     @property
     def default_inverse_kinematics_method(self) -> str:
@@ -165,4 +216,6 @@ class DexmateVega1UPyBulletRobot(SingleArmPyBulletRobot):
         )
         if q is None:
             return None
-        return [float(v) for v in q]
+        # The arm solution covers the 7 arm joints; keep the fingers where they are.
+        current_fingers = self.finger_state_to_joints(self.get_finger_state())
+        return [float(v) for v in q] + current_fingers

--- a/pybullet-helpers/tests/conftest.py
+++ b/pybullet-helpers/tests/conftest.py
@@ -4,6 +4,22 @@ import pybullet as p
 import pytest
 
 
+def pytest_addoption(parser):
+    """Register custom command-line options."""
+    parser.addoption(
+        "--make-videos",
+        action="store_true",
+        default=False,
+        help="Render videos for tests that support visualization.",
+    )
+
+
+@pytest.fixture(name="make_videos")
+def _make_videos(request) -> bool:
+    """Whether tests that support visualization should render a video."""
+    return bool(request.config.getoption("--make-videos"))
+
+
 @pytest.fixture(scope="function", name="physics_client_id")
 def _connect_to_pybullet():
     """Direct connect to PyBullet physics server, and disconnect when we're done.

--- a/pybullet-helpers/tests/robots/test_dexmate_vega.py
+++ b/pybullet-helpers/tests/robots/test_dexmate_vega.py
@@ -3,16 +3,23 @@
 import importlib.util
 import warnings
 
+import imageio.v2 as iio
 import numpy as np
+import pybullet as p
 import pytest
 
+from pybullet_helpers.camera import capture_image
+from pybullet_helpers.geometry import Pose, multiply_poses
 from pybullet_helpers.inverse_kinematics import (
     InverseKinematicsError,
     inverse_kinematics,
 )
+from pybullet_helpers.manipulation import get_kinematic_plan_to_pick_object
 from pybullet_helpers.robots import _dexmate_vega_ik as _vega_ik
 from pybullet_helpers.robots import dexmate_vega
 from pybullet_helpers.robots.dexmate_vega import DexmateVega1UPyBulletRobot
+from pybullet_helpers.states import KinematicState
+from pybullet_helpers.utils import create_pybullet_block
 
 EAIK_INSTALLED = importlib.util.find_spec("eaik") is not None
 
@@ -21,6 +28,7 @@ def test_dexmate_vega_1u_robot(physics_client_id):
     """Tests for DexmateVega1UPyBulletRobot."""
     robot = DexmateVega1UPyBulletRobot(physics_client_id)
     assert robot.get_name() == "dexmate-vega-1u"
+    # The 7 left-arm joints followed by the 2 parallel-jaw gripper joints.
     assert robot.arm_joint_names == [
         "L_arm_j1",
         "L_arm_j2",
@@ -29,7 +37,10 @@ def test_dexmate_vega_1u_robot(physics_client_id):
         "L_arm_j5",
         "L_arm_j6",
         "L_arm_j7",
+        "L_gripper_j1",
+        "L_gripper_j2",
     ]
+    assert robot.finger_joint_idxs == [7, 8]
     assert np.allclose(robot.action_space.low, robot.joint_lower_limits)
     assert np.allclose(robot.action_space.high, robot.joint_upper_limits)
     # Moving each joint to its midpoint produces an EE pose within reach
@@ -147,6 +158,115 @@ def test_dexmate_vega_solve_arm_ik_roundtrip(prefix):
     assert (
         n_success >= n_trials - 1
     ), f"only {n_success}/{n_trials} roundtrips succeeded"
+
+
+def test_dexmate_vega_1u_gripper_open_close(physics_client_id):
+    """Opening and closing the parallel-jaw gripper drives both jaw joints between the
+    open and closed states."""
+    robot = DexmateVega1UPyBulletRobot(physics_client_id)
+    robot.open_fingers()
+    assert np.isclose(robot.get_finger_state(), robot.open_fingers_state)
+    assert np.allclose(
+        robot.get_joint_positions()[robot.finger_joint_idxs[0] :],
+        robot.open_fingers_state,
+    )
+    robot.close_fingers()
+    assert np.isclose(robot.get_finger_state(), robot.closed_fingers_state)
+    assert np.allclose(
+        robot.get_joint_positions()[robot.finger_joint_idxs[0] :],
+        robot.closed_fingers_state,
+    )
+
+
+def _render_pick_plan(robot, plan, path):
+    """Render a kinematic plan to a video."""
+    frames = []
+    for state in plan:
+        state.set_pybullet(robot)
+        frames.append(
+            capture_image(
+                robot.physics_client_id,
+                camera_distance=1.6,
+                camera_yaw=70,
+                camera_pitch=-25,
+                camera_target=(0.4, 0.2, 0.65),
+                image_width=480,
+                image_height=360,
+            )
+        )
+    iio.mimsave(path, frames, fps=20)
+
+
+@pytest.mark.skipif(not EAIK_INSTALLED, reason="EAIK not installed")
+def test_dexmate_vega_1u_pick_cube(physics_client_id, make_videos):
+    """The left arm plans a top-down grasp of a cube resting on a table.
+
+    Run pytest with --make-videos to render the plan to dexmate_vega_1u_pick.mp4.
+    """
+    robot = DexmateVega1UPyBulletRobot(physics_client_id)
+
+    # Table and a small cube on top of it, within the left arm's reach.
+    table_height = 0.5
+    table_id = create_pybullet_block(
+        (0.5, 0.5, 0.5, 1.0), (0.15, 0.15, table_height / 2), physics_client_id
+    )
+    p.resetBasePositionAndOrientation(
+        table_id, (0.45, 0.3, table_height / 2), (0, 0, 0, 1), physics_client_id
+    )
+    cube_half = 0.025
+    cube_id = create_pybullet_block(
+        (0.9, 0.3, 0.3, 1.0), (cube_half,) * 3, physics_client_id
+    )
+    p.resetBasePositionAndOrientation(
+        cube_id, (0.45, 0.3, table_height + cube_half), (0, 0, 0, 1), physics_client_id
+    )
+
+    initial_state = KinematicState.from_pybullet(robot, {cube_id, table_id})
+
+    # Top-down grasps: the gripper approaches along +z in the L_ee frame, so a roll of
+    # pi points it straight down. The standoff places L_ee far enough above the cube
+    # that the cube sits between the fingertips rather than up in the gripper throat
+    # (where it would be occluded by the gripper body); vary the yaw to find a feasible
+    # arm configuration.
+    grasp_standoff = 0.18
+
+    def grasp_generator():
+        for yaw in np.linspace(-np.pi, np.pi, 16, endpoint=False):
+            top_down = multiply_poses(
+                Pose.from_rpy((0, 0, 0), (0, 0, float(yaw))),
+                Pose.from_rpy((0, 0, 0), (np.pi, 0, 0)),
+            )
+            yield Pose((0.0, 0.0, grasp_standoff), top_down.orientation)
+
+    # For a clean video, spend more time in run_smooth_motion_planning_to_pose, which
+    # reruns planning and keeps the smoothest (shortest geometrically-weighted) path; for
+    # normal CI, use a small budget so the test stays fast.
+    if make_videos:
+        planning_kwargs = {
+            "max_motion_planning_time": 30.0,
+            "max_motion_planning_candidates": 30,
+            "max_smoothing_iters_per_step": 100,
+        }
+    else:
+        planning_kwargs = {"max_motion_planning_time": 2.0}
+
+    plan = get_kinematic_plan_to_pick_object(
+        initial_state,
+        robot,
+        cube_id,
+        table_id,
+        collision_ids={table_id, cube_id},
+        grasp_generator=grasp_generator(),
+        grasp_generator_iters=60,
+        **planning_kwargs,
+    )
+
+    assert plan is not None
+    # The plan ends with the cube grasped (attached to the end effector).
+    assert cube_id in plan[-1].attachments
+
+    if make_videos:
+        _render_pick_plan(robot, plan, "dexmate_vega_1u_pick.mp4")
 
 
 def test_dexmate_vega_1u_eaik_fallback_warning(physics_client_id, monkeypatch):


### PR DESCRIPTION
## Summary

Gives the single-arm Dexmate Vega 1U a working parallel-jaw gripper and adds a cube-pick test with optional video rendering. Builds on #476 (body binding) and #477 (dual-arm IK).

### Changes

- **Gripper URDF.** `DexmateVega1UPyBulletRobot` now loads `vega_1u_gripper.urdf` and is a `FingeredSingleArmPyBulletRobot[float]`. `arm_joints` is the 7 `L_arm_jN` joints plus the 2 gripper jaw joints; `finger_state` drives both jaws together (open `0.0` / closed `0.7854`), and `custom_inverse_kinematics` returns the 7-joint EAIK arm solution with the current finger state appended.
  - **DexGripper S, not D.** `vega_1u_gripper.urdf` ships the DexGripper D (forked fingertips, reads as 4 fingers). The S gripper is kinematically identical (same mount, joints, limits) and differs only in meshes, so we swap the gripper mesh paths to use it.
- **Generalized URDF prep.** `prepare_pybullet_urdf` rewrites each `.glb` visual/collision mesh to its sibling collision `.obj` when one exists and drops the element otherwise (handles the gripper's `hands/` meshes and the base/lift/torso/connector links with no `.obj`). It takes optional `mesh_substitutions` (used for the D→S swap).
- **`--make-videos` pytest option.** Added to the package `conftest.py` (with a `make_videos` fixture) — a reusable pattern for visualization tests.
- **Cube-pick test.** `test_dexmate_vega_1u_pick_cube` plans a top-down grasp of a cube on a table via `get_kinematic_plan_to_pick_object` and asserts the cube is attached at the end. The grasp standoff (0.18 m) places the cube between the fingertips rather than in the gripper throat. With `--make-videos` it renders `dexmate_vega_1u_pick.mp4` and uses a larger smooth-motion-planning budget for a cleaner path; normal CI uses a small, fast budget.
- **Gripper open/close test.**

### Notes

- No shared IK/motion-planning code was changed. The kinematic pick planner samples the finger joints as free DOF (they don't affect the EE pose), so the jaws jitter slightly along the plan — a cosmetic, pre-existing behavior (masked on Panda's tiny prismatic fingers); left as-is by design. The video renders the raw plan states (not `remap_kinematic_state_plan_to_constant_distance`, which densely interpolates and amplifies that jitter).
- Generated `*.mp4` videos are not committed.

## Test plan

- [x] `./run_ci_checks.sh` passes locally (82 tests; mypy + pylint clean).
- [x] Gripper URDF loads and renders (DexGripper S, 2 fingers).
- [x] `test_dexmate_vega_1u_pick_cube` plans a grasp and attaches the cube; `--make-videos` renders the plan.
- [x] `test_dexmate_vega_1u_gripper_open_close` drives both jaws between open/closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
