### PR TITLE
make pybullet-helpers run_ci_checks.sh fail fast (set -e)

### DIFF
--- a/pybullet-helpers/run_ci_checks.sh
+++ b/pybullet-helpers/run_ci_checks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 ./run_autoformat.sh
 mypy .
 pytest . --pylint -m pylint --pylint-rcfile=.pylintrc


### PR DESCRIPTION
## Summary

Adds `set -e` to `pybullet-helpers/run_ci_checks.sh` so it fails fast.

Without it, a failure in the autoformat, `mypy`, or `pytest . --pylint` step does not stop the script — it continues to the final `pytest tests/` step. When only the tail of the output is inspected, that final "tests passed" line masks an earlier lint/type failure (which is what bit a recent PR). With `set -e`, the script exits non-zero at the first failing step.

## Test plan

- [x] `./run_ci_checks.sh` runs clean end-to-end and exits 0.
- [x] Confirmed a forced pylint failure now stops the script with a non-zero exit instead of proceeding to the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
