### PR TITLE
Add prpl-kinematics package scaffold with KinematicTree core

### DIFF
--- a/prpl-kinematics/.pylintrc
+++ b/prpl-kinematics/.pylintrc
@@ -1,0 +1,427 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=numpy,pybullet
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,venv
+
+# Add paths to the blacklist.
+ignore-paths=src/prpl_kinematics/third_party,src/prpl_kinematics/assets
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=pylint_plugins.no_np_random
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,not-callable,logging-format-interpolation,consider-using-enumerate,invalid-name,eval-used,len-as-condition,raise-missing-from,consider-using-with,logging-fstring-interpolation,cache-max-size-none,unnecessary-lambda-assignment,too-many-positional-arguments
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=10
+
+
+[BASIC]
+
+# Naming hint for argument names
+argument-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct argument names
+argument-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Naming hint for attribute names
+attr-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct attribute names
+attr-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,99}|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,99}|(__.*__))$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,l,t,m,n,ex,Run,_,i1,i2,i3,j1,j2,j3,v,pt,ax,X,Y,Z,W,W1,W2,W3,x,y,z,w,Xtest,Ytest,Xtrain,Ytrain,Yhat,p,dt,f,g,h,xs,ys,e,ie,kb,op,T,R,S,A,O,c,vs,c1,c2,s,a,r,cp,vf,M,N
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming hint for variable names
+variable-name-hint=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=(([a-z][a-z0-9_]{2,99})|(_[a-z0-9_]*))$
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=89
+
+# Maximum number of lines in a module
+max-module-lines=10000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=100
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,tensorflow.python.util.tf_contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=torch.*,cv2.*
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=mit_semseg,semseg
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=yes
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=1000
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=1000
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=1000
+
+# Maximum number of branch for function / method body
+max-branches=1000
+
+# Maximum number of locals for function / method body
+max-locals=1000
+
+# Maximum number of parents for a class (see R0901).
+max-parents=1000
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=1000
+
+# Maximum number of return / yield for function / method body
+max-returns=1000
+
+# Maximum number of statements in function / method body
+max-statements=1000
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -1,0 +1,113 @@
+# prpl-kinematics — design
+
+A ground-up successor to `pybullet-helpers`. Kinematics only, engine-agnostic,
+built around one general scene graph. This document is the plan; code is added
+one milestone at a time, and **nothing lands without unit tests**.
+
+## Principles
+
+1. **Kinematic only.** No dynamics, no `stepSimulation`. State is set by reset.
+2. **One scene graph; everything is an edge.** A robot joint, a mobile base, and
+   a grasp are all just edges in a `KinematicTree`.
+3. **spatialmath is the substrate.** Poses are `SE3`/`SE2`, rotations `SO3`/
+   `UnitQuaternion`. We do not define our own Pose or Quaternion classes.
+4. **PyBullet is a backend, not the source of truth.** The tree owns forward
+   kinematics; PyBullet (and, later, others) are pluggable collision/render
+   backends behind an interface.
+5. **Interfaces are subclassable.** IK, motion planning, and manipulation
+   primitives are ABCs with swappable implementations (e.g. BiRRT vs OMPL).
+6. **Start minimal, add as we go.** Every class and method must be necessary
+   *now* and covered by a unit test. Speculative abstractions live in this doc,
+   not in code.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Package name | `prpl_kinematics`, in the `prpl-mono` monorepo |
+| Transform math | `spatialmath-python` |
+| PyBullet's role | Collision/render **backend** behind an interface |
+| Engine of truth | The `KinematicTree` (FK via spatialmath) |
+| Proving-set robots | Panda, Kinova, Dexmate Vega (bimanual), TidyBot (mobile) |
+
+## The KinematicTree (the centerpiece)
+
+A directed tree of named frames (`Node`) rooted at `world`. Each non-root node
+has exactly one incoming `Edge` carrying a `Joint`. The union of all joints with
+`num_dof > 0` is the configuration. One structure unifies cases other libraries
+keep separate:
+
+```
+world (root)
+ ├─[planar joint]→ base ─[fixed]→ torso ─[revolute×7]→ … → gripper_link
+ │                                                            └─[fixed: grasp]→ mug   ← re-parented on grasp
+ ├─[fixed]→ table
+ └─[fixed]→ block
+```
+
+- **Robot arm** — a chain of revolute/prismatic edges.
+- **Mobile base** — a `PlanarJoint` (SE(2)) edge from `world` to the base frame.
+- **Grasp** — `attach()`: re-parent an object's edge onto a gripper frame with a
+  `FixedJoint` holding the grasp transform. Release is `attach()` back to `world`.
+- **Bimanual / multi-robot / scene** — one tree (or forest under `world`); the
+  backend never sees morphology.
+
+Forward kinematics composes joint transforms along the path from the root. The
+tree owns no physics.
+
+### Why PyBullet-as-backend is clean here
+
+Because the tree provides the world-frame pose of every geometry-bearing node,
+the collision backend never needs joints or articulation: it holds **one
+collision shape per node** and, per query, positions each shape from the tree's
+FK before running collision detection. Consequences:
+
+- Grasps need no special handling — a held object's shape just follows FK.
+- Mobile / bimanual / multi-robot all use one code path.
+- The backend is swappable (PyBullet today; FCL/meshcat later) and can run
+  headless without a simulator process.
+
+## Layered structure (target)
+
+```
+geometry/      spatialmath <-> external-convention conversions (PyBullet xyzw).   [built]
+tree/          KinematicTree, Joint types, FK, attach (grasp), KinematicState.    [built]
+loading/       URDF -> KinematicTree (via yourdfpy).                              [planned]
+backends/      CollisionBackend / Renderer ABCs; PyBullet impls (shape-soup).     [planned]
+ik/            InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.     [planned]
+planning/      ConfigurationSpace ABC + MotionPlanner ABC; BiRRT, OMPL.           [planned]
+robots/        Assemblies over a tree: SingleArm, Bimanual, MobileBase, MobileManip. [planned]
+manipulation/  Primitive ABC; Pick, Place with injected grasp generators.        [planned]
+```
+
+The `ConfigurationSpace` abstraction (sample/distance/interpolate/is_valid) is
+what lets one planner work over joint space, an SE(2) base, or a Cartesian EE
+target uniformly. Robots are composition over a tree (named joint groups, an EE
+link, a home config), not an inheritance tower.
+
+## What is built today
+
+The minimal, fully-tested core:
+
+- `geometry.transforms` — `pose_from_pybullet`, `pose_to_pybullet`.
+- `tree.joints` — `Joint` ABC + `FixedJoint` (0 DOF), `RevoluteJoint` (1),
+  `PrismaticJoint` (1), `PlanarJoint` (3). Each maps joint values to an `SE3`.
+- `tree.kinematic_tree` — `Node`, `Edge`, `KinematicTree` (`add_node`,
+  `add_edge`, `forward_kinematics`, `relative_pose`, `attach`,
+  `actuated_joint_names`, `joint`, `path_from_root`).
+- `tree.state` — `KinematicState` snapshot of actuated joint values.
+
+21 unit tests cover conversions, every joint type, FK propagation, grasp
+re-parenting, and snapshotting.
+
+## Milestones (each adds code + tests)
+
+1. **Geometry + tree core** — done.
+2. **Loading** — `yourdfpy` URDF → tree; round-trip FK against a known robot.
+3. **Backends** — `CollisionBackend`/`Renderer` ABCs + shape-soup PyBullet impls.
+4. **IK** — `InverseKinematics` ABC; `NumericalIK` (Jacobian-DLS, folding in the
+   ee-follow jitter fix), then `AnalyticIK` (EAIK/IKFast port).
+5. **Planning** — `ConfigurationSpace` + `MotionPlanner` ABC; `BiRRTPlanner`
+   (wrapping `prpl_utils`), then `OMPLPlanner`.
+6. **Robots** — port Panda, Kinova, Dexmate Vega, TidyBot as assemblies.
+7. **Manipulation** — `Pick`/`Place` on the new stack.

--- a/prpl-kinematics/LICENSE
+++ b/prpl-kinematics/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Tom Silver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/prpl-kinematics/LICENSE
+++ b/prpl-kinematics/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Tom Silver
+Copyright (c) 2026 Tom Silver
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/prpl-kinematics/README.md
+++ b/prpl-kinematics/README.md
@@ -1,0 +1,33 @@
+# prpl-kinematics
+
+Kinematics-only robot modeling, IK, motion planning, and manipulation primitives
+built on a general `KinematicTree`. A ground-up successor to `pybullet-helpers`:
+engine-agnostic (PyBullet is a pluggable collision/render backend, not the source
+of truth), with poses represented as `spatialmath` `SE3`/`SE2`.
+
+See [`DESIGN.md`](DESIGN.md) for the architecture and roadmap.
+
+## Status
+
+Early. The built core is the geometry layer and the `KinematicTree` (joints,
+forward kinematics, grasp via re-parenting, state snapshots). Loading, backends,
+IK, planning, robots, and manipulation are planned milestones — each lands with
+unit tests.
+
+## Requirements
+
+- Python 3.10+
+
+## Installation
+
+From the monorepo root, with [uv](https://docs.astral.sh/uv/):
+
+```
+uv pip install -e "./prpl-kinematics[develop]"
+```
+
+## Development
+
+```
+./run_ci_checks.sh   # autoformat, mypy, pylint, pytest
+```

--- a/prpl-kinematics/prpl_requirements.txt
+++ b/prpl-kinematics/prpl_requirements.txt
@@ -1,0 +1,2 @@
+# Other packages in prpl-mono that are required by this one.
+# (None currently.)

--- a/prpl-kinematics/pylint_plugins/no_np_random.py
+++ b/prpl-kinematics/pylint_plugins/no_np_random.py
@@ -1,0 +1,45 @@
+"""Pylint checker that bans direct use of np.random (global RNG state).
+
+Allowed: np.random.default_rng, np.random.Generator
+Banned:  everything else under np.random
+"""
+
+from astroid import nodes  # type: ignore[import-untyped]
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+_ALLOWED_ATTRS = frozenset({"default_rng", "Generator"})
+
+
+class NoNpRandomChecker(BaseChecker):
+    """Flag ``np.random.<X>`` unless *X* is ``default_rng`` or ``Generator``."""
+
+    name = "no-np-random"
+    msgs = {
+        "C9900": (
+            "Use np.random.default_rng() instead of np.random.%s",
+            "np-random-disallowed",
+            "Direct use of np.random functions/classes relies on global "
+            "state and is non-reproducible. Use np.random.default_rng() "
+            "to create a local Generator instance instead.",
+        ),
+    }
+
+    def visit_attribute(self, node: nodes.Attribute) -> None:
+        """Check every attribute access for banned np.random usage."""
+        if node.attrname in _ALLOWED_ATTRS:
+            return
+        expr = node.expr
+        if not isinstance(expr, nodes.Attribute):
+            return
+        if (
+            expr.attrname == "random"
+            and isinstance(expr.expr, nodes.Name)
+            and expr.expr.name == "np"
+        ):
+            self.add_message("np-random-disallowed", node=node, args=(node.attrname,))
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker with pylint."""
+    linter.register_checker(NoNpRandomChecker(linter))

--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prpl_kinematics"
+version = "0.0.1"
+description = "Kinematics-only robot modeling, IK, motion planning, and manipulation primitives built on a general KinematicTree."
+readme = "README.md"
+requires-python = ">=3.10"
+# Lists only what the code imports.
+dependencies = [
+   "numpy>=1.23.5,<2.0",
+   "scipy>=1.10",
+   "spatialmath-python>=1.1.10",
+]
+
+[project.optional-dependencies]
+develop = [
+    "black",
+    "docformatter",
+    "isort",
+    "mypy",
+    "pylint>=2.14.5",
+    "pytest-pylint>=0.18.0",
+    "pytest>=7.2.2",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+prpl_kinematics = ["py.typed"]
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+extend-exclude = "third_party/*"
+
+[tool.docformatter]
+line-length = 88
+wrap-summaries = 88
+wrap-descriptions = 88
+
+[tool.isort]
+py_version = 310
+profile = "black"
+multi_line_output = 2
+skip_glob = ["venv/*", ".venv/*", "build", "dist", "third_party", "third-party", "__pycache__/"]
+split_on_trailing_comma = true
+
+[tool.mypy]
+strict_equality = true
+disallow_untyped_calls = true
+warn_unreachable = true
+exclude = ["venv/*", ".venv/*", "build", "dist", "third_party", "third-party", "__pycache__/"]
+
+[[tool.mypy.overrides]]
+module = [
+    "pybullet.*",
+    "pybullet_utils.*",
+    "scipy.*",
+    "spatialmath.*",
+    "yourdfpy.*",
+    "eaik.*",
+    "ompl.*",
+]
+ignore_missing_imports = true

--- a/prpl-kinematics/run_autoformat.sh
+++ b/prpl-kinematics/run_autoformat.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+python -m black .
+docformatter -i -r . --exclude venv
+isort .

--- a/prpl-kinematics/run_ci_checks.sh
+++ b/prpl-kinematics/run_ci_checks.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+./run_autoformat.sh
+mypy .
+pytest . --pylint -m pylint --pylint-rcfile=.pylintrc
+pytest tests/

--- a/prpl-kinematics/src/prpl_kinematics/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/__init__.py
@@ -1,0 +1,9 @@
+"""prpl_kinematics: kinematics-only robot modeling, IK, motion planning, and
+manipulation primitives built on a general KinematicTree.
+
+The package is engine-agnostic: a ``KinematicTree`` (transforms via spatialmath)
+is the single source of truth for forward kinematics, and physics engines such
+as PyBullet are used only as pluggable collision/render backends.
+"""
+
+__version__ = "0.0.1"

--- a/prpl-kinematics/src/prpl_kinematics/geometry/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/geometry/__init__.py
@@ -1,0 +1,16 @@
+"""Geometry: conversions between spatialmath ``SE3`` and external conventions.
+
+Poses are spatialmath ``SE3``/``SE2`` everywhere; this package only bridges the
+PyBullet boundary. Import ``SE3``, ``SE2``, ``SO3``, ``UnitQuaternion`` directly
+from ``spatialmath``.
+"""
+
+from prpl_kinematics.geometry.transforms import (
+    pose_from_pybullet,
+    pose_to_pybullet,
+)
+
+__all__ = [
+    "pose_from_pybullet",
+    "pose_to_pybullet",
+]

--- a/prpl-kinematics/src/prpl_kinematics/geometry/transforms.py
+++ b/prpl-kinematics/src/prpl_kinematics/geometry/transforms.py
@@ -1,0 +1,46 @@
+"""Conversions between spatialmath ``SE3`` and external pose conventions.
+
+Internally, prpl_kinematics represents every rigid-body pose as a spatialmath
+``SE3`` (or ``SE2`` for planar quantities) and every rotation as ``SO3`` /
+``UnitQuaternion``. We deliberately do *not* define our own Pose or Quaternion
+classes -- spatialmath already ships battle-tested ones, and elsewhere in the
+codebase a roll-pitch-yaw pose is just ``SE3(x, y, z) * SE3.RPY([r, p, y])``.
+
+The only conversions we need are at the boundary with tools that use a different
+convention. PyBullet represents a pose as a position ``(x, y, z)`` plus a
+quaternion in ``(x, y, z, w)`` order, whereas spatialmath's ``UnitQuaternion``
+uses ``(w, x, y, z)`` order; these helpers bridge that gap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from scipy.spatial.transform import Rotation
+from spatialmath import SE3
+
+
+def pose_from_pybullet(position: Sequence[float], orientation: Sequence[float]) -> SE3:
+    """Build an ``SE3`` from a PyBullet ``(position, xyzw-quaternion)`` pose."""
+    rotation = Rotation.from_quat(list(orientation)).as_matrix()
+    return SE3.Rt(rotation, list(position))
+
+
+def pose_to_pybullet(
+    pose: SE3,
+) -> tuple[tuple[float, float, float], tuple[float, float, float, float]]:
+    """Convert an ``SE3`` to a PyBullet ``(position, xyzw-quaternion)`` pose."""
+    quat = Rotation.from_matrix(pose.R).as_quat()
+    translation = pose.t
+    position = (
+        float(translation[0]),
+        float(translation[1]),
+        float(translation[2]),
+    )
+    orientation = (
+        float(quat[0]),
+        float(quat[1]),
+        float(quat[2]),
+        float(quat[3]),
+    )
+    return position, orientation

--- a/prpl-kinematics/src/prpl_kinematics/tree/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/__init__.py
@@ -1,0 +1,31 @@
+"""The KinematicTree and its joints -- the package's single source of truth."""
+
+from prpl_kinematics.tree.joints import (
+    FixedJoint,
+    Joint,
+    JointValues,
+    PlanarJoint,
+    PrismaticJoint,
+    RevoluteJoint,
+)
+from prpl_kinematics.tree.kinematic_tree import (
+    Configuration,
+    Edge,
+    KinematicTree,
+    Node,
+)
+from prpl_kinematics.tree.state import KinematicState
+
+__all__ = [
+    "FixedJoint",
+    "Joint",
+    "JointValues",
+    "PlanarJoint",
+    "PrismaticJoint",
+    "RevoluteJoint",
+    "Configuration",
+    "Edge",
+    "KinematicTree",
+    "Node",
+    "KinematicState",
+]

--- a/prpl-kinematics/src/prpl_kinematics/tree/joints.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/joints.py
@@ -1,0 +1,130 @@
+"""Joints: parameterized transforms between a parent frame and a child frame.
+
+Every edge in a :class:`~prpl_kinematics.tree.kinematic_tree.KinematicTree` carries
+a joint. A joint maps a vector of joint values (length ``num_dof``) to the rigid
+transform from its parent frame to its child frame. Robot actuators, a mobile
+base, and even a rigid grasp are all just joints:
+
+* ``FixedJoint`` (0 DOF) -- rigid attachment, e.g. a grasp or a sensor mount.
+* ``RevoluteJoint`` (1 DOF) -- a rotary actuator.
+* ``PrismaticJoint`` (1 DOF) -- a linear actuator.
+* ``PlanarJoint`` (3 DOF) -- an SE(2) mobile base ``(x, y, yaw)``.
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from spatialmath import SE3
+
+JointValues = list[float]  # Length must equal ``num_dof``.
+
+Axis = tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class Joint(ABC):
+    """A parameterized parent-to-child transform.
+
+    ``origin`` is the parent-to-joint transform at zero configuration (the URDF
+    joint origin); each subclass applies its motion on top of ``origin``.
+    """
+
+    name: str
+    origin: SE3 = field(default_factory=SE3)
+
+    @property
+    @abstractmethod
+    def num_dof(self) -> int:
+        """Number of scalar values this joint consumes."""
+
+    @abstractmethod
+    def transform(self, values: JointValues) -> SE3:
+        """Parent-to-child transform for the given joint values."""
+
+    @property
+    def lower_limits(self) -> list[float]:
+        """Lower bound for each DOF (``-inf`` if unbounded)."""
+        return [-math.inf] * self.num_dof
+
+    @property
+    def upper_limits(self) -> list[float]:
+        """Upper bound for each DOF (``+inf`` if unbounded)."""
+        return [math.inf] * self.num_dof
+
+
+@dataclass(frozen=True)
+class FixedJoint(Joint):
+    """A rigid (0-DOF) attachment; the transform is always ``origin``."""
+
+    @property
+    def num_dof(self) -> int:
+        return 0
+
+    def transform(self, values: JointValues) -> SE3:
+        return self.origin
+
+
+@dataclass(frozen=True)
+class RevoluteJoint(Joint):
+    """A 1-DOF rotary joint about ``axis`` with position limits."""
+
+    axis: Axis = (0.0, 0.0, 1.0)
+    lower: float = -math.pi
+    upper: float = math.pi
+
+    @property
+    def num_dof(self) -> int:
+        return 1
+
+    def transform(self, values: JointValues) -> SE3:
+        (theta,) = values
+        return self.origin * SE3.AngVec(theta, self.axis)
+
+    @property
+    def lower_limits(self) -> list[float]:
+        return [self.lower]
+
+    @property
+    def upper_limits(self) -> list[float]:
+        return [self.upper]
+
+
+@dataclass(frozen=True)
+class PrismaticJoint(Joint):
+    """A 1-DOF linear joint along ``axis`` with position limits."""
+
+    axis: Axis = (0.0, 0.0, 1.0)
+    lower: float = 0.0
+    upper: float = 1.0
+
+    @property
+    def num_dof(self) -> int:
+        return 1
+
+    def transform(self, values: JointValues) -> SE3:
+        (d,) = values
+        return self.origin * SE3(d * self.axis[0], d * self.axis[1], d * self.axis[2])
+
+    @property
+    def lower_limits(self) -> list[float]:
+        return [self.lower]
+
+    @property
+    def upper_limits(self) -> list[float]:
+        return [self.upper]
+
+
+@dataclass(frozen=True)
+class PlanarJoint(Joint):
+    """A 3-DOF SE(2) joint ``(x, y, yaw)`` -- e.g. a mobile base."""
+
+    @property
+    def num_dof(self) -> int:
+        return 3
+
+    def transform(self, values: JointValues) -> SE3:
+        x, y, yaw = values
+        return self.origin * SE3(x, y, 0.0) * SE3.Rz(yaw)

--- a/prpl-kinematics/src/prpl_kinematics/tree/kinematic_tree.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/kinematic_tree.py
@@ -1,0 +1,154 @@
+"""The KinematicTree: one scene graph in which everything is an edge.
+
+A ``KinematicTree`` is a directed tree of named frames (``Node``) rooted at a
+single node (conventionally ``"world"``). Each non-root node has exactly one
+incoming ``Edge`` carrying a :class:`~prpl_kinematics.tree.joints.Joint`. The
+union of all joints with ``num_dof > 0`` is the tree's configuration.
+
+This single structure unifies what other libraries treat as separate cases:
+
+* A robot arm is a chain of revolute/prismatic edges.
+* A mobile base is a ``PlanarJoint`` edge from ``world`` to the base frame.
+* A grasp is :meth:`attach` -- re-parenting an object's edge onto a gripper
+  frame with a ``FixedJoint``. Release is just ``attach`` back onto ``world``.
+* A bimanual robot is one tree with two arm chains; multiple robots and free
+  objects all live under ``world``.
+
+Forward kinematics composes the joint transforms along the path from the root.
+The tree owns no physics: it computes frame poses but performs no collision
+checking or rendering itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from spatialmath import SE3
+
+from prpl_kinematics.tree.joints import FixedJoint, Joint, JointValues
+
+Configuration = Mapping[str, JointValues]
+
+
+@dataclass
+class Node:
+    """A named frame, optionally carrying collision/visual geometry.
+
+    ``geometry`` is an opaque handle (e.g. a path to a mesh or a primitive-shape
+    spec). The tree never interprets it; only consumers that render or check
+    collisions do.
+    """
+
+    name: str
+    geometry: object | None = None
+
+
+@dataclass
+class Edge:
+    """A directed parent-to-child connection carrying a joint."""
+
+    parent: str
+    child: str
+    joint: Joint
+
+
+class KinematicTree:
+    """A directed tree of frames connected by joints, rooted at ``root``."""
+
+    def __init__(self, root: str = "world") -> None:
+        self._root = root
+        self._nodes: dict[str, Node] = {root: Node(root)}
+        # Each non-root child has exactly one incoming edge, keyed by child name.
+        self._edges: dict[str, Edge] = {}
+
+    @property
+    def root(self) -> str:
+        """The name of the root frame."""
+        return self._root
+
+    @property
+    def nodes(self) -> Mapping[str, Node]:
+        """All frames, keyed by name."""
+        return self._nodes
+
+    def add_node(self, node: Node) -> None:
+        """Register a frame.
+
+        Raises if the name is already present.
+        """
+        if node.name in self._nodes:
+            raise ValueError(f"Node already exists: {node.name}")
+        self._nodes[node.name] = node
+
+    def add_edge(self, edge: Edge) -> None:
+        """Connect ``edge.child`` to ``edge.parent`` via ``edge.joint``."""
+        if edge.parent not in self._nodes:
+            raise ValueError(f"Unknown parent: {edge.parent}")
+        if edge.child not in self._nodes:
+            raise ValueError(f"Unknown child: {edge.child}")
+        if edge.child in self._edges:
+            raise ValueError(f"Node already has a parent: {edge.child}")
+        self._edges[edge.child] = edge
+
+    def path_from_root(self, name: str) -> list[Edge]:
+        """Edges from the root down to ``name`` (empty for the root itself)."""
+        if name not in self._nodes:
+            raise ValueError(f"Unknown node: {name}")
+        edges: list[Edge] = []
+        cursor = name
+        while cursor != self._root:
+            edge = self._edges[cursor]
+            edges.append(edge)
+            cursor = edge.parent
+        edges.reverse()
+        return edges
+
+    def actuated_joint_names(self) -> list[str]:
+        """Names of all joints with at least one DOF, in insertion order."""
+        return [e.joint.name for e in self._edges.values() if e.joint.num_dof > 0]
+
+    def joint(self, joint_name: str) -> Joint:
+        """Look up a joint by name.
+
+        Raises ``KeyError`` if absent.
+        """
+        for edge in self._edges.values():
+            if edge.joint.name == joint_name:
+                return edge.joint
+        raise KeyError(f"No joint named {joint_name}")
+
+    def forward_kinematics(self, name: str, config: Configuration) -> SE3:
+        """World-frame pose of frame ``name`` under ``config``.
+
+        Joints absent from ``config`` are taken at their zero values.
+        """
+        pose = SE3()
+        for edge in self.path_from_root(name):
+            joint = edge.joint
+            values = list(config.get(joint.name, [0.0] * joint.num_dof))
+            pose = pose * joint.transform(values)
+        return pose
+
+    def relative_pose(self, a: str, b: str, config: Configuration) -> SE3:
+        """Pose of frame ``b`` expressed in frame ``a``."""
+        return self.forward_kinematics(a, config).inv() * self.forward_kinematics(
+            b, config
+        )
+
+    def attach(self, child: str, new_parent: str, transform: SE3) -> None:
+        """Re-parent ``child`` onto ``new_parent`` via a fixed ``transform``.
+
+        This is the grasp operation: the held object's frame becomes rigidly
+        fixed to (e.g.) a gripper frame. The joint name is preserved if ``child``
+        already had one so that snapshots stay stable.
+        """
+        if new_parent not in self._nodes:
+            raise ValueError(f"Unknown parent: {new_parent}")
+        existing = self._edges.get(child)
+        joint_name = existing.joint.name if existing else f"{child}_attachment"
+        self._edges[child] = Edge(
+            parent=new_parent,
+            child=child,
+            joint=FixedJoint(name=joint_name, origin=transform),
+        )

--- a/prpl-kinematics/src/prpl_kinematics/tree/state.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/state.py
@@ -1,0 +1,32 @@
+"""KinematicState: a restorable snapshot of a tree's configuration.
+
+A state captures the joint values for every actuated joint of a tree, so a
+configuration can be saved and later reapplied for forward kinematics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from prpl_kinematics.tree.joints import JointValues
+from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
+
+
+@dataclass(frozen=True)
+class KinematicState:
+    """An immutable snapshot of all actuated joint values."""
+
+    joint_values: dict[str, tuple[float, ...]]
+
+    @classmethod
+    def from_tree(cls, tree: KinematicTree, config: Configuration) -> KinematicState:
+        """Snapshot ``config`` over the actuated joints of ``tree``."""
+        values: dict[str, tuple[float, ...]] = {}
+        for name in tree.actuated_joint_names():
+            num_dof = tree.joint(name).num_dof
+            values[name] = tuple(config.get(name, [0.0] * num_dof))
+        return cls(values)
+
+    def as_configuration(self) -> dict[str, JointValues]:
+        """Return the snapshot as a configuration mapping for forward kinematics."""
+        return {name: list(vals) for name, vals in self.joint_values.items()}

--- a/prpl-kinematics/tests/test_joints.py
+++ b/prpl-kinematics/tests/test_joints.py
@@ -1,0 +1,59 @@
+"""Unit tests for joint types."""
+
+import math
+
+import numpy as np
+from spatialmath import SE3
+
+from prpl_kinematics.tree.joints import (
+    FixedJoint,
+    PlanarJoint,
+    PrismaticJoint,
+    RevoluteJoint,
+)
+
+
+def test_fixed_joint_ignores_values():
+    """A fixed joint has zero DOF and always returns its origin."""
+    origin = SE3(1.0, 2.0, 3.0)
+    joint = FixedJoint(name="mount", origin=origin)
+    assert joint.num_dof == 0
+    assert np.allclose(joint.transform([]).A, origin.A)
+    assert not joint.lower_limits
+    assert not joint.upper_limits
+
+
+def test_revolute_rotates_about_axis():
+    """A revolute joint rotates about its axis by the given angle."""
+    joint = RevoluteJoint(name="r")  # Default axis is +z.
+    pose = joint.transform([math.pi / 2])
+    assert joint.num_dof == 1
+    assert np.allclose(pose.R @ np.array([1.0, 0.0, 0.0]), [0.0, 1.0, 0.0], atol=1e-6)
+    assert np.allclose(joint.lower_limits, [-math.pi])
+    assert np.allclose(joint.upper_limits, [math.pi])
+
+
+def test_revolute_composes_with_origin():
+    """A revolute joint applies its rotation on top of its origin offset."""
+    joint = RevoluteJoint(name="r", origin=SE3(0.0, 0.0, 1.0))
+    pose = joint.transform([0.0])
+    assert np.allclose(pose.t, [0.0, 0.0, 1.0])
+
+
+def test_prismatic_translates_along_axis():
+    """A prismatic joint translates along its axis with its limits."""
+    joint = PrismaticJoint(name="p", axis=(1.0, 0.0, 0.0), lower=0.0, upper=2.0)
+    pose = joint.transform([0.5])
+    assert joint.num_dof == 1
+    assert np.allclose(pose.t, [0.5, 0.0, 0.0])
+    assert np.allclose(joint.lower_limits, [0.0])
+    assert np.allclose(joint.upper_limits, [2.0])
+
+
+def test_planar_joint_is_se2():
+    """A planar joint applies an (x, y, yaw) SE(2) transform."""
+    joint = PlanarJoint(name="base")
+    pose = joint.transform([1.0, 2.0, math.pi / 2])
+    assert joint.num_dof == 3
+    assert np.allclose(pose.t, [1.0, 2.0, 0.0])
+    assert np.allclose(pose.R @ np.array([1.0, 0.0, 0.0]), [0.0, 1.0, 0.0], atol=1e-6)

--- a/prpl-kinematics/tests/test_kinematic_tree.py
+++ b/prpl-kinematics/tests/test_kinematic_tree.py
@@ -1,0 +1,107 @@
+"""Unit tests for the KinematicTree."""
+
+import math
+
+import numpy as np
+import pytest
+from spatialmath import SE3
+
+from prpl_kinematics.tree import (
+    Edge,
+    FixedJoint,
+    KinematicTree,
+    Node,
+    RevoluteJoint,
+)
+
+
+def _two_link_tree() -> KinematicTree:
+    """World -[revolute j1]-> link1 -[fixed +x]-> link2."""
+    tree = KinematicTree()
+    tree.add_node(Node("link1"))
+    tree.add_node(Node("link2"))
+    tree.add_edge(Edge("world", "link1", RevoluteJoint(name="j1")))
+    tree.add_edge(Edge("link1", "link2", FixedJoint(name="mount", origin=SE3(1, 0, 0))))
+    return tree
+
+
+def test_forward_kinematics_default_config():
+    """Unspecified joints default to zero, so link2 sits at its origin offset."""
+    tree = _two_link_tree()
+    pose = tree.forward_kinematics("link2", {})
+    assert np.allclose(pose.t, [1.0, 0.0, 0.0])
+
+
+def test_forward_kinematics_propagates_rotation():
+    """Rotating j1 by 90 degrees swings link2's +x offset onto +y."""
+    tree = _two_link_tree()
+    pose = tree.forward_kinematics("link2", {"j1": [math.pi / 2]})
+    assert np.allclose(pose.t, [0.0, 1.0, 0.0], atol=1e-6)
+
+
+def test_actuated_joint_names_excludes_fixed():
+    """Only joints with DOF are reported as actuated."""
+    tree = _two_link_tree()
+    assert tree.actuated_joint_names() == ["j1"]
+
+
+def test_path_from_root():
+    """The path lists edges root-to-leaf; the root itself has an empty path."""
+    tree = _two_link_tree()
+    assert [edge.child for edge in tree.path_from_root("link2")] == ["link1", "link2"]
+    assert not tree.path_from_root("world")
+
+
+def test_joint_lookup():
+    """Joints are retrievable by name; unknown names raise KeyError."""
+    tree = _two_link_tree()
+    assert tree.joint("j1").num_dof == 1
+    with pytest.raises(KeyError):
+        tree.joint("missing")
+
+
+def test_attach_makes_object_follow_new_parent():
+    """A grasped object's pose tracks the gripper frame times the grasp transform."""
+    tree = _two_link_tree()
+    tree.add_node(Node("mug"))
+    tree.add_edge(Edge("world", "mug", FixedJoint(name="mug_free")))
+    grasp = SE3(0.0, 0.0, 0.1)
+    tree.attach("mug", "link2", grasp)
+    config = {"j1": [math.pi / 2]}
+    mug_pose = tree.forward_kinematics("mug", config)
+    link2_pose = tree.forward_kinematics("link2", config)
+    assert np.allclose(mug_pose.A, (link2_pose * grasp).A, atol=1e-6)
+
+
+def test_relative_pose_recovers_grasp_transform():
+    """The object's pose relative to its parent equals the attachment transform."""
+    tree = _two_link_tree()
+    tree.add_node(Node("mug"))
+    tree.add_edge(Edge("world", "mug", FixedJoint(name="mug_free")))
+    grasp = SE3(0.0, 0.0, 0.1)
+    tree.attach("mug", "link2", grasp)
+    relative = tree.relative_pose("link2", "mug", {"j1": [0.3]})
+    assert np.allclose(relative.A, grasp.A, atol=1e-6)
+
+
+def test_add_edge_unknown_parent_raises():
+    """Adding an edge to a missing parent is an error."""
+    tree = KinematicTree()
+    tree.add_node(Node("a"))
+    with pytest.raises(ValueError):
+        tree.add_edge(Edge("ghost", "a", FixedJoint(name="x")))
+
+
+def test_add_duplicate_node_raises():
+    """Registering the same node name twice is an error."""
+    tree = KinematicTree()
+    tree.add_node(Node("a"))
+    with pytest.raises(ValueError):
+        tree.add_node(Node("a"))
+
+
+def test_add_second_parent_raises():
+    """A node may have only one incoming edge."""
+    tree = _two_link_tree()
+    with pytest.raises(ValueError):
+        tree.add_edge(Edge("world", "link2", FixedJoint(name="dup")))

--- a/prpl-kinematics/tests/test_state.py
+++ b/prpl-kinematics/tests/test_state.py
@@ -1,0 +1,44 @@
+"""Unit tests for KinematicState snapshots."""
+
+from prpl_kinematics.tree import (
+    Edge,
+    KinematicState,
+    KinematicTree,
+    Node,
+    PlanarJoint,
+    RevoluteJoint,
+)
+
+
+def _base_and_arm_tree() -> KinematicTree:
+    """World -[planar base]-> base -[revolute arm]-> arm."""
+    tree = KinematicTree()
+    tree.add_node(Node("base"))
+    tree.add_node(Node("arm"))
+    tree.add_edge(Edge("world", "base", PlanarJoint(name="base_joint")))
+    tree.add_edge(Edge("base", "arm", RevoluteJoint(name="arm_joint")))
+    return tree
+
+
+def test_state_captures_all_actuated_joints():
+    """A snapshot records every actuated joint, preserving multi-DOF values."""
+    tree = _base_and_arm_tree()
+    config = {"base_joint": [1.0, 2.0, 0.5], "arm_joint": [0.3]}
+    state = KinematicState.from_tree(tree, config)
+    assert set(state.joint_values) == {"base_joint", "arm_joint"}
+    assert state.joint_values["base_joint"] == (1.0, 2.0, 0.5)
+
+
+def test_state_defaults_absent_joints_to_zero():
+    """Joints missing from the config are snapshotted at their zero values."""
+    tree = _base_and_arm_tree()
+    state = KinematicState.from_tree(tree, {"arm_joint": [0.3]})
+    assert state.joint_values["base_joint"] == (0.0, 0.0, 0.0)
+
+
+def test_state_round_trips_to_configuration():
+    """as_configuration reproduces a usable forward-kinematics config."""
+    tree = _base_and_arm_tree()
+    config = {"base_joint": [1.0, 2.0, 0.5], "arm_joint": [0.3]}
+    state = KinematicState.from_tree(tree, config)
+    assert state.as_configuration() == config

--- a/prpl-kinematics/tests/test_transforms.py
+++ b/prpl-kinematics/tests/test_transforms.py
@@ -1,0 +1,34 @@
+"""Unit tests for spatialmath <-> PyBullet pose conversions."""
+
+import numpy as np
+from spatialmath import SE3
+
+from prpl_kinematics.geometry import pose_from_pybullet, pose_to_pybullet
+
+
+def test_identity_orientation_round_trip():
+    """A pure translation with identity orientation round-trips exactly."""
+    position = (1.0, 2.0, 3.0)
+    orientation = (0.0, 0.0, 0.0, 1.0)
+    pose = pose_from_pybullet(position, orientation)
+    assert np.allclose(pose.t, position)
+    assert np.allclose(pose.R, np.eye(3))
+    out_position, out_orientation = pose_to_pybullet(pose)
+    assert np.allclose(out_position, position)
+    assert np.allclose(out_orientation, orientation)
+
+
+def test_z_rotation_maps_x_to_y():
+    """A 90-degree rotation about +z sends the +x axis to +y."""
+    half_sqrt2 = np.sqrt(2) / 2
+    pose = pose_from_pybullet((0.0, 0.0, 0.0), (0.0, 0.0, half_sqrt2, half_sqrt2))
+    rotated = pose.R @ np.array([1.0, 0.0, 0.0])
+    assert np.allclose(rotated, [0.0, 1.0, 0.0], atol=1e-6)
+
+
+def test_arbitrary_pose_round_trip():
+    """An arbitrary SE3 survives a round-trip through PyBullet conventions."""
+    pose = SE3.Rt(SE3.RPY([0.3, -0.7, 1.1]).R, [0.5, -1.0, 2.0])
+    position, orientation = pose_to_pybullet(pose)
+    recovered = pose_from_pybullet(position, orientation)
+    assert np.allclose(recovered.A, pose.A, atol=1e-6)


### PR DESCRIPTION
## What

Adds a new monorepo package, **`prpl-kinematics`** — a ground-up successor to `pybullet-helpers`. It is kinematics-only and engine-agnostic, built around a general **`KinematicTree`** in which robot joints, mobile bases, and grasps are all just edges. Poses use `spatialmath` `SE3`/`SE2`; PyBullet is intended as a pluggable collision/render backend rather than the source of truth.

This PR lands only the **minimal, fully-tested core**. The remaining layers (loading, backends, IK, planning, robots, manipulation) are documented as milestones in `DESIGN.md` and will land incrementally, each with tests.

## What's included

- `geometry/transforms.py` — `pose_from_pybullet` / `pose_to_pybullet` (the only conversions needed at the PyBullet `xyzw` boundary; no homegrown Pose/Quaternion class).
- `tree/joints.py` — `Joint` ABC + `FixedJoint` (0-DOF), `RevoluteJoint`, `PrismaticJoint` (1-DOF), `PlanarJoint` (3-DOF); each maps joint values to an `SE3`.
- `tree/kinematic_tree.py` — `Node`, `Edge`, `KinematicTree` with forward kinematics, `relative_pose`, and `attach` (a grasp is re-parenting an object onto a gripper frame with a fixed transform).
- `tree/state.py` — `KinematicState` snapshot of actuated joint values.
- Package config matching monorepo conventions (`pyproject.toml`, `.pylintrc`, pylint plugin, CI scripts), plus `README.md` and `DESIGN.md`.

## Design decisions

| Decision | Choice |
|---|---|
| Package name / location | `prpl_kinematics`, in `prpl-mono` |
| Transform math | `spatialmath-python` |
| PyBullet's role | collision/render **backend** behind an interface (not built yet) |
| Source of truth | the `KinematicTree` (FK via spatialmath) |
| Proving-set robots | Panda, Kinova, Dexmate Vega (bimanual), TidyBot (mobile) |

## Testing

21 unit tests cover conversions, every joint type, FK propagation, grasp re-parenting (`relative_pose` recovers the grasp transform), and snapshotting. `./run_ci_checks.sh` passes locally: autoformat, `mypy` clean, `pylint` clean, all tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
