### PR TITLE
Add URDF loading and shape-soup rendering to prpl-kinematics

### DIFF
--- a/prpl-kinematics/.gitignore
+++ b/prpl-kinematics/.gitignore
@@ -1,0 +1,2 @@
+# Rendered video artifacts from --make-videos tests.
+*.mp4

--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -70,15 +70,21 @@ FK before running collision detection. Consequences:
 ## Layered structure (target)
 
 ```
-geometry/      spatialmath <-> external-convention conversions (PyBullet xyzw).   [built]
-tree/          KinematicTree, Joint types, FK, attach (grasp), KinematicState.    [built]
-loading/       URDF -> KinematicTree (via yourdfpy).                              [planned]
-backends/      CollisionBackend / Renderer ABCs; PyBullet impls (shape-soup).     [planned]
-ik/            InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.     [planned]
-planning/      ConfigurationSpace ABC + MotionPlanner ABC; BiRRT, OMPL.           [planned]
-robots/        Assemblies over a tree: SingleArm, Bimanual, MobileBase, MobileManip. [planned]
-manipulation/  Primitive ABC; Pick, Place with injected grasp generators.        [planned]
+geometry/        spatialmath <-> external-convention conversions (PyBullet xyzw). [built]
+tree/            KinematicTree, Joint types, FK, attach (grasp), KinematicState.  [built]
+loading/         URDF -> KinematicTree (via yourdfpy).                            [built]
+visualization.py PyBullet viewer: capture frames, save videos (--make-videos).   [built]
+backends/        CollisionBackend ABC; PyBullet impl (shape-soup).               [planned]
+ik/              InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.   [planned]
+planning/        ConfigurationSpace ABC + MotionPlanner ABC; BiRRT, OMPL.         [planned]
+robots/          Assemblies over a tree: SingleArm, Bimanual, MobileBase, MobileManip. [planned]
+manipulation/    Primitive ABC; Pick, Place with injected grasp generators.       [planned]
 ```
+
+The v1 visualizer drives PyBullet's own articulation to render a configuration
+(robust mesh handling); the tree's kinematics are validated independently by a
+forward-kinematics test that compares against PyBullet across random configs. A
+shape-soup `Renderer` on top of the collision backend may replace it later.
 
 The `ConfigurationSpace` abstraction (sample/distance/interpolate/is_valid) is
 what lets one planner work over joint space, an SE(2) base, or a Cartesian EE
@@ -96,15 +102,20 @@ The minimal, fully-tested core:
   `add_edge`, `forward_kinematics`, `relative_pose`, `attach`,
   `actuated_joint_names`, `joint`, `path_from_root`).
 - `tree.state` — `KinematicState` snapshot of actuated joint values.
+- `loading.urdf` — `load_urdf` (yourdfpy → tree).
+- `visualization` — `load_urdf_for_rendering`, `render_configurations`,
+  `capture_image`, `save_video`, plus the `--make-videos` test fixture.
 
-21 unit tests cover conversions, every joint type, FK propagation, grasp
-re-parenting, and snapshotting.
+Tests cover conversions, every joint type, FK propagation, grasp re-parenting,
+snapshotting, URDF loading, FK equivalence with PyBullet on Panda, and video
+rendering (a Panda joint sweep).
 
 ## Milestones (each adds code + tests)
 
 1. **Geometry + tree core** — done.
-2. **Loading** — `yourdfpy` URDF → tree; round-trip FK against a known robot.
-3. **Backends** — `CollisionBackend`/`Renderer` ABCs + shape-soup PyBullet impls.
+2. **Loading + visualization** — done. URDF → tree (FK validated against
+   PyBullet); `--make-videos` rendering pipeline.
+3. **Backends** — `CollisionBackend` ABC + shape-soup PyBullet impl.
 4. **IK** — `InverseKinematics` ABC; `NumericalIK` (Jacobian-DLS, folding in the
    ee-follow jitter fix), then `AnalyticIK` (EAIK/IKFast port).
 5. **Planning** — `ConfigurationSpace` + `MotionPlanner` ABC; `BiRRTPlanner`

--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -70,10 +70,10 @@ FK before running collision detection. Consequences:
 ## Layered structure (target)
 
 ```
-geometry/        spatialmath <-> external-convention conversions (PyBullet xyzw). [built]
+geometry/        spatialmath conversions (PyBullet xyzw) + shape specs.          [built]
 tree/            KinematicTree, Joint types, FK, attach (grasp), KinematicState.  [built]
-loading/         URDF -> KinematicTree (via yourdfpy).                            [built]
-visualization.py PyBullet viewer: capture frames, save videos (--make-videos).   [built]
+loading/         URDF -> KinematicTree with per-node geometry (via yourdfpy).     [built]
+visualization.py Shape-soup renderer (FK-driven), capture, video (--make-videos). [built]
 backends/        CollisionBackend ABC; PyBullet impl (shape-soup).               [planned]
 ik/              InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.   [planned]
 planning/        ConfigurationSpace ABC + MotionPlanner ABC; BiRRT, OMPL.         [planned]
@@ -81,10 +81,13 @@ robots/          Assemblies over a tree: SingleArm, Bimanual, MobileBase, Mobile
 manipulation/    Primitive ABC; Pick, Place with injected grasp generators.       [planned]
 ```
 
-The v1 visualizer drives PyBullet's own articulation to render a configuration
-(robust mesh handling); the tree's kinematics are validated independently by a
-forward-kinematics test that compares against PyBullet across random configs. A
-shape-soup `Renderer` on top of the collision backend may replace it later.
+The renderer is shape-soup: it creates one PyBullet visual body per node shape
+and positions every body from the tree's own forward kinematics, so a grasped
+object (re-parented in the tree) renders with no special handling and nothing
+relies on PyBullet's articulation. Meshes go through PyBullet's file importer;
+`.obj`/`.stl`/`.dae` pass through directly and other formats (e.g. `.glb`) are
+converted to `.obj` once via trimesh and cached on disk. The same per-shape,
+FK-positioned approach is what the collision backend will use.
 
 The `ConfigurationSpace` abstraction (sample/distance/interpolate/is_valid) is
 what lets one planner work over joint space, an SE(2) base, or a Cartesian EE
@@ -102,20 +105,22 @@ The minimal, fully-tested core:
   `add_edge`, `forward_kinematics`, `relative_pose`, `attach`,
   `actuated_joint_names`, `joint`, `path_from_root`).
 - `tree.state` — `KinematicState` snapshot of actuated joint values.
-- `loading.urdf` — `load_urdf` (yourdfpy → tree).
-- `visualization` — `load_urdf_for_rendering`, `render_configurations`,
-  `capture_image`, `save_video`, plus the `--make-videos` test fixture.
+- `geometry.shapes` — `MeshShape`/`BoxShape`/`CylinderShape`/`SphereShape`.
+- `loading.urdf` — `load_urdf` (yourdfpy → tree, with per-node geometry).
+- `visualization` — `PyBulletRenderer`, `render_configurations`, `capture_image`,
+  `save_video`, `to_pybullet_mesh`, plus the `--make-videos` test fixture.
 
 Tests cover conversions, every joint type, FK propagation, grasp re-parenting,
-snapshotting, URDF loading, FK equivalence with PyBullet on Panda, and video
-rendering (a Panda joint sweep).
+snapshotting, URDF loading, FK equivalence with PyBullet on Panda, `.glb` mesh
+conversion, and shape-soup rendering.
 
 ## Milestones (each adds code + tests)
 
 1. **Geometry + tree core** — done.
-2. **Loading + visualization** — done. URDF → tree (FK validated against
-   PyBullet); `--make-videos` rendering pipeline.
-3. **Backends** — `CollisionBackend` ABC + shape-soup PyBullet impl.
+2. **Loading + visualization** — done. URDF → tree with geometry (FK validated
+   against PyBullet); shape-soup FK-driven renderer + `--make-videos` pipeline.
+3. **Backends** — `CollisionBackend` ABC + shape-soup PyBullet impl (same
+   per-shape FK positioning as the renderer; adds allowed-self-collision pairs).
 4. **IK** — `InverseKinematics` ABC; `NumericalIK` (Jacobian-DLS, folding in the
    ee-follow jitter fix), then `AnalyticIK` (EAIK/IKFast port).
 5. **Planning** — `ConfigurationSpace` + `MotionPlanner` ABC; `BiRRTPlanner`

--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
    "numpy>=1.23.5,<2.0",
    "scipy>=1.10",
    "spatialmath-python>=1.1.10",
+   "yourdfpy>=0.0.56",
+   "pybullet-arm64>=3.2.8",
+   "imageio>=2.30",
 ]
 
 [project.optional-dependencies]
@@ -58,10 +61,12 @@ exclude = ["venv/*", ".venv/*", "build", "dist", "third_party", "third-party", "
 [[tool.mypy.overrides]]
 module = [
     "pybullet.*",
+    "pybullet_data.*",
     "pybullet_utils.*",
     "scipy.*",
     "spatialmath.*",
     "yourdfpy.*",
+    "imageio.*",
     "eaik.*",
     "ompl.*",
 ]

--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
    "scipy>=1.10",
    "spatialmath-python>=1.1.10",
    "yourdfpy>=0.0.56",
+   "trimesh>=4.0",
    "pybullet-arm64>=3.2.8",
    "imageio>=2.30",
 ]
@@ -66,6 +67,7 @@ module = [
     "scipy.*",
     "spatialmath.*",
     "yourdfpy.*",
+    "trimesh.*",
     "imageio.*",
     "eaik.*",
     "ompl.*",

--- a/prpl-kinematics/src/prpl_kinematics/geometry/shapes.py
+++ b/prpl-kinematics/src/prpl_kinematics/geometry/shapes.py
@@ -1,0 +1,50 @@
+"""Geometry shapes attached to KinematicTree nodes.
+
+Each shape carries an ``origin`` (the link-frame to shape-frame transform) and
+its parameters. Backends turn these into PyBullet collision/visual shapes; the
+tree itself never interprets them. A node may hold several visual and several
+collision shapes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from spatialmath import SE3
+
+
+@dataclass(frozen=True)
+class MeshShape:
+    """A triangle mesh loaded from ``filename`` (any trimesh-readable format)."""
+
+    filename: str
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    origin: SE3 = field(default_factory=SE3)
+
+
+@dataclass(frozen=True)
+class BoxShape:
+    """An axis-aligned box specified by its full-extent ``size``."""
+
+    size: tuple[float, float, float]
+    origin: SE3 = field(default_factory=SE3)
+
+
+@dataclass(frozen=True)
+class CylinderShape:
+    """A cylinder of the given ``radius`` and ``length`` along its local +z."""
+
+    radius: float
+    length: float
+    origin: SE3 = field(default_factory=SE3)
+
+
+@dataclass(frozen=True)
+class SphereShape:
+    """A sphere of the given ``radius``."""
+
+    radius: float
+    origin: SE3 = field(default_factory=SE3)
+
+
+Shape = MeshShape | BoxShape | CylinderShape | SphereShape

--- a/prpl-kinematics/src/prpl_kinematics/loading/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/loading/__init__.py
@@ -1,0 +1,5 @@
+"""Model loading: build a KinematicTree from a URDF."""
+
+from prpl_kinematics.loading.urdf import load_urdf
+
+__all__ = ["load_urdf"]

--- a/prpl-kinematics/src/prpl_kinematics/loading/urdf.py
+++ b/prpl-kinematics/src/prpl_kinematics/loading/urdf.py
@@ -1,17 +1,27 @@
 """Load a URDF into a KinematicTree.
 
 Parsing is delegated to ``yourdfpy`` (pure-Python, lazy mesh loading); this
-module maps its link/joint graph onto our ``Node``/``Edge``/``Joint`` types.
+module maps its link/joint graph onto our ``Node``/``Edge``/``Joint`` types and
+attaches each link's visual and collision geometry to its node.
 """
 
 from __future__ import annotations
 
 import math
+import os
+from collections.abc import Callable
 from pathlib import Path
 
 import yourdfpy
 from spatialmath import SE3
 
+from prpl_kinematics.geometry.shapes import (
+    BoxShape,
+    CylinderShape,
+    MeshShape,
+    Shape,
+    SphereShape,
+)
 from prpl_kinematics.tree.joints import (
     FixedJoint,
     Joint,
@@ -24,19 +34,21 @@ from prpl_kinematics.tree.kinematic_tree import Edge, KinematicTree, Node
 def load_urdf(path: Path | str, root: str | None = None) -> KinematicTree:
     """Build a ``KinematicTree`` from a URDF file.
 
-    URDF links become nodes and joints become edges. ``revolute`` and
-    ``prismatic`` joints carry their position limits; ``continuous`` maps to an
-    unlimited revolute joint; ``fixed`` becomes a zero-DOF joint. Each joint's
-    ``origin`` is taken from the URDF joint frame. ``planar`` and ``floating``
-    URDF joints are not supported.
+    URDF links become nodes (carrying their visual and collision geometry) and
+    joints become edges. ``revolute`` and ``prismatic`` joints carry their
+    position limits; ``continuous`` maps to an unlimited revolute joint;
+    ``fixed`` becomes a zero-DOF joint. Each joint's ``origin`` is taken from the
+    URDF joint frame. ``planar`` and ``floating`` URDF joints are not supported.
 
     ``root`` defaults to the URDF's base link.
     """
+    handler = _make_filename_handler(path)
     urdf = yourdfpy.URDF.load(
         str(path),
         load_meshes=False,
         build_scene_graph=True,
         build_collision_scene_graph=False,
+        filename_handler=handler,
     )
     base = root if root is not None else urdf.base_link
     tree = KinematicTree(root=base)
@@ -47,7 +59,25 @@ def load_urdf(path: Path | str, root: str | None = None) -> KinematicTree:
         tree.add_edge(
             Edge(parent=joint.parent, child=joint.child, joint=_convert_joint(joint))
         )
+    for link_name, link in urdf.link_map.items():
+        node = tree.nodes[link_name]
+        node.visuals = [_convert_geometry(v, handler) for v in link.visuals]
+        node.collisions = [_convert_geometry(c, handler) for c in link.collisions]
     return tree
+
+
+def _make_filename_handler(path: Path | str) -> Callable[[str], str]:
+    directory = os.path.dirname(os.path.abspath(str(path)))
+    prefix = "package://"
+
+    def handler(filename: str) -> str:
+        if filename.startswith(prefix):
+            return os.path.join(directory, filename[len(prefix) :])
+        if os.path.isabs(filename):
+            return filename
+        return os.path.join(directory, filename)
+
+    return handler
 
 
 def _convert_joint(joint: yourdfpy.Joint) -> Joint:
@@ -76,3 +106,31 @@ def _convert_joint(joint: yourdfpy.Joint) -> Joint:
             name=joint.name, origin=origin, axis=axis, lower=-math.inf, upper=math.inf
         )
     raise ValueError(f"Unsupported URDF joint type: {joint.type}")
+
+
+def _convert_geometry(element: yourdfpy.Visual, handler: Callable[[str], str]) -> Shape:
+    origin = SE3(element.origin, check=False) if element.origin is not None else SE3()
+    geometry = element.geometry
+    if geometry.box is not None:
+        box = geometry.box.size
+        size = (float(box[0]), float(box[1]), float(box[2]))
+        return BoxShape(size=size, origin=origin)
+    if geometry.cylinder is not None:
+        return CylinderShape(
+            radius=float(geometry.cylinder.radius),
+            length=float(geometry.cylinder.length),
+            origin=origin,
+        )
+    if geometry.sphere is not None:
+        return SphereShape(radius=float(geometry.sphere.radius), origin=origin)
+    if geometry.mesh is not None:
+        raw = geometry.mesh.scale
+        scale = (
+            (1.0, 1.0, 1.0)
+            if raw is None
+            else (float(raw[0]), float(raw[1]), float(raw[2]))
+        )
+        return MeshShape(
+            filename=handler(geometry.mesh.filename), scale=scale, origin=origin
+        )
+    raise ValueError("URDF geometry has no recognized shape")

--- a/prpl-kinematics/src/prpl_kinematics/loading/urdf.py
+++ b/prpl-kinematics/src/prpl_kinematics/loading/urdf.py
@@ -1,0 +1,78 @@
+"""Load a URDF into a KinematicTree.
+
+Parsing is delegated to ``yourdfpy`` (pure-Python, lazy mesh loading); this
+module maps its link/joint graph onto our ``Node``/``Edge``/``Joint`` types.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import yourdfpy
+from spatialmath import SE3
+
+from prpl_kinematics.tree.joints import (
+    FixedJoint,
+    Joint,
+    PrismaticJoint,
+    RevoluteJoint,
+)
+from prpl_kinematics.tree.kinematic_tree import Edge, KinematicTree, Node
+
+
+def load_urdf(path: Path | str, root: str | None = None) -> KinematicTree:
+    """Build a ``KinematicTree`` from a URDF file.
+
+    URDF links become nodes and joints become edges. ``revolute`` and
+    ``prismatic`` joints carry their position limits; ``continuous`` maps to an
+    unlimited revolute joint; ``fixed`` becomes a zero-DOF joint. Each joint's
+    ``origin`` is taken from the URDF joint frame. ``planar`` and ``floating``
+    URDF joints are not supported.
+
+    ``root`` defaults to the URDF's base link.
+    """
+    urdf = yourdfpy.URDF.load(
+        str(path),
+        load_meshes=False,
+        build_scene_graph=True,
+        build_collision_scene_graph=False,
+    )
+    base = root if root is not None else urdf.base_link
+    tree = KinematicTree(root=base)
+    for link_name in urdf.link_map:
+        if link_name != base:
+            tree.add_node(Node(link_name))
+    for joint in urdf.robot.joints:
+        tree.add_edge(
+            Edge(parent=joint.parent, child=joint.child, joint=_convert_joint(joint))
+        )
+    return tree
+
+
+def _convert_joint(joint: yourdfpy.Joint) -> Joint:
+    origin = SE3(joint.origin, check=False)
+    if joint.type == "fixed":
+        return FixedJoint(name=joint.name, origin=origin)
+    axis = (float(joint.axis[0]), float(joint.axis[1]), float(joint.axis[2]))
+    if joint.type == "prismatic":
+        return PrismaticJoint(
+            name=joint.name,
+            origin=origin,
+            axis=axis,
+            lower=float(joint.limit.lower),
+            upper=float(joint.limit.upper),
+        )
+    if joint.type == "revolute":
+        return RevoluteJoint(
+            name=joint.name,
+            origin=origin,
+            axis=axis,
+            lower=float(joint.limit.lower),
+            upper=float(joint.limit.upper),
+        )
+    if joint.type == "continuous":
+        return RevoluteJoint(
+            name=joint.name, origin=origin, axis=axis, lower=-math.inf, upper=math.inf
+        )
+    raise ValueError(f"Unsupported URDF joint type: {joint.type}")

--- a/prpl-kinematics/src/prpl_kinematics/tree/joints.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/joints.py
@@ -17,11 +17,21 @@ import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
+import numpy as np
+from scipy.spatial.transform import Rotation
 from spatialmath import SE3
 
 JointValues = list[float]  # Length must equal ``num_dof``.
 
 Axis = tuple[float, float, float]
+
+
+def _rotation_about_axis(theta: float, axis: Axis) -> np.ndarray:
+    """3x3 rotation matrix for an angle ``theta`` about a (possibly unnormalized)
+    ``axis``."""
+    unit = np.asarray(axis, dtype=float)
+    unit = unit / np.linalg.norm(unit)
+    return Rotation.from_rotvec(theta * unit).as_matrix()
 
 
 @dataclass(frozen=True)
@@ -81,7 +91,7 @@ class RevoluteJoint(Joint):
 
     def transform(self, values: JointValues) -> SE3:
         (theta,) = values
-        return self.origin * SE3.AngVec(theta, self.axis)
+        return self.origin * SE3.Rt(_rotation_about_axis(theta, self.axis), [0, 0, 0])
 
     @property
     def lower_limits(self) -> list[float]:

--- a/prpl-kinematics/src/prpl_kinematics/tree/kinematic_tree.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/kinematic_tree.py
@@ -22,10 +22,11 @@ checking or rendering itself.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from spatialmath import SE3
 
+from prpl_kinematics.geometry.shapes import Shape
 from prpl_kinematics.tree.joints import FixedJoint, Joint, JointValues
 
 Configuration = Mapping[str, JointValues]
@@ -33,15 +34,16 @@ Configuration = Mapping[str, JointValues]
 
 @dataclass
 class Node:
-    """A named frame, optionally carrying collision/visual geometry.
+    """A named frame, optionally carrying visual and collision geometry.
 
-    ``geometry`` is an opaque handle (e.g. a path to a mesh or a primitive-shape
-    spec). The tree never interprets it; only consumers that render or check
-    collisions do.
+    ``visuals`` and ``collisions`` are shape lists in the node's own frame. The
+    tree never interprets them; only consumers that render or check collisions
+    do.
     """
 
     name: str
-    geometry: object | None = None
+    visuals: list[Shape] = field(default_factory=list)
+    collisions: list[Shape] = field(default_factory=list)
 
 
 @dataclass

--- a/prpl-kinematics/src/prpl_kinematics/visualization.py
+++ b/prpl-kinematics/src/prpl_kinematics/visualization.py
@@ -1,22 +1,35 @@
-"""PyBullet-based visualization: capture frames and save videos.
+"""PyBullet-based visualization: a shape-soup renderer, capture, and video.
 
-A lightweight viewer that drives PyBullet's own articulation to render a
-``KinematicTree`` configuration, so motion can be reviewed as video. The
-correctness of the tree's kinematics is established separately by
-forward-kinematics tests, not by this viewer.
+``PyBulletRenderer`` creates one PyBullet visual body per node shape and, each
+frame, positions every body from the tree's forward kinematics. Nothing uses
+PyBullet's articulation, so a grasped object (re-parented in the tree) renders
+correctly with no special handling.
+
+Meshes are fed to PyBullet's file importer. Formats it reads natively
+(``.obj``/``.stl``/``.dae``) are passed straight through; others (e.g. ``.glb``)
+are converted to ``.obj`` once via trimesh and cached on disk.
 """
 
 from __future__ import annotations
 
+import hashlib
+import os
+import tempfile
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from typing import Any
 
 import imageio.v2 as imageio
 import numpy as np
 import pybullet as p
+import trimesh
 
-from prpl_kinematics.tree.kinematic_tree import Configuration
+from prpl_kinematics.geometry.shapes import BoxShape, CylinderShape, MeshShape, Shape
+from prpl_kinematics.geometry.transforms import pose_to_pybullet
+from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
+
+_NATIVE_MESH_FORMATS = frozenset({".obj", ".stl", ".dae"})
+_MESH_CACHE_DIR = os.path.join(tempfile.gettempdir(), "prpl_kinematics_mesh_cache")
 
 
 @dataclass(frozen=True)
@@ -34,34 +47,92 @@ class CameraParams:
     far: float = 100.0
 
 
-def load_urdf_for_rendering(
-    physics_client_id: int, path: Path | str, fixed_base: bool = True
-) -> tuple[int, dict[str, int]]:
-    """Load a URDF into PyBullet for rendering.
+def to_pybullet_mesh(filename: str) -> str:
+    """Return a path to a PyBullet-loadable mesh for ``filename``.
 
-    Returns the body id and a map from joint name to PyBullet joint index.
+    Native formats are returned unchanged; others are converted to ``.obj`` via
+    trimesh and cached on disk by source path and modification time, so the
+    conversion is paid at most once per mesh.
     """
-    body = p.loadURDF(
-        str(path), useFixedBase=fixed_base, physicsClientId=physics_client_id
+    extension = os.path.splitext(filename)[1].lower()
+    if extension in _NATIVE_MESH_FORMATS:
+        return filename
+    os.makedirs(_MESH_CACHE_DIR, exist_ok=True)
+    key = f"{os.path.abspath(filename)}:{os.path.getmtime(filename)}"
+    cached = os.path.join(
+        _MESH_CACHE_DIR, hashlib.md5(key.encode()).hexdigest() + ".obj"
     )
-    joint_index: dict[str, int] = {}
-    for i in range(p.getNumJoints(body, physicsClientId=physics_client_id)):
-        info = p.getJointInfo(body, i, physicsClientId=physics_client_id)
-        joint_index[info[1].decode()] = i
-    return body, joint_index
+    if not os.path.exists(cached):
+        mesh: Any = trimesh.load(filename, force="mesh")
+        mesh.export(cached)
+    return cached
 
 
-def apply_configuration(
-    physics_client_id: int,
-    body: int,
-    joint_index: dict[str, int],
-    config: Configuration,
-) -> None:
-    """Reset the PyBullet joint states for the 1-DOF joints named in ``config``."""
-    for name, values in config.items():
-        if name in joint_index and len(values) == 1:
-            p.resetJointState(
-                body, joint_index[name], values[0], physicsClientId=physics_client_id
+def _create_visual_shape(physics_client_id: int, shape: Shape) -> int:
+    position, orientation = pose_to_pybullet(shape.origin)
+    common = {
+        "visualFramePosition": position,
+        "visualFrameOrientation": orientation,
+        "physicsClientId": physics_client_id,
+    }
+    if isinstance(shape, MeshShape):
+        return int(
+            p.createVisualShape(
+                p.GEOM_MESH,
+                fileName=to_pybullet_mesh(shape.filename),
+                meshScale=list(shape.scale),
+                **common,
+            )
+        )
+    if isinstance(shape, BoxShape):
+        half_extents = [shape.size[0] / 2, shape.size[1] / 2, shape.size[2] / 2]
+        return int(p.createVisualShape(p.GEOM_BOX, halfExtents=half_extents, **common))
+    if isinstance(shape, CylinderShape):
+        return int(
+            p.createVisualShape(
+                p.GEOM_CYLINDER, radius=shape.radius, length=shape.length, **common
+            )
+        )
+    return int(p.createVisualShape(p.GEOM_SPHERE, radius=shape.radius, **common))
+
+
+class PyBulletRenderer:
+    """Renders a KinematicTree by positioning per-shape visual bodies via FK."""
+
+    def __init__(self, physics_client_id: int) -> None:
+        self._physics_client_id = physics_client_id
+        self._tree: KinematicTree | None = None
+        self._bodies: list[tuple[int, str]] = []
+
+    @property
+    def physics_client_id(self) -> int:
+        """The PyBullet client this renderer draws into."""
+        return self._physics_client_id
+
+    def load(self, tree: KinematicTree) -> None:
+        """Create one visual body per node shape (positioned later by FK)."""
+        self._tree = tree
+        for name, node in tree.nodes.items():
+            for shape in node.visuals:
+                visual = _create_visual_shape(self._physics_client_id, shape)
+                body = int(
+                    p.createMultiBody(
+                        baseMass=0,
+                        baseVisualShapeIndex=visual,
+                        physicsClientId=self._physics_client_id,
+                    )
+                )
+                self._bodies.append((body, name))
+
+    def render(self, config: Configuration) -> None:
+        """Move every visual body to its node's world pose under ``config``."""
+        assert self._tree is not None, "call load() before render()"
+        for body, name in self._bodies:
+            position, orientation = pose_to_pybullet(
+                self._tree.forward_kinematics(name, config)
+            )
+            p.resetBasePositionAndOrientation(
+                body, position, orientation, physicsClientId=self._physics_client_id
             )
 
 
@@ -98,20 +169,18 @@ def capture_image(
 
 
 def render_configurations(
-    physics_client_id: int,
-    body: int,
-    joint_index: dict[str, int],
+    renderer: PyBulletRenderer,
     configs: Iterable[Configuration],
     camera: CameraParams = CameraParams(),
 ) -> list[np.ndarray]:
-    """Apply each configuration in turn and capture a frame."""
+    """Render each configuration and capture a frame."""
     frames = []
     for config in configs:
-        apply_configuration(physics_client_id, body, joint_index, config)
-        frames.append(capture_image(physics_client_id, camera))
+        renderer.render(config)
+        frames.append(capture_image(renderer.physics_client_id, camera))
     return frames
 
 
-def save_video(frames: Sequence[np.ndarray], path: Path | str, fps: int = 20) -> None:
+def save_video(frames: Sequence[np.ndarray], path: str, fps: int = 20) -> None:
     """Write captured frames to a video file."""
-    imageio.mimsave(str(path), list(frames), fps=fps)
+    imageio.mimsave(path, list(frames), fps=fps)

--- a/prpl-kinematics/src/prpl_kinematics/visualization.py
+++ b/prpl-kinematics/src/prpl_kinematics/visualization.py
@@ -1,0 +1,117 @@
+"""PyBullet-based visualization: capture frames and save videos.
+
+A lightweight viewer that drives PyBullet's own articulation to render a
+``KinematicTree`` configuration, so motion can be reviewed as video. The
+correctness of the tree's kinematics is established separately by
+forward-kinematics tests, not by this viewer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import imageio.v2 as imageio
+import numpy as np
+import pybullet as p
+
+from prpl_kinematics.tree.kinematic_tree import Configuration
+
+
+@dataclass(frozen=True)
+class CameraParams:
+    """Synthetic-camera settings for image capture."""
+
+    target: tuple[float, float, float] = (0.0, 0.0, 0.5)
+    distance: float = 1.5
+    yaw: float = 45.0
+    pitch: float = -30.0
+    width: int = 480
+    height: int = 360
+    fov: float = 60.0
+    near: float = 0.1
+    far: float = 100.0
+
+
+def load_urdf_for_rendering(
+    physics_client_id: int, path: Path | str, fixed_base: bool = True
+) -> tuple[int, dict[str, int]]:
+    """Load a URDF into PyBullet for rendering.
+
+    Returns the body id and a map from joint name to PyBullet joint index.
+    """
+    body = p.loadURDF(
+        str(path), useFixedBase=fixed_base, physicsClientId=physics_client_id
+    )
+    joint_index: dict[str, int] = {}
+    for i in range(p.getNumJoints(body, physicsClientId=physics_client_id)):
+        info = p.getJointInfo(body, i, physicsClientId=physics_client_id)
+        joint_index[info[1].decode()] = i
+    return body, joint_index
+
+
+def apply_configuration(
+    physics_client_id: int,
+    body: int,
+    joint_index: dict[str, int],
+    config: Configuration,
+) -> None:
+    """Reset the PyBullet joint states for the 1-DOF joints named in ``config``."""
+    for name, values in config.items():
+        if name in joint_index and len(values) == 1:
+            p.resetJointState(
+                body, joint_index[name], values[0], physicsClientId=physics_client_id
+            )
+
+
+def capture_image(
+    physics_client_id: int, camera: CameraParams = CameraParams()
+) -> np.ndarray:
+    """Capture an RGB image (H, W, 3) ``uint8`` from a synthetic camera."""
+    view = p.computeViewMatrixFromYawPitchRoll(
+        cameraTargetPosition=camera.target,
+        distance=camera.distance,
+        yaw=camera.yaw,
+        pitch=camera.pitch,
+        roll=0.0,
+        upAxisIndex=2,
+    )
+    projection = p.computeProjectionMatrixFOV(
+        fov=camera.fov,
+        aspect=camera.width / camera.height,
+        nearVal=camera.near,
+        farVal=camera.far,
+    )
+    _, _, rgba, _, _ = p.getCameraImage(
+        camera.width,
+        camera.height,
+        viewMatrix=view,
+        projectionMatrix=projection,
+        renderer=p.ER_TINY_RENDERER,
+        physicsClientId=physics_client_id,
+    )
+    image = np.reshape(
+        np.asarray(rgba, dtype=np.uint8), (camera.height, camera.width, 4)
+    )
+    return image[:, :, :3]
+
+
+def render_configurations(
+    physics_client_id: int,
+    body: int,
+    joint_index: dict[str, int],
+    configs: Iterable[Configuration],
+    camera: CameraParams = CameraParams(),
+) -> list[np.ndarray]:
+    """Apply each configuration in turn and capture a frame."""
+    frames = []
+    for config in configs:
+        apply_configuration(physics_client_id, body, joint_index, config)
+        frames.append(capture_image(physics_client_id, camera))
+    return frames
+
+
+def save_video(frames: Sequence[np.ndarray], path: Path | str, fps: int = 20) -> None:
+    """Write captured frames to a video file."""
+    imageio.mimsave(str(path), list(frames), fps=fps)

--- a/prpl-kinematics/tests/conftest.py
+++ b/prpl-kinematics/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Common fixtures for the prpl_kinematics tests."""
+
+import pybullet as p
+import pytest
+
+
+def pytest_addoption(parser):
+    """Register custom command-line options."""
+    parser.addoption(
+        "--make-videos",
+        action="store_true",
+        default=False,
+        help="Render videos for tests that support visualization.",
+    )
+
+
+@pytest.fixture(name="make_videos")
+def _make_videos(request) -> bool:
+    """Whether tests that support visualization should render a video."""
+    return bool(request.config.getoption("--make-videos"))
+
+
+@pytest.fixture(name="physics_client_id")
+def _physics_client_id():
+    """A headless PyBullet client, disconnected on teardown."""
+    physics_client_id = p.connect(p.DIRECT)
+    yield physics_client_id
+    p.disconnect(physics_client_id)

--- a/prpl-kinematics/tests/test_urdf_loading.py
+++ b/prpl-kinematics/tests/test_urdf_loading.py
@@ -1,0 +1,72 @@
+"""Unit tests for URDF loading and forward-kinematics correctness."""
+
+import os
+
+import numpy as np
+import pybullet as p
+import pybullet_data
+from scipy.spatial.transform import Rotation
+
+from prpl_kinematics.loading import load_urdf
+from prpl_kinematics.tree.joints import FixedJoint, PrismaticJoint, RevoluteJoint
+
+
+def _panda_path() -> str:
+    return os.path.join(pybullet_data.getDataPath(), "franka_panda", "panda.urdf")
+
+
+def test_load_urdf_structure():
+    """Loading Panda yields the expected root, actuated joints, and joint types."""
+    tree = load_urdf(_panda_path())
+    assert tree.root == "panda_link0"
+    assert tree.actuated_joint_names() == [
+        "panda_joint1",
+        "panda_joint2",
+        "panda_joint3",
+        "panda_joint4",
+        "panda_joint5",
+        "panda_joint6",
+        "panda_joint7",
+        "panda_finger_joint1",
+        "panda_finger_joint2",
+    ]
+    assert isinstance(tree.joint("panda_joint1"), RevoluteJoint)
+    assert isinstance(tree.joint("panda_finger_joint1"), PrismaticJoint)
+    assert isinstance(tree.joint("panda_hand_joint"), FixedJoint)
+
+
+def test_forward_kinematics_matches_pybullet(physics_client_id):
+    """Tree FK agrees with PyBullet's link poses across random configurations."""
+    path = _panda_path()
+    tree = load_urdf(path)
+    body = p.loadURDF(path, useFixedBase=True, physicsClientId=physics_client_id)
+    joint_index = {}
+    link_index = {}
+    for i in range(p.getNumJoints(body, physicsClientId=physics_client_id)):
+        info = p.getJointInfo(body, i, physicsClientId=physics_client_id)
+        joint_index[info[1].decode()] = i
+        link_index[info[12].decode()] = i
+
+    rng = np.random.default_rng(123)
+    for _ in range(5):
+        config = {}
+        for name in tree.actuated_joint_names():
+            joint = tree.joint(name)
+            lo = max(joint.lower_limits[0], -3.0)
+            hi = min(joint.upper_limits[0], 3.0)
+            value = float(rng.uniform(lo, hi))
+            config[name] = [value]
+            p.resetJointState(
+                body, joint_index[name], value, physicsClientId=physics_client_id
+            )
+        for link_name, index in link_index.items():
+            ours = tree.forward_kinematics(link_name, config)
+            state = p.getLinkState(
+                body,
+                index,
+                computeForwardKinematics=True,
+                physicsClientId=physics_client_id,
+            )
+            assert np.allclose(ours.t, state[4], atol=1e-5)
+            pybullet_rotation = Rotation.from_quat(state[5]).as_matrix()
+            assert np.allclose(ours.R, pybullet_rotation, atol=1e-5)

--- a/prpl-kinematics/tests/test_visualization.py
+++ b/prpl-kinematics/tests/test_visualization.py
@@ -1,18 +1,21 @@
-"""Render a Panda joint sweep, exercising the --make-videos pattern."""
+"""Shape-soup rendering tests, exercising the --make-videos pattern."""
 
 import os
 
 import numpy as np
+import pybullet as p
 import pybullet_data
 import pytest
+import trimesh
 
 from prpl_kinematics.loading import load_urdf
 from prpl_kinematics.tree.kinematic_tree import KinematicTree
 from prpl_kinematics.visualization import (
     CameraParams,
-    load_urdf_for_rendering,
+    PyBulletRenderer,
     render_configurations,
     save_video,
+    to_pybullet_mesh,
 )
 
 
@@ -26,29 +29,49 @@ def _sweep_configs(tree: KinematicTree, num_steps: int) -> list[dict[str, list[f
     configs = []
     for step in range(num_steps):
         phase = 2 * np.pi * step / num_steps
-        config = {}
+        config: dict[str, list[float]] = {}
         for k, name in enumerate(names):
             joint = tree.joint(name)
             lo = max(joint.lower_limits[0], -2.5)
             hi = min(joint.upper_limits[0], 2.5)
             mid = 0.5 * (lo + hi)
             amplitude = 0.4 * (hi - lo)
-            config[name] = [mid + amplitude * np.sin(phase + k)]
+            config[name] = [mid + amplitude * float(np.sin(phase + k))]
         configs.append(config)
     return configs
 
 
-def test_panda_sweep_renders_frames(physics_client_id):
-    """Rendering yields correctly shaped RGB frames (runs without --make-videos)."""
-    tree = load_urdf(_panda_path())
-    body, joint_index = load_urdf_for_rendering(physics_client_id, _panda_path())
-    camera = CameraParams(distance=1.6, width=320, height=240)
-    frames = render_configurations(
-        physics_client_id, body, joint_index, _sweep_configs(tree, 4), camera
+def test_native_mesh_passthrough():
+    """Native mesh formats are returned unchanged, without conversion."""
+    assert to_pybullet_mesh("/some/dir/link.obj") == "/some/dir/link.obj"
+    assert to_pybullet_mesh("/some/dir/link.STL") == "/some/dir/link.STL"
+
+
+def test_glb_converted_to_loadable_obj(physics_client_id, tmp_path):
+    """A non-native .glb mesh is converted to a .obj that PyBullet can load."""
+    glb = tmp_path / "box.glb"
+    trimesh.creation.box((0.2, 0.2, 0.2)).export(str(glb))
+    obj = to_pybullet_mesh(str(glb))
+    assert obj.endswith(".obj")
+    assert os.path.exists(obj)
+    shape = p.createVisualShape(
+        p.GEOM_MESH, fileName=obj, physicsClientId=physics_client_id
     )
+    assert shape >= 0
+
+
+def test_panda_renders_frames(physics_client_id):
+    """The shape-soup renderer yields correctly shaped RGB frames."""
+    tree = load_urdf(_panda_path())
+    renderer = PyBulletRenderer(physics_client_id)
+    renderer.load(tree)
+    camera = CameraParams(distance=1.6, width=320, height=240)
+    frames = render_configurations(renderer, _sweep_configs(tree, 4), camera)
     assert len(frames) == 4
     assert frames[0].shape == (240, 320, 3)
     assert frames[0].dtype == np.uint8
+    # The robot occupies a non-trivial portion of the frame (not blank).
+    assert float((frames[0].sum(axis=2) < 720).mean()) > 0.01
 
 
 def test_panda_sweep_video(physics_client_id, make_videos):
@@ -56,10 +79,9 @@ def test_panda_sweep_video(physics_client_id, make_videos):
     if not make_videos:
         pytest.skip("pass --make-videos to render the video")
     tree = load_urdf(_panda_path())
-    body, joint_index = load_urdf_for_rendering(physics_client_id, _panda_path())
+    renderer = PyBulletRenderer(physics_client_id)
+    renderer.load(tree)
     camera = CameraParams(distance=1.6, width=480, height=360)
-    frames = render_configurations(
-        physics_client_id, body, joint_index, _sweep_configs(tree, 48), camera
-    )
+    frames = render_configurations(renderer, _sweep_configs(tree, 48), camera)
     save_video(frames, "panda_sweep.mp4", fps=20)
     assert os.path.exists("panda_sweep.mp4")

--- a/prpl-kinematics/tests/test_visualization.py
+++ b/prpl-kinematics/tests/test_visualization.py
@@ -1,0 +1,65 @@
+"""Render a Panda joint sweep, exercising the --make-videos pattern."""
+
+import os
+
+import numpy as np
+import pybullet_data
+import pytest
+
+from prpl_kinematics.loading import load_urdf
+from prpl_kinematics.tree.kinematic_tree import KinematicTree
+from prpl_kinematics.visualization import (
+    CameraParams,
+    load_urdf_for_rendering,
+    render_configurations,
+    save_video,
+)
+
+
+def _panda_path() -> str:
+    return os.path.join(pybullet_data.getDataPath(), "franka_panda", "panda.urdf")
+
+
+def _sweep_configs(tree: KinematicTree, num_steps: int) -> list[dict[str, list[float]]]:
+    """A gentle sinusoidal sweep of every actuated joint within its limits."""
+    names = tree.actuated_joint_names()
+    configs = []
+    for step in range(num_steps):
+        phase = 2 * np.pi * step / num_steps
+        config = {}
+        for k, name in enumerate(names):
+            joint = tree.joint(name)
+            lo = max(joint.lower_limits[0], -2.5)
+            hi = min(joint.upper_limits[0], 2.5)
+            mid = 0.5 * (lo + hi)
+            amplitude = 0.4 * (hi - lo)
+            config[name] = [mid + amplitude * np.sin(phase + k)]
+        configs.append(config)
+    return configs
+
+
+def test_panda_sweep_renders_frames(physics_client_id):
+    """Rendering yields correctly shaped RGB frames (runs without --make-videos)."""
+    tree = load_urdf(_panda_path())
+    body, joint_index = load_urdf_for_rendering(physics_client_id, _panda_path())
+    camera = CameraParams(distance=1.6, width=320, height=240)
+    frames = render_configurations(
+        physics_client_id, body, joint_index, _sweep_configs(tree, 4), camera
+    )
+    assert len(frames) == 4
+    assert frames[0].shape == (240, 320, 3)
+    assert frames[0].dtype == np.uint8
+
+
+def test_panda_sweep_video(physics_client_id, make_videos):
+    """With --make-videos, render the full sweep to panda_sweep.mp4 in the cwd."""
+    if not make_videos:
+        pytest.skip("pass --make-videos to render the video")
+    tree = load_urdf(_panda_path())
+    body, joint_index = load_urdf_for_rendering(physics_client_id, _panda_path())
+    camera = CameraParams(distance=1.6, width=480, height=360)
+    frames = render_configurations(
+        physics_client_id, body, joint_index, _sweep_configs(tree, 48), camera
+    )
+    save_video(frames, "panda_sweep.mp4", fps=20)
+    assert os.path.exists("panda_sweep.mp4")


### PR DESCRIPTION
## What

Gets `prpl-kinematics` to reviewable videos via the `--make-videos` pattern, with a **FK-driven shape-soup renderer** — robot joints, mobile bases, and grasps all render through the `KinematicTree`'s own forward kinematics; nothing relies on PyBullet's articulation.

## Included

- **`loading/urdf.py`** — `load_urdf`: `yourdfpy` → `KinematicTree`, mapping links→`Node`s (with visual + collision geometry) and joints→`Joint` edges (`revolute`/`prismatic` with limits, `continuous`→unlimited revolute, `fixed`→0-DOF). Resolves `package://` mesh paths.
- **`geometry/shapes.py`** — `Mesh`/`Box`/`Cylinder`/`Sphere` shape specs attached to nodes.
- **`visualization.py`** — `PyBulletRenderer` (one visual body per shape, positioned each frame by `tree.forward_kinematics`), `capture_image`, `render_configurations`, `save_video`, `to_pybullet_mesh`.
- **`tests/conftest.py`** — `--make-videos` option + headless `physics_client_id` fixture.

## Mesh handling (the interesting part)

A spike found PyBullet's programmatic `createVisualShape(vertices=…)` is capped (~8k verts / ~32k indices), which fails on high-poly meshes — but `createVisualShape(fileName=…)` uses PyBullet's file importer with **no cap**. So meshes go through the file importer: `.obj`/`.stl`/`.dae` pass straight through, and other formats (e.g. Vega's `.glb`) are converted to `.obj` **once** via trimesh and cached on disk. Native formats incur zero conversion; the one-time `.glb` conversion (~1.5s for all of Vega) is cached across runs.

## Correctness

- `test_urdf_loading.py`: tree `forward_kinematics` matches PyBullet `getLinkState` to **1e-5** on Panda across random configs.
- Verified end to end by rendering the full **bimanual Dexmate Vega** (22 `.glb` meshes, mobile base + torso + two arms) and Panda through the FK-driven renderer.

`./run_ci_checks.sh` passes (autoformat, mypy, pylint, pytest). Adds `yourdfpy`, `trimesh`, `pybullet-arm64`, `imageio`; `.gitignore` for `*.mp4`.

## Try it

```
cd prpl-kinematics
pytest tests/test_visualization.py --make-videos   # writes panda_sweep.mp4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
