### PR TITLE
Add shape-soup collision checking to prpl-kinematics

### DIFF
--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -73,8 +73,9 @@ FK before running collision detection. Consequences:
 geometry/        spatialmath conversions (PyBullet xyzw) + shape specs.          [built]
 tree/            KinematicTree, Joint types, FK, attach (grasp), KinematicState.  [built]
 loading/         URDF -> KinematicTree with per-node geometry (via yourdfpy).     [built]
+meshes.py        Prepare meshes for PyBullet's file importer (convert/cache).      [built]
 visualization.py Shape-soup renderer (FK-driven), capture, video (--make-videos). [built]
-backends/        CollisionBackend ABC; PyBullet impl (shape-soup).               [planned]
+collision.py     Shape-soup collision checker (FK-driven) + allowed pairs.         [built]
 ik/              InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.   [planned]
 planning/        ConfigurationSpace ABC + MotionPlanner ABC; BiRRT, OMPL.         [planned]
 robots/          Assemblies over a tree: SingleArm, Bimanual, MobileBase, MobileManip. [planned]
@@ -86,8 +87,14 @@ and positions every body from the tree's own forward kinematics, so a grasped
 object (re-parented in the tree) renders with no special handling and nothing
 relies on PyBullet's articulation. Meshes go through PyBullet's file importer;
 `.obj`/`.stl`/`.dae` pass through directly and other formats (e.g. `.glb`) are
-converted to `.obj` once via trimesh and cached on disk. The same per-shape,
-FK-positioned approach is what the collision backend will use.
+converted to `.obj` once via trimesh and cached on disk. The collision checker
+uses the same per-shape, FK-positioned approach: one collision body per shape,
+positioned by FK, with non-ignored body pairs tested via `getClosestPoints`. A
+grasped object (re-parented in the tree) collides with the environment for free.
+Same-node and tree-adjacent pairs are ignored; rest-overlapping pairs (an
+allowed-collision matrix) are discovered with `pairs_in_collision` and supplied
+to `ignore`. There is no `CollisionBackend` ABC yet — a planner takes a plain
+`config -> bool` callable; the ABC arrives with a second backend (e.g. FCL).
 
 The `ConfigurationSpace` abstraction (sample/distance/interpolate/is_valid) is
 what lets one planner work over joint space, an SE(2) base, or a Cartesian EE
@@ -107,20 +114,24 @@ The minimal, fully-tested core:
 - `tree.state` — `KinematicState` snapshot of actuated joint values.
 - `geometry.shapes` — `MeshShape`/`BoxShape`/`CylinderShape`/`SphereShape`.
 - `loading.urdf` — `load_urdf` (yourdfpy → tree, with per-node geometry).
+- `meshes` — `to_pybullet_mesh` (native passthrough + cached `.glb`→`.obj`).
 - `visualization` — `PyBulletRenderer`, `render_configurations`, `capture_image`,
-  `save_video`, `to_pybullet_mesh`, plus the `--make-videos` test fixture.
+  `save_video`, plus the `--make-videos` test fixture.
+- `collision` — `PyBulletCollisionChecker` (`in_collision`, `pairs_in_collision`,
+  `ignore`).
 
 Tests cover conversions, every joint type, FK propagation, grasp re-parenting,
 snapshotting, URDF loading, FK equivalence with PyBullet on Panda, `.glb` mesh
-conversion, and shape-soup rendering.
+conversion, shape-soup rendering, and collision checking (primitives, adjacency,
+attached-object-vs-environment, and Panda rest pose).
 
 ## Milestones (each adds code + tests)
 
 1. **Geometry + tree core** — done.
 2. **Loading + visualization** — done. URDF → tree with geometry (FK validated
    against PyBullet); shape-soup FK-driven renderer + `--make-videos` pipeline.
-3. **Backends** — `CollisionBackend` ABC + shape-soup PyBullet impl (same
-   per-shape FK positioning as the renderer; adds allowed-self-collision pairs).
+3. **Collision** — done. Shape-soup `PyBulletCollisionChecker` (FK-positioned
+   bodies, allowed-pair discovery); a grasped object collides for free.
 4. **IK** — `InverseKinematics` ABC; `NumericalIK` (Jacobian-DLS, folding in the
    ee-follow jitter fix), then `AnalyticIK` (EAIK/IKFast port).
 5. **Planning** — `ConfigurationSpace` + `MotionPlanner` ABC; `BiRRTPlanner`

--- a/prpl-kinematics/src/prpl_kinematics/collision.py
+++ b/prpl-kinematics/src/prpl_kinematics/collision.py
@@ -1,0 +1,139 @@
+"""PyBullet-based collision checking via shape-soup.
+
+One PyBullet collision body per node shape; each query positions every body from
+the tree's forward kinematics, then checks the non-ignored body pairs. Because
+bodies are positioned by FK, a grasped object (re-parented in the tree) collides
+with the environment for free.
+
+Pairs that are in contact by construction are ignored: shapes on the same node,
+and tree-adjacent (parent-child) node pairs. Some links' collision geometry also
+overlaps at rest without being adjacent; such pairs can be supplied up front or
+discovered with :meth:`PyBulletCollisionChecker.pairs_in_collision` and passed to
+:meth:`PyBulletCollisionChecker.ignore`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pybullet as p
+
+from prpl_kinematics.geometry.shapes import BoxShape, CylinderShape, MeshShape, Shape
+from prpl_kinematics.geometry.transforms import pose_to_pybullet
+from prpl_kinematics.meshes import to_pybullet_mesh
+from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
+
+
+def _create_collision_shape(physics_client_id: int, shape: Shape) -> int:
+    position, orientation = pose_to_pybullet(shape.origin)
+    common = {
+        "collisionFramePosition": position,
+        "collisionFrameOrientation": orientation,
+        "physicsClientId": physics_client_id,
+    }
+    if isinstance(shape, MeshShape):
+        return int(
+            p.createCollisionShape(
+                p.GEOM_MESH,
+                fileName=to_pybullet_mesh(shape.filename),
+                meshScale=list(shape.scale),
+                **common,
+            )
+        )
+    if isinstance(shape, BoxShape):
+        half_extents = [shape.size[0] / 2, shape.size[1] / 2, shape.size[2] / 2]
+        return int(
+            p.createCollisionShape(p.GEOM_BOX, halfExtents=half_extents, **common)
+        )
+    if isinstance(shape, CylinderShape):
+        return int(
+            p.createCollisionShape(
+                p.GEOM_CYLINDER, radius=shape.radius, height=shape.length, **common
+            )
+        )
+    return int(p.createCollisionShape(p.GEOM_SPHERE, radius=shape.radius, **common))
+
+
+class PyBulletCollisionChecker:
+    """Shape-soup collision checker for a KinematicTree."""
+
+    def __init__(
+        self,
+        physics_client_id: int,
+        ignored_pairs: Iterable[Iterable[str]] = (),
+    ) -> None:
+        self._physics_client_id = physics_client_id
+        self._tree: KinematicTree | None = None
+        self._bodies: list[tuple[int, str]] = []
+        self._ignored: set[frozenset[str]] = {frozenset(pair) for pair in ignored_pairs}
+
+    def load(self, tree: KinematicTree) -> None:
+        """Create one collision body per node shape and ignore adjacent pairs."""
+        self._tree = tree
+        for name, node in tree.nodes.items():
+            for shape in node.collisions:
+                collision = _create_collision_shape(self._physics_client_id, shape)
+                body = int(
+                    p.createMultiBody(
+                        baseMass=0,
+                        baseCollisionShapeIndex=collision,
+                        physicsClientId=self._physics_client_id,
+                    )
+                )
+                self._bodies.append((body, name))
+        for child in tree.nodes:
+            edges = tree.path_from_root(child)
+            if edges:
+                self._ignored.add(frozenset({edges[-1].parent, child}))
+
+    def ignore(self, pairs: Iterable[Iterable[str]]) -> None:
+        """Additionally ignore collisions between the given node-name pairs."""
+        for pair in pairs:
+            self._ignored.add(frozenset(pair))
+
+    def in_collision(self, config: Configuration, max_distance: float = 0.0) -> bool:
+        """Whether any non-ignored shape pair is within ``max_distance``."""
+        self._position(config)
+        for index, (body_a, node_a) in enumerate(self._bodies):
+            for body_b, node_b in self._bodies[index + 1 :]:
+                if node_a == node_b or frozenset({node_a, node_b}) in self._ignored:
+                    continue
+                if self._closest_points(body_a, body_b, max_distance):
+                    return True
+        return False
+
+    def pairs_in_collision(
+        self, config: Configuration, max_distance: float = 0.0
+    ) -> set[frozenset[str]]:
+        """All overlapping node-name pairs, ignoring only same-node shapes.
+
+        Useful for discovering rest-overlapping pairs to pass to :meth:`ignore`.
+        """
+        self._position(config)
+        found: set[frozenset[str]] = set()
+        for index, (body_a, node_a) in enumerate(self._bodies):
+            for body_b, node_b in self._bodies[index + 1 :]:
+                if node_a == node_b:
+                    continue
+                if self._closest_points(body_a, body_b, max_distance):
+                    found.add(frozenset({node_a, node_b}))
+        return found
+
+    def _position(self, config: Configuration) -> None:
+        assert self._tree is not None, "call load() before querying"
+        for body, name in self._bodies:
+            position, orientation = pose_to_pybullet(
+                self._tree.forward_kinematics(name, config)
+            )
+            p.resetBasePositionAndOrientation(
+                body, position, orientation, physicsClientId=self._physics_client_id
+            )
+
+    def _closest_points(self, body_a: int, body_b: int, max_distance: float) -> bool:
+        points = p.getClosestPoints(
+            body_a,
+            body_b,
+            distance=max_distance,
+            physicsClientId=self._physics_client_id,
+        )
+        return len(points) > 0

--- a/prpl-kinematics/src/prpl_kinematics/meshes.py
+++ b/prpl-kinematics/src/prpl_kinematics/meshes.py
@@ -1,0 +1,40 @@
+"""Prepare mesh files for PyBullet's file importer.
+
+PyBullet's file-based mesh loader (used by both the renderer and the collision
+checker) reads ``.obj``/``.stl``/``.dae`` natively and has no vertex-count limit,
+unlike the programmatic ``createVisualShape(vertices=...)`` path. Other formats
+(e.g. ``.glb``) are converted to ``.obj`` once via trimesh and cached on disk.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from typing import Any
+
+import trimesh
+
+_NATIVE_MESH_FORMATS = frozenset({".obj", ".stl", ".dae"})
+_MESH_CACHE_DIR = os.path.join(tempfile.gettempdir(), "prpl_kinematics_mesh_cache")
+
+
+def to_pybullet_mesh(filename: str) -> str:
+    """Return a path to a PyBullet-loadable mesh for ``filename``.
+
+    Native formats are returned unchanged; others are converted to ``.obj`` via
+    trimesh and cached on disk by source path and modification time, so the
+    conversion is paid at most once per mesh.
+    """
+    extension = os.path.splitext(filename)[1].lower()
+    if extension in _NATIVE_MESH_FORMATS:
+        return filename
+    os.makedirs(_MESH_CACHE_DIR, exist_ok=True)
+    key = f"{os.path.abspath(filename)}:{os.path.getmtime(filename)}"
+    cached = os.path.join(
+        _MESH_CACHE_DIR, hashlib.md5(key.encode()).hexdigest() + ".obj"
+    )
+    if not os.path.exists(cached):
+        mesh: Any = trimesh.load(filename, force="mesh")
+        mesh.export(cached)
+    return cached

--- a/prpl-kinematics/src/prpl_kinematics/visualization.py
+++ b/prpl-kinematics/src/prpl_kinematics/visualization.py
@@ -4,32 +4,21 @@
 frame, positions every body from the tree's forward kinematics. Nothing uses
 PyBullet's articulation, so a grasped object (re-parented in the tree) renders
 correctly with no special handling.
-
-Meshes are fed to PyBullet's file importer. Formats it reads natively
-(``.obj``/``.stl``/``.dae``) are passed straight through; others (e.g. ``.glb``)
-are converted to ``.obj`` once via trimesh and cached on disk.
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
-import tempfile
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import imageio.v2 as imageio
 import numpy as np
 import pybullet as p
-import trimesh
 
 from prpl_kinematics.geometry.shapes import BoxShape, CylinderShape, MeshShape, Shape
 from prpl_kinematics.geometry.transforms import pose_to_pybullet
+from prpl_kinematics.meshes import to_pybullet_mesh
 from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
-
-_NATIVE_MESH_FORMATS = frozenset({".obj", ".stl", ".dae"})
-_MESH_CACHE_DIR = os.path.join(tempfile.gettempdir(), "prpl_kinematics_mesh_cache")
 
 
 @dataclass(frozen=True)
@@ -45,27 +34,6 @@ class CameraParams:
     fov: float = 60.0
     near: float = 0.1
     far: float = 100.0
-
-
-def to_pybullet_mesh(filename: str) -> str:
-    """Return a path to a PyBullet-loadable mesh for ``filename``.
-
-    Native formats are returned unchanged; others are converted to ``.obj`` via
-    trimesh and cached on disk by source path and modification time, so the
-    conversion is paid at most once per mesh.
-    """
-    extension = os.path.splitext(filename)[1].lower()
-    if extension in _NATIVE_MESH_FORMATS:
-        return filename
-    os.makedirs(_MESH_CACHE_DIR, exist_ok=True)
-    key = f"{os.path.abspath(filename)}:{os.path.getmtime(filename)}"
-    cached = os.path.join(
-        _MESH_CACHE_DIR, hashlib.md5(key.encode()).hexdigest() + ".obj"
-    )
-    if not os.path.exists(cached):
-        mesh: Any = trimesh.load(filename, force="mesh")
-        mesh.export(cached)
-    return cached
 
 
 def _create_visual_shape(physics_client_id: int, shape: Shape) -> int:

--- a/prpl-kinematics/tests/test_collision.py
+++ b/prpl-kinematics/tests/test_collision.py
@@ -1,0 +1,81 @@
+"""Unit tests for PyBullet shape-soup collision checking."""
+
+import os
+
+import pybullet_data
+from spatialmath import SE3
+
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.geometry.shapes import BoxShape
+from prpl_kinematics.loading import load_urdf
+from prpl_kinematics.tree.joints import FixedJoint, PrismaticJoint
+from prpl_kinematics.tree.kinematic_tree import Edge, KinematicTree, Node
+
+
+def _box(name: str, size: float = 0.2) -> Node:
+    return Node(name, collisions=[BoxShape(size=(size, size, size))])
+
+
+def _two_box_tree() -> KinematicTree:
+    """World -[prismatic x]-> a(box); world -[fixed]-> b(box at origin)."""
+    tree = KinematicTree()
+    tree.add_node(_box("a"))
+    tree.add_node(_box("b"))
+    tree.add_edge(
+        Edge(
+            "world", "a", PrismaticJoint(name="slide", axis=(1, 0, 0), lower=0, upper=5)
+        )
+    )
+    tree.add_edge(Edge("world", "b", FixedJoint(name="fix_b", origin=SE3())))
+    return tree
+
+
+def test_boxes_collide_when_overlapping(physics_client_id):
+    """Two boxes collide when overlapping and not when separated."""
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(_two_box_tree())
+    assert checker.in_collision({"slide": [0.0]})
+    assert not checker.in_collision({"slide": [1.0]})
+
+
+def test_adjacent_links_ignored(physics_client_id):
+    """Overlapping parent-child links are ignored, but still reported raw."""
+    tree = KinematicTree()
+    tree.add_node(_box("l1"))
+    tree.add_node(_box("l2"))
+    tree.add_edge(Edge("world", "l1", FixedJoint(name="f1", origin=SE3())))
+    tree.add_edge(Edge("l1", "l2", FixedJoint(name="f2", origin=SE3(0.05, 0, 0))))
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(tree)
+    assert not checker.in_collision({})
+    assert frozenset({"l1", "l2"}) in checker.pairs_in_collision({})
+
+
+def test_explicitly_ignored_pair(physics_client_id):
+    """A non-adjacent overlapping pair can be explicitly allowed."""
+    checker = PyBulletCollisionChecker(physics_client_id, ignored_pairs=[("a", "b")])
+    checker.load(_two_box_tree())
+    assert not checker.in_collision({"slide": [0.0]})
+
+
+def test_attached_object_collides_with_environment(physics_client_id):
+    """A grasped object (attached in the tree) collides with the environment."""
+    tree = _two_box_tree()
+    tree.add_node(Node("held", collisions=[BoxShape(size=(0.1, 0.1, 0.1))]))
+    tree.attach("held", "a", SE3(-1, 0, 0))  # held trails 1m behind link a
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(tree)
+    # a at x=1 (clear of b), so the held object at x=0 is what overlaps b.
+    assert checker.in_collision({"slide": [1.0]})
+    assert not checker.in_collision({"slide": [3.0]})
+
+
+def test_panda_home_collision_free_with_allowed_pairs(physics_client_id):
+    """Panda's rest pose is collision-free once rest-overlapping pairs are allowed."""
+    path = os.path.join(pybullet_data.getDataPath(), "franka_panda", "panda.urdf")
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(load_urdf(path))
+    resting = checker.pairs_in_collision({})
+    assert resting  # mesh collision shapes detect real rest overlaps
+    checker.ignore(resting)
+    assert not checker.in_collision({})


### PR DESCRIPTION
## What

Adds **shape-soup collision checking** to `prpl-kinematics`, mirroring the renderer: one PyBullet collision body per node shape, positioned each query by the tree's forward kinematics, with non-ignored body pairs tested via `getClosestPoints`. Because bodies are FK-positioned, **a grasped object (re-parented in the tree) collides with the environment for free** — the core grasp thesis, now in collision.

## Included

- **`collision.py`** — `PyBulletCollisionChecker` with `in_collision(config)`, `pairs_in_collision(config)`, and `ignore(pairs)`.
- **`meshes.py`** — factored `to_pybullet_mesh` out of `visualization` so collision can share the mesh-prep path without depending on the renderer.

## Allowed-collision matrix

Same-node and tree-adjacent (parent-child) pairs are ignored by default. But some links overlap at rest without being adjacent — e.g. Panda's `link7`/`hand`, separated only by a massless fixed `link8`. These are handled as an ACM: `pairs_in_collision(home)` discovers them and `ignore(...)` allows them. (No `CollisionBackend` ABC yet — a planner takes a plain `config -> bool` callable; the ABC arrives with a second backend like FCL.)

## Spike findings baked in

- `createCollisionShape(fileName=…)` is **uncapped** (loaded a 60k-vert mesh), so collision reuses the same mesh-import path as the renderer (convert-and-cache `.glb`, native passthrough otherwise).
- `getClosestPoints(distance=0)` returns points only on touch/penetration; separated bodies return none → `in_collision = any non-ignored pair returns points`.

## Testing

`./run_ci_checks.sh` passes (31 tests). Collision tests: overlapping vs separated primitives, adjacency ignored, explicit allowed pair, **attached-object-vs-environment**, and Panda rest pose collision-free once rest-overlapping pairs are allowed (exercises real mesh collision shapes).

This unblocks the BiRRT planner (which takes the checker as its collision callable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
