### PR TITLE
Add joint-space BiRRT motion planning to prpl-kinematics

### DIFF
--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -19,6 +19,15 @@ one milestone at a time, and **nothing lands without unit tests**.
 6. **Start minimal, add as we go.** Every class and method must be necessary
    *now* and covered by a unit test. Speculative abstractions live in this doc,
    not in code.
+7. **Configurations are name-keyed; joint groups are explicit.** A
+   `Configuration` is a `Mapping[str, JointValues]`, never a bare positional
+   vector whose length silently implies which joints it covers. "Does this
+   include the gripper?" is answered by which names are keys, not by counting
+   values. Flat vectors exist only *inside* a `JointSpace`, which always carries
+   its ordered name list. The gripper is just another named joint group, never a
+   special `finger_state` scalar — a lesson learned from pybullet-helpers, where
+   an ambiguous "robot joints" vector (7 vs 13) plus a bolted-on finger state
+   caused constant confusion.
 
 ## Decisions (locked)
 
@@ -77,7 +86,7 @@ meshes.py        Prepare meshes for PyBullet's file importer (convert/cache).   
 visualization.py Shape-soup renderer (FK-driven), capture, video (--make-videos). [built]
 collision.py     Shape-soup collision checker (FK-driven) + allowed pairs.         [built]
 ik/              InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.   [planned]
-planning/        ConfigurationSpace ABC + MotionPlanner ABC; BiRRT, OMPL.         [planned]
+planning/        JointSpace + BiRRTPlanner (over a config->bool callable); OMPL.   [built]
 robots/          Assemblies over a tree: SingleArm, Bimanual, MobileBase, MobileManip. [planned]
 manipulation/    Primitive ABC; Pick, Place with injected grasp generators.       [planned]
 ```
@@ -96,10 +105,16 @@ allowed-collision matrix) are discovered with `pairs_in_collision` and supplied
 to `ignore`. There is no `CollisionBackend` ABC yet — a planner takes a plain
 `config -> bool` callable; the ABC arrives with a second backend (e.g. FCL).
 
-The `ConfigurationSpace` abstraction (sample/distance/interpolate/is_valid) is
-what lets one planner work over joint space, an SE(2) base, or a Cartesian EE
-target uniformly. Robots are composition over a tree (named joint groups, an EE
-link, a home config), not an inheritance tower.
+A `JointSpace` is a group of actuated joints in a fixed order, supplying the
+sample/distance/interpolate operations a sampling planner needs plus conversion
+between a flat coordinate vector and a `Configuration`. `BiRRTPlanner` adapts the
+generic `BiRRT` from `prpl_utils` to it, taking a plain `config -> bool`
+collision callable (the checker satisfies this) and holding non-planned joints
+fixed at the start configuration. There is no `MotionPlanner` or
+`ConfigurationSpace` ABC yet; the abstraction (so one planner spans joint space,
+an SE(2) base, or a Cartesian EE target) arrives with the second planner (OMPL).
+Robots are composition over a tree (named joint groups, an EE link, a home
+config), not an inheritance tower.
 
 ## What is built today
 
@@ -119,11 +134,14 @@ The minimal, fully-tested core:
   `save_video`, plus the `--make-videos` test fixture.
 - `collision` — `PyBulletCollisionChecker` (`in_collision`, `pairs_in_collision`,
   `ignore`).
+- `planning` — `JointSpace` (sample/distance/interpolate, vector<->config) and
+  `BiRRTPlanner` (collision-free joint-space paths via `prpl_utils.BiRRT`).
 
 Tests cover conversions, every joint type, FK propagation, grasp re-parenting,
 snapshotting, URDF loading, FK equivalence with PyBullet on Panda, `.glb` mesh
-conversion, shape-soup rendering, and collision checking (primitives, adjacency,
-attached-object-vs-environment, and Panda rest pose).
+conversion, shape-soup rendering, collision checking (primitives, adjacency,
+attached-object-vs-environment, and Panda rest pose), and BiRRT planning (joint-
+space geometry, steering around an obstacle, and a Panda plan around a block).
 
 ## Milestones (each adds code + tests)
 
@@ -134,7 +152,12 @@ attached-object-vs-environment, and Panda rest pose).
    bodies, allowed-pair discovery); a grasped object collides for free.
 4. **IK** — `InverseKinematics` ABC; `NumericalIK` (Jacobian-DLS, folding in the
    ee-follow jitter fix), then `AnalyticIK` (EAIK/IKFast port).
-5. **Planning** — `ConfigurationSpace` + `MotionPlanner` ABC; `BiRRTPlanner`
-   (wrapping `prpl_utils`), then `OMPLPlanner`.
-6. **Robots** — port Panda, Kinova, Dexmate Vega, TidyBot as assemblies.
+5. **Planning** — `JointSpace` + `BiRRTPlanner` (wrapping `prpl_utils`) over a
+   `config -> bool` callable — done. `OMPLPlanner` next, extracting the
+   `MotionPlanner`/`ConfigurationSpace` ABCs once a second implementation exists.
+6. **Robots** — port Panda, Kinova, Dexmate Vega, TidyBot as assemblies. Each
+   exposes *explicitly named* joint groups (e.g. `"arm"`, `"gripper"`) as
+   `JointSpace`s plus an EE link and home config — never a single ambiguous "the
+   robot's joints" vector, and the gripper is a group, not a `finger_state`
+   scalar (principle 7).
 7. **Manipulation** — `Pick`/`Place` on the new stack.

--- a/prpl-kinematics/prpl_requirements.txt
+++ b/prpl-kinematics/prpl_requirements.txt
@@ -1,2 +1,2 @@
 # Other packages in prpl-mono that are required by this one.
-# (None currently.)
+../prpl-utils

--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
    "numpy>=1.23.5,<2.0",
    "scipy>=1.10",
+   "prpl_utils>=0.0.1",
    "spatialmath-python>=1.1.10",
    "yourdfpy>=0.0.56",
    "trimesh>=4.0",

--- a/prpl-kinematics/src/prpl_kinematics/planning/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/__init__.py
@@ -1,0 +1,6 @@
+"""Motion planning: a joint-space view of a tree and planners over it."""
+
+from prpl_kinematics.planning.birrt import BiRRTPlanner
+from prpl_kinematics.planning.joint_space import JointSpace
+
+__all__ = ["BiRRTPlanner", "JointSpace"]

--- a/prpl-kinematics/src/prpl_kinematics/planning/birrt.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/birrt.py
@@ -1,0 +1,68 @@
+"""Bidirectional RRT motion planning over a JointSpace.
+
+``BiRRTPlanner`` adapts the generic ``BiRRT`` from ``prpl_utils`` to a
+:class:`~prpl_kinematics.planning.joint_space.JointSpace`: states are flat
+coordinate vectors, and a collision test on a vector is the user-supplied
+``config -> bool`` callable evaluated on the full configuration (the planned
+joints merged over the start configuration, so non-planned joints stay fixed).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+from prpl_utils.motion_planning import BiRRT
+
+from prpl_kinematics.planning.joint_space import JointSpace
+from prpl_kinematics.tree.kinematic_tree import Configuration
+
+
+class BiRRTPlanner:
+    """Plans a collision-free joint-space path with a bidirectional RRT."""
+
+    def __init__(
+        self,
+        space: JointSpace,
+        collision_fn: Callable[[Configuration], bool],
+        rng: np.random.Generator,
+        resolution: float = 0.05,
+        num_attempts: int = 10,
+        num_iters: int = 100,
+        smooth_amt: int = 50,
+    ) -> None:
+        self._space = space
+        self._collision_fn = collision_fn
+        self._rng = rng
+        self._resolution = resolution
+        self._num_attempts = num_attempts
+        self._num_iters = num_iters
+        self._smooth_amt = smooth_amt
+
+    def plan(
+        self, start: Configuration, goal: Configuration
+    ) -> list[Configuration] | None:
+        """Return a path of configurations from ``start`` to ``goal``, or ``None``.
+
+        Each returned configuration carries every joint of ``start``, with the
+        planned joints varied along the path.
+        """
+        base = dict(start)
+
+        def in_collision(vector: np.ndarray) -> bool:
+            return self._collision_fn({**base, **self._space.to_configuration(vector)})
+
+        rrt: BiRRT[np.ndarray] = BiRRT(
+            sample_fn=lambda _: self._space.sample(self._rng),
+            extend_fn=lambda a, b: self._space.interpolate(a, b, self._resolution),
+            collision_fn=in_collision,
+            distance_fn=self._space.distance,
+            rng=self._rng,
+            num_attempts=self._num_attempts,
+            num_iters=self._num_iters,
+            smooth_amt=self._smooth_amt,
+        )
+        path = rrt.query(self._space.to_vector(base), self._space.to_vector(dict(goal)))
+        if path is None:
+            return None
+        return [{**base, **self._space.to_configuration(v)} for v in path]

--- a/prpl-kinematics/src/prpl_kinematics/planning/joint_space.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/joint_space.py
@@ -1,0 +1,83 @@
+"""A joint-space view of a KinematicTree for motion planning.
+
+A :class:`JointSpace` is a group of actuated joints, in a fixed order, together
+with the geometry a sampling planner needs: the bounds to sample within, a
+distance metric, and straight-line interpolation. It also converts between a
+flat coordinate vector (what a planner manipulates) and a
+:class:`~prpl_kinematics.tree.kinematic_tree.Configuration` (what forward
+kinematics and collision checking consume).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+
+import numpy as np
+
+from prpl_kinematics.tree.joints import JointValues
+from prpl_kinematics.tree.kinematic_tree import KinematicTree
+
+
+class JointSpace:
+    """An ordered group of actuated joints with sampling and interpolation."""
+
+    def __init__(self, tree: KinematicTree, joint_names: Sequence[str]) -> None:
+        self._joint_names = list(joint_names)
+        lower: list[float] = []
+        upper: list[float] = []
+        self._dof_per_joint: list[int] = []
+        for name in self._joint_names:
+            joint = tree.joint(name)
+            lower.extend(joint.lower_limits)
+            upper.extend(joint.upper_limits)
+            self._dof_per_joint.append(joint.num_dof)
+        self._lower = np.asarray(lower, dtype=float)
+        self._upper = np.asarray(upper, dtype=float)
+
+    @property
+    def joint_names(self) -> list[str]:
+        """The joints spanned by this space, in coordinate order."""
+        return list(self._joint_names)
+
+    @property
+    def dimension(self) -> int:
+        """Total number of scalar coordinates across all joints."""
+        return int(self._lower.size)
+
+    def sample(self, rng: np.random.Generator) -> np.ndarray:
+        """A uniform random coordinate vector within the joint bounds."""
+        return rng.uniform(self._lower, self._upper)
+
+    def distance(self, a: np.ndarray, b: np.ndarray) -> float:
+        """Euclidean distance between two coordinate vectors."""
+        return float(np.linalg.norm(np.subtract(a, b)))
+
+    def interpolate(
+        self, a: np.ndarray, b: np.ndarray, resolution: float
+    ) -> Iterator[np.ndarray]:
+        """Yield waypoints stepping from ``a`` toward ``b`` (``a`` excluded).
+
+        Steps are at most ``resolution`` apart; the final waypoint is exactly
+        ``b``.
+        """
+        a = np.asarray(a, dtype=float)
+        b = np.asarray(b, dtype=float)
+        num_steps = max(1, int(np.ceil(self.distance(a, b) / resolution)))
+        for step in range(1, num_steps + 1):
+            yield a + (b - a) * (step / num_steps)
+
+    def to_configuration(self, vector: np.ndarray) -> dict[str, JointValues]:
+        """Split a coordinate vector into per-joint values."""
+        config: dict[str, JointValues] = {}
+        index = 0
+        for name, dof in zip(self._joint_names, self._dof_per_joint):
+            config[name] = [float(v) for v in vector[index : index + dof]]
+            index += dof
+        return config
+
+    def to_vector(self, config: dict[str, JointValues]) -> np.ndarray:
+        """Concatenate this space's joint values from ``config`` into a vector."""
+        values: list[float] = []
+        for name in self._joint_names:
+            values.extend(config[name])
+        return np.asarray(values, dtype=float)

--- a/prpl-kinematics/tests/test_planning.py
+++ b/prpl-kinematics/tests/test_planning.py
@@ -112,10 +112,12 @@ def _panda_around_obstacle():
     """A Panda with a block obstacle placed on the arm's straight-line sweep."""
     path = os.path.join(pybullet_data.getDataPath(), "franka_panda", "panda.urdf")
     tree = load_urdf(path)
-    block = BoxShape(size=(0.2, 0.2, 0.4))
+    block = BoxShape(size=(0.12, 0.12, 0.5))
     tree.add_node(Node("obstacle", visuals=[block], collisions=[block]))
     tree.add_edge(
-        Edge(tree.root, "obstacle", FixedJoint(name="ofix", origin=SE3(0.2, 0.2, 0.85)))
+        Edge(
+            tree.root, "obstacle", FixedJoint(name="ofix", origin=SE3(0.2, 0.21, 0.82))
+        )
     )
     arm = [f"panda_joint{i}" for i in range(1, 8)]
     start = {name: [0.0] for name in tree.actuated_joint_names()}
@@ -132,10 +134,23 @@ def test_birrt_plans_panda_around_obstacle(physics_client_id, make_videos):
     tree, arm, start, goal = _panda_around_obstacle()
     checker = PyBulletCollisionChecker(physics_client_id)
     checker.load(tree)
-    checker.ignore(checker.pairs_in_collision(start))
+    # The robot's rest-overlapping pairs are intrinsic to the robot; discovering
+    # them must not absorb any arm-vs-obstacle overlap, or the obstacle would be
+    # silently ignored for the rest of planning.
+    allowed = {
+        pair for pair in checker.pairs_in_collision(start) if "obstacle" not in pair
+    }
+    checker.ignore(allowed)
+    assert not checker.in_collision(start)
+    assert not checker.in_collision(goal)
     space = JointSpace(tree, arm)
+    margin = 0.01
+
+    def collision_with_margin(config):
+        return checker.in_collision(config, max_distance=margin)
+
     planner = BiRRTPlanner(
-        space, checker.in_collision, np.random.default_rng(0), num_iters=1000
+        space, collision_with_margin, np.random.default_rng(0), num_iters=1500
     )
     path = planner.plan(start, goal)
     assert path is not None
@@ -143,7 +158,9 @@ def test_birrt_plans_panda_around_obstacle(physics_client_id, make_videos):
     if make_videos:
         renderer = PyBulletRenderer(physics_client_id)
         renderer.load(tree)
-        camera = CameraParams(distance=2.0, yaw=70.0, width=480, height=360)
+        camera = CameraParams(
+            target=(0.1, 0.12, 0.8), distance=1.4, yaw=180.0, pitch=-10.0
+        )
         frames = render_configurations(renderer, path, camera)
         save_video(frames, "panda_birrt.mp4", fps=20)
         assert os.path.exists("panda_birrt.mp4")

--- a/prpl-kinematics/tests/test_planning.py
+++ b/prpl-kinematics/tests/test_planning.py
@@ -1,0 +1,149 @@
+"""Unit tests for joint-space BiRRT motion planning."""
+
+import os
+
+import numpy as np
+import pybullet_data
+import pytest
+from spatialmath import SE3
+
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.geometry.shapes import BoxShape
+from prpl_kinematics.loading import load_urdf
+from prpl_kinematics.planning import BiRRTPlanner, JointSpace
+from prpl_kinematics.tree.joints import FixedJoint, PrismaticJoint
+from prpl_kinematics.tree.kinematic_tree import Edge, KinematicTree, Node
+from prpl_kinematics.visualization import (
+    CameraParams,
+    PyBulletRenderer,
+    render_configurations,
+    save_video,
+)
+
+
+def _gantry_tree() -> KinematicTree:
+    """An XY gantry: a small box robot that slides in x then y, plus a central
+    block obstacle it must steer around."""
+    tree = KinematicTree()
+    tree.add_node(Node("jx"))
+    tree.add_node(Node("robot", collisions=[BoxShape(size=(0.2, 0.2, 0.2))]))
+    tree.add_node(Node("obstacle", collisions=[BoxShape(size=(2.0, 2.0, 2.0))]))
+    tree.add_edge(
+        Edge(
+            "world",
+            "jx",
+            PrismaticJoint(name="jx_joint", axis=(1, 0, 0), lower=-1, upper=5),
+        )
+    )
+    tree.add_edge(
+        Edge(
+            "jx",
+            "robot",
+            PrismaticJoint(name="jy_joint", axis=(0, 1, 0), lower=-1, upper=5),
+        )
+    )
+    tree.add_edge(
+        Edge("world", "obstacle", FixedJoint(name="ofix", origin=SE3(2.5, 2.5, 0)))
+    )
+    return tree
+
+
+def test_joint_space_geometry():
+    """A JointSpace samples within bounds and converts vectors round-trip."""
+    space = JointSpace(_gantry_tree(), ["jx_joint", "jy_joint"])
+    assert space.dimension == 2
+    rng = np.random.default_rng(0)
+    for _ in range(50):
+        sample = space.sample(rng)
+        assert np.all(sample >= -1) and np.all(sample <= 5)
+    config = {"jx_joint": [1.5], "jy_joint": [-0.5]}
+    assert space.to_configuration(space.to_vector(config)) == config
+    assert space.distance(np.array([0.0, 0.0]), np.array([3.0, 4.0])) == pytest.approx(
+        5.0
+    )
+
+
+def test_interpolate_resolution_and_endpoint():
+    """Interpolation steps stay within resolution and end exactly at the target."""
+    space = JointSpace(_gantry_tree(), ["jx_joint", "jy_joint"])
+    a, b = np.array([0.0, 0.0]), np.array([1.0, 0.0])
+    waypoints = list(space.interpolate(a, b, resolution=0.1))
+    assert len(waypoints) == 10
+    assert np.allclose(waypoints[-1], b)
+    steps = np.diff([a] + waypoints, axis=0)
+    assert np.all(np.linalg.norm(steps, axis=1) <= 0.1 + 1e-9)
+
+
+def test_birrt_solves_around_obstacle(physics_client_id):
+    """BiRRT finds a collision-free path when the straight line is blocked."""
+    tree = _gantry_tree()
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(tree)
+    space = JointSpace(tree, ["jx_joint", "jy_joint"])
+    start = {"jx_joint": [0.0], "jy_joint": [0.0]}
+    goal = {"jx_joint": [5.0], "jy_joint": [5.0]}
+    # The straight-line interpolation passes through the central obstacle.
+    direct = space.interpolate(space.to_vector(start), space.to_vector(goal), 0.05)
+    assert any(
+        checker.in_collision({**start, **space.to_configuration(v)}) for v in direct
+    )
+    planner = BiRRTPlanner(
+        space, checker.in_collision, np.random.default_rng(0), num_iters=500
+    )
+    path = planner.plan(start, goal)
+    assert path is not None
+    assert path[0] == start and path[-1] == goal
+    assert all(not checker.in_collision(config) for config in path)
+
+
+def test_birrt_returns_none_when_start_in_collision(physics_client_id):
+    """Planning from a colliding configuration yields no path."""
+    tree = _gantry_tree()
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(tree)
+    space = JointSpace(tree, ["jx_joint", "jy_joint"])
+    inside = {"jx_joint": [2.5], "jy_joint": [2.5]}
+    goal = {"jx_joint": [5.0], "jy_joint": [5.0]}
+    planner = BiRRTPlanner(space, checker.in_collision, np.random.default_rng(0))
+    assert planner.plan(inside, goal) is None
+
+
+def _panda_around_obstacle():
+    """A Panda with a block obstacle placed on the arm's straight-line sweep."""
+    path = os.path.join(pybullet_data.getDataPath(), "franka_panda", "panda.urdf")
+    tree = load_urdf(path)
+    block = BoxShape(size=(0.2, 0.2, 0.4))
+    tree.add_node(Node("obstacle", visuals=[block], collisions=[block]))
+    tree.add_edge(
+        Edge(tree.root, "obstacle", FixedJoint(name="ofix", origin=SE3(0.2, 0.2, 0.85)))
+    )
+    arm = [f"panda_joint{i}" for i in range(1, 8)]
+    start = {name: [0.0] for name in tree.actuated_joint_names()}
+    start["panda_joint2"] = [-0.5]
+    start["panda_joint4"] = [-1.5]
+    start["panda_joint6"] = [1.0]
+    goal = dict(start)
+    goal["panda_joint1"] = [1.6]
+    return tree, arm, start, goal
+
+
+def test_birrt_plans_panda_around_obstacle(physics_client_id, make_videos):
+    """BiRRT steers the Panda's arm around a block; --make-videos renders it."""
+    tree, arm, start, goal = _panda_around_obstacle()
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(tree)
+    checker.ignore(checker.pairs_in_collision(start))
+    space = JointSpace(tree, arm)
+    planner = BiRRTPlanner(
+        space, checker.in_collision, np.random.default_rng(0), num_iters=1000
+    )
+    path = planner.plan(start, goal)
+    assert path is not None
+    assert all(not checker.in_collision(config) for config in path)
+    if make_videos:
+        renderer = PyBulletRenderer(physics_client_id)
+        renderer.load(tree)
+        camera = CameraParams(distance=2.0, yaw=70.0, width=480, height=360)
+        frames = render_configurations(renderer, path, camera)
+        save_video(frames, "panda_birrt.mp4", fps=20)
+        assert os.path.exists("panda_birrt.mp4")


### PR DESCRIPTION
## Summary

Adds the **planning** milestone to `prpl-kinematics`: collision-free joint-space motion planning with a bidirectional RRT.

- **`JointSpace`** — an explicitly named, ordered group of actuated joints. Provides `sample`/`distance`/`interpolate` and converts between a flat coordinate vector (what a planner manipulates) and a name-keyed `Configuration` (what FK and collision checking consume).
- **`BiRRTPlanner`** — adapts the generic `BiRRT` from `prpl_utils` to a `JointSpace`, taking a plain `config -> bool` collision callable (the `PyBulletCollisionChecker` satisfies this directly). Non-planned joints are held fixed at the start configuration, so planning the arm never silently moves the gripper.

No `MotionPlanner`/`ConfigurationSpace` ABC yet — per the minimal-first principle, those get extracted when the second planner (OMPL) lands.

## Avoiding the joint-group ambiguity from pybullet-helpers

DESIGN.md gains **principle 7**: configurations are always name-keyed (never a positional vector whose length implies which joints it covers), joint groups are explicit, flat vectors live only inside a `JointSpace`, and the gripper is just another named group — never a `finger_state` scalar. The Robots milestone now spells out that each robot exposes named joint groups (`"arm"`, `"gripper"`) rather than one ambiguous "the robot's joints" vector.

## Tests

- `JointSpace`: dimension, in-bounds sampling, vector round-trip, distance, and interpolation (resolution + exact endpoint).
- BiRRT steers an XY-gantry box around a central block when the straight line is blocked; every returned configuration is collision-free and the endpoints match.
- Planning from a colliding start returns `None`.
- Panda plans its 7-DOF arm around a block obstacle; `--make-videos` renders `panda_birrt.mp4`.

36 passed, 1 skipped; `./run_ci_checks.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
