### PR TITLE
Add numerical IK and EE-path following to prpl-kinematics

### DIFF
--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -85,7 +85,7 @@ loading/         URDF -> KinematicTree with per-node geometry (via yourdfpy).   
 meshes.py        Prepare meshes for PyBullet's file importer (convert/cache).      [built]
 visualization.py Shape-soup renderer (FK-driven), capture, video (--make-videos). [built]
 collision.py     Shape-soup collision checker (FK-driven) + allowed pairs.         [built]
-ik/              InverseKinematics ABC; NumericalIK (Jacobian-DLS), AnalyticIK.   [planned]
+ik/              NumericalIK (Jacobian-DLS) + EE-path follower; AnalyticIK next.  [built]
 planning/        JointSpace + BiRRTPlanner (over a config->bool callable); OMPL.   [built]
 robots/          Assemblies over a tree: SingleArm, Bimanual, MobileBase, MobileManip. [planned]
 manipulation/    Primitive ABC; Pick, Place with injected grasp generators.       [planned]
@@ -116,6 +116,15 @@ an SE(2) base, or a Cartesian EE target) arrives with the second planner (OMPL).
 Robots are composition over a tree (named joint groups, an EE link, a home
 config), not an inheritance tower.
 
+`NumericalIK` reuses the same `JointSpace` to solve for a configuration whose
+EE frame reaches a target pose, via damped-least-squares differential steps
+(`dq = J^T (J J^T + lambda^2 I)^-1 e`) with a finite-difference Jacobian over
+the tree's FK. It is a local solver (converges from a seed in the basin);
+`follow_end_effector_path` chains solves warm-started from the previous one so a
+redundant arm tracks a Cartesian path on one smooth IK branch. Global, seedless
+IK is the job of a later `AnalyticIK`, at which point an `InverseKinematics` ABC
+is extracted.
+
 ## What is built today
 
 The minimal, fully-tested core:
@@ -134,14 +143,18 @@ The minimal, fully-tested core:
   `save_video`, plus the `--make-videos` test fixture.
 - `collision` — `PyBulletCollisionChecker` (`in_collision`, `pairs_in_collision`,
   `ignore`).
-- `planning` — `JointSpace` (sample/distance/interpolate, vector<->config) and
-  `BiRRTPlanner` (collision-free joint-space paths via `prpl_utils.BiRRT`).
+- `planning` — `JointSpace` (sample/distance/interpolate/clamp, vector<->config)
+  and `BiRRTPlanner` (collision-free joint-space paths via `prpl_utils.BiRRT`).
+- `ik` — `NumericalIK` (Jacobian-DLS differential solve) and
+  `follow_end_effector_path` (warm-started Cartesian-path tracking).
 
 Tests cover conversions, every joint type, FK propagation, grasp re-parenting,
 snapshotting, URDF loading, FK equivalence with PyBullet on Panda, `.glb` mesh
 conversion, shape-soup rendering, collision checking (primitives, adjacency,
-attached-object-vs-environment, and Panda rest pose), and BiRRT planning (joint-
-space geometry, steering around an obstacle, and a Panda plan around a block).
+attached-object-vs-environment, and Panda rest pose), BiRRT planning (joint-
+space geometry, steering around an obstacle, and a Panda plan around a block),
+and IK (reaching a pose from a nearby seed, unreachable targets, and smooth
+warm-started EE-path following).
 
 ## Milestones (each adds code + tests)
 
@@ -150,8 +163,9 @@ space geometry, steering around an obstacle, and a Panda plan around a block).
    against PyBullet); shape-soup FK-driven renderer + `--make-videos` pipeline.
 3. **Collision** — done. Shape-soup `PyBulletCollisionChecker` (FK-positioned
    bodies, allowed-pair discovery); a grasped object collides for free.
-4. **IK** — `InverseKinematics` ABC; `NumericalIK` (Jacobian-DLS, folding in the
-   ee-follow jitter fix), then `AnalyticIK` (EAIK/IKFast port).
+4. **IK** — `NumericalIK` (Jacobian-DLS) + `follow_end_effector_path` (the
+   warm-started ee-follow jitter fix) — done. `AnalyticIK` (EAIK/IKFast port)
+   next, extracting an `InverseKinematics` ABC once it lands.
 5. **Planning** — `JointSpace` + `BiRRTPlanner` (wrapping `prpl_utils`) over a
    `config -> bool` callable — done. `OMPLPlanner` next, extracting the
    `MotionPlanner`/`ConfigurationSpace` ABCs once a second implementation exists.

--- a/prpl-kinematics/src/prpl_kinematics/ik/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/ik/__init__.py
@@ -1,0 +1,6 @@
+"""Inverse kinematics: solve for configurations that reach target poses."""
+
+from prpl_kinematics.ik.follow import follow_end_effector_path
+from prpl_kinematics.ik.numerical import NumericalIK
+
+__all__ = ["NumericalIK", "follow_end_effector_path"]

--- a/prpl-kinematics/src/prpl_kinematics/ik/follow.py
+++ b/prpl-kinematics/src/prpl_kinematics/ik/follow.py
@@ -1,0 +1,33 @@
+"""Follow an end-effector path by chaining warm-started IK solves.
+
+Each target pose is solved seeded from the previous solution, so a redundant arm tracks
+the path on one continuous IK branch -- avoiding the elbow jitter that comes from
+solving each waypoint independently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from spatialmath import SE3
+
+from prpl_kinematics.ik.numerical import NumericalIK
+from prpl_kinematics.tree.kinematic_tree import Configuration
+
+
+def follow_end_effector_path(
+    ik: NumericalIK, poses: Sequence[SE3], seed: Configuration
+) -> list[Configuration] | None:
+    """Configurations tracking ``poses`` in order, or ``None`` if any fails.
+
+    Each solve is seeded from the previous solution (the first from ``seed``).
+    """
+    configs: list[Configuration] = []
+    current_seed = seed
+    for pose in poses:
+        solution = ik.solve(pose, current_seed)
+        if solution is None:
+            return None
+        configs.append(solution)
+        current_seed = solution
+    return configs

--- a/prpl-kinematics/src/prpl_kinematics/ik/numerical.py
+++ b/prpl-kinematics/src/prpl_kinematics/ik/numerical.py
@@ -1,0 +1,100 @@
+"""Numerical inverse kinematics via Jacobian damped least squares.
+
+``NumericalIK`` solves for a configuration whose end-effector frame reaches a
+target pose by stepping differentially from a seed configuration:
+``dq = J^T (J J^T + lambda^2 I)^-1 e``, with the step clipped and clamped to the
+joint limits each iteration. Seeding from the previous solution (see
+:func:`~prpl_kinematics.ik.follow.follow_end_effector_path`) keeps a redundant
+arm on a single, smooth IK branch instead of flipping between solutions.
+
+The Jacobian is computed by finite-differencing the tree's forward kinematics,
+so it works for any joint group without an analytic derivative.
+
+This is a local solver: it converges when the seed is within the target's basin
+of attraction (a nearby configuration), and returns ``None`` otherwise. Global,
+seedless solutions are the job of an analytic solver (a later addition).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+from spatialmath import SE3
+
+from prpl_kinematics.planning.joint_space import JointSpace
+from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
+
+
+def _pose_twist(current: SE3, target: SE3) -> np.ndarray:
+    """6-vector ``[dx, dy, dz, rx, ry, rz]`` carrying ``current`` to ``target``."""
+    position = np.asarray(target.t) - np.asarray(current.t)
+    rotation = Rotation.from_matrix(np.asarray(target.R) @ np.asarray(current.R).T)
+    return np.concatenate([position, rotation.as_rotvec()])
+
+
+class NumericalIK:
+    """Damped-least-squares differential IK over a JointSpace."""
+
+    def __init__(
+        self,
+        tree: KinematicTree,
+        space: JointSpace,
+        ee_frame: str,
+        position_tolerance: float = 1e-3,
+        orientation_tolerance: float = 1e-2,
+        max_iters: int = 100,
+        damping: float = 0.05,
+        step_clip: float = 0.2,
+        jacobian_epsilon: float = 1e-6,
+    ) -> None:
+        self._tree = tree
+        self._space = space
+        self._ee_frame = ee_frame
+        self._position_tolerance = position_tolerance
+        self._orientation_tolerance = orientation_tolerance
+        self._max_iters = max_iters
+        self._damping = damping
+        self._step_clip = step_clip
+        self._jacobian_epsilon = jacobian_epsilon
+
+    def solve(self, target_pose: SE3, seed: Configuration) -> Configuration | None:
+        """A configuration reaching ``target_pose``, or ``None`` if not converged.
+
+        The returned configuration carries every joint of ``seed``, with the
+        space's joints driven toward the target.
+        """
+        base = dict(seed)
+        q = self._space.to_vector(base)
+        for _ in range(self._max_iters):
+            config = {**base, **self._space.to_configuration(q)}
+            current = self._tree.forward_kinematics(self._ee_frame, config)
+            error = _pose_twist(current, target_pose)
+            if self._within_tolerance(error):
+                return config
+            jacobian = self._jacobian(q, base, current)
+            damped = jacobian @ jacobian.T + self._damping**2 * np.eye(6)
+            dq = jacobian.T @ np.linalg.solve(damped, error)
+            step = float(np.linalg.norm(dq))
+            scale = self._step_clip / step if step > self._step_clip else 1.0
+            q = self._space.clamp(q + dq * scale)
+        config = {**base, **self._space.to_configuration(q)}
+        current = self._tree.forward_kinematics(self._ee_frame, config)
+        if self._within_tolerance(_pose_twist(current, target_pose)):
+            return config
+        return None
+
+    def _within_tolerance(self, error: np.ndarray) -> bool:
+        return bool(
+            np.linalg.norm(error[:3]) < self._position_tolerance
+            and np.linalg.norm(error[3:]) < self._orientation_tolerance
+        )
+
+    def _jacobian(self, q: np.ndarray, base: Configuration, current: SE3) -> np.ndarray:
+        columns = []
+        for i in range(q.size):
+            perturbed = q.copy()
+            perturbed[i] += self._jacobian_epsilon
+            config = {**base, **self._space.to_configuration(perturbed)}
+            pose = self._tree.forward_kinematics(self._ee_frame, config)
+            columns.append(_pose_twist(current, pose) / self._jacobian_epsilon)
+        return np.column_stack(columns)

--- a/prpl-kinematics/src/prpl_kinematics/planning/joint_space.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/joint_space.py
@@ -52,6 +52,10 @@ class JointSpace:
         """Euclidean distance between two coordinate vectors."""
         return float(np.linalg.norm(np.subtract(a, b)))
 
+    def clamp(self, vector: np.ndarray) -> np.ndarray:
+        """Clip a coordinate vector to the joint bounds."""
+        return np.clip(vector, self._lower, self._upper)
+
     def interpolate(
         self, a: np.ndarray, b: np.ndarray, resolution: float
     ) -> Iterator[np.ndarray]:

--- a/prpl-kinematics/tests/test_ik.py
+++ b/prpl-kinematics/tests/test_ik.py
@@ -1,0 +1,121 @@
+"""Unit tests for numerical inverse kinematics and end-effector following."""
+
+import os
+
+import numpy as np
+import pybullet_data
+import pytest
+from scipy.spatial.transform import Rotation
+from spatialmath import SE3
+
+from prpl_kinematics.ik import NumericalIK, follow_end_effector_path
+from prpl_kinematics.loading import load_urdf
+from prpl_kinematics.planning import JointSpace
+from prpl_kinematics.visualization import (
+    CameraParams,
+    PyBulletRenderer,
+    render_configurations,
+    save_video,
+)
+
+ARM = [f"panda_joint{i}" for i in range(1, 8)]
+
+
+def _panda():
+    path = os.path.join(pybullet_data.getDataPath(), "franka_panda", "panda.urdf")
+    tree = load_urdf(path)
+    return tree, JointSpace(tree, ARM)
+
+
+def _comfortable() -> dict[str, list[float]]:
+    config = {name: [0.0] for name in ARM}
+    config["panda_joint2"] = [-0.5]
+    config["panda_joint4"] = [-1.8]
+    config["panda_joint6"] = [1.5]
+    return config
+
+
+def _pose_error(tree, ee, config, target) -> tuple[float, float]:
+    reached = tree.forward_kinematics(ee, config)
+    position = float(np.linalg.norm(np.asarray(target.t) - np.asarray(reached.t)))
+    rotation = Rotation.from_matrix(np.asarray(target.R) @ np.asarray(reached.R).T)
+    return position, float(np.linalg.norm(rotation.as_rotvec()))
+
+
+def test_solve_reaches_nearby_pose():
+    """IK recovers a configuration reaching a pose from a nearby seed."""
+    tree, space = _panda()
+    ik = NumericalIK(tree, space, "panda_hand")
+    truth = _comfortable()
+    target = tree.forward_kinematics("panda_hand", truth)
+    seed = {name: [value[0] + 0.3] for name, value in truth.items()}
+    solution = ik.solve(target, seed)
+    assert solution is not None
+    position_error, orientation_error = _pose_error(
+        tree, "panda_hand", solution, target
+    )
+    assert position_error < 1e-3 and orientation_error < 1e-2
+    vector = space.to_vector(solution)
+    assert np.allclose(vector, space.clamp(vector))
+
+
+def test_solve_returns_none_when_unreachable():
+    """A target far outside the workspace yields no solution."""
+    tree, space = _panda()
+    ik = NumericalIK(tree, space, "panda_hand")
+    assert ik.solve(SE3(5.0, 5.0, 5.0), _comfortable()) is None
+
+
+def test_follow_end_effector_path_is_smooth():
+    """Following a Cartesian path warm-started stays on one smooth IK branch."""
+    tree, space = _panda()
+    ik = NumericalIK(tree, space, "panda_hand")
+    start = _comfortable()
+    origin = tree.forward_kinematics("panda_hand", start)
+    # A 15 cm straight line in world +y, sampled finely.
+    poses = [SE3(0.0, 0.15 * k / 40, 0.0) * origin for k in range(41)]
+    path = follow_end_effector_path(ik, poses, start)
+    assert path is not None and len(path) == len(poses)
+    for config, target in zip(path, poses):
+        position_error, orientation_error = _pose_error(
+            tree, "panda_hand", config, target
+        )
+        assert position_error < 1e-3 and orientation_error < 1e-2
+    steps = [
+        space.distance(space.to_vector(path[i]), space.to_vector(path[i + 1]))
+        for i in range(len(path) - 1)
+    ]
+    assert max(steps) < 0.1  # no IK-branch flips
+
+
+def test_follow_returns_none_when_a_pose_is_unreachable():
+    """The follower reports failure if any pose along the path is unreachable."""
+    tree, space = _panda()
+    ik = NumericalIK(tree, space, "panda_hand")
+    start = _comfortable()
+    origin = tree.forward_kinematics("panda_hand", start)
+    poses = [origin, SE3(5.0, 5.0, 5.0)]
+    assert follow_end_effector_path(ik, poses, start) is None
+
+
+def test_ik_follow_video(physics_client_id, make_videos):
+    """With --make-videos, render an EE circle traced via warm-started IK."""
+    if not make_videos:
+        pytest.skip("pass --make-videos to render the video")
+    tree, space = _panda()
+    ik = NumericalIK(tree, space, "panda_hand")
+    start = _comfortable()
+    origin = tree.forward_kinematics("panda_hand", start)
+    poses = []
+    for k in range(80):
+        angle = 2 * np.pi * k / 80
+        offset = SE3(0.0, 0.08 * np.sin(angle), 0.08 * (1 - np.cos(angle)))
+        poses.append(offset * origin)
+    path = follow_end_effector_path(ik, poses, start)
+    assert path is not None
+    renderer = PyBulletRenderer(physics_client_id)
+    renderer.load(tree)
+    camera = CameraParams(target=(0.3, 0.0, 0.6), distance=1.5, yaw=90.0, pitch=-15.0)
+    frames = render_configurations(renderer, path, camera)
+    save_video(frames, "panda_ik_follow.mp4", fps=20)
+    assert os.path.exists("panda_ik_follow.mp4")

--- a/prpl-kinematics/tests/test_planning.py
+++ b/prpl-kinematics/tests/test_planning.py
@@ -61,6 +61,7 @@ def test_joint_space_geometry():
     assert space.distance(np.array([0.0, 0.0]), np.array([3.0, 4.0])) == pytest.approx(
         5.0
     )
+    assert np.allclose(space.clamp(np.array([-3.0, 7.0])), [-1.0, 5.0])
 
 
 def test_interpolate_resolution_and_endpoint():


### PR DESCRIPTION
## Summary

Adds the **IK** milestone to `prpl-kinematics`: numerical inverse kinematics and warm-started end-effector path following.

- **`NumericalIK`** — solves for a configuration whose end-effector frame reaches a target `SE3`, via damped-least-squares differential steps `dq = Jᵀ(JJᵀ + λ²I)⁻¹e`, step-clipped and clamped to joint limits each iteration. The Jacobian is finite-differenced over the tree's FK, so it works for any joint group with no analytic derivative. It is a *local* solver: it converges from a seed in the target's basin of attraction and returns `None` otherwise (global, seedless IK is the job of a later `AnalyticIK`).
- **`follow_end_effector_path`** — chains solves, each seeded from the previous solution, so a redundant arm tracks a Cartesian path on one continuous IK branch. This is the elbow-jitter fix from pybullet-helpers (`smoothly_follow_end_effector_path`), here achieved by construction rather than patched in.
- **`JointSpace.clamp`** — clip a coordinate vector to the joint bounds (used by the IK step).

No `InverseKinematics` ABC yet — per the minimal-first rule, it's extracted when the second implementation (`AnalyticIK`) lands.

## Tests

- IK recovers a configuration reaching a pose from a nearby seed (position < 1e-3, orientation < 1e-2), within joint limits.
- An unreachable target returns `None`.
- Following a 15 cm Cartesian line tracks every pose and stays smooth — worst joint step < 0.1 rad (no IK-branch flips).
- The follower returns `None` if any pose along the path is unreachable.
- `--make-videos` renders `panda_ik_follow.mp4` (EE tracing a circle).

40 passed, 2 skipped; `./run_ci_checks.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
