### PR TITLE
Add Pick/Place manipulation primitives (grasp = a tree edge)

### DIFF
--- a/prpl-kinematics/DESIGN.md
+++ b/prpl-kinematics/DESIGN.md
@@ -88,7 +88,7 @@ collision.py     Shape-soup collision checker (FK-driven) + allowed pairs.      
 ik/              InverseKinematics protocol; NumericalIK (DLS) + IKFastSolver.    [built]
 planning/        ConfigurationSpace + MotionPlanner; BiRRTPlanner, OMPLPlanner.  [built]
 robots/          Robot composition + Panda, Kinova, TidyBot, Vega (bimanual).    [built]
-manipulation/    Primitive ABC; Pick, Place with injected grasp generators.       [planned]
+manipulation.py  Primitive protocol; Pick, Place (grasp = a tree edge).           [built]
 ```
 
 The renderer is shape-soup: it creates one PyBullet visual body per node shape

--- a/prpl-kinematics/notebooks/pick_place_embodiments.ipynb
+++ b/prpl-kinematics/notebooks/pick_place_embodiments.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2fe491a6",
+   "metadata": {},
+   "source": [
+    "# Pick and place across embodiments\n",
+    "\n",
+    "The `Pick` and `Place` primitives are robot-agnostic: they consume a `Robot` (named groups, manipulators, IK) and a collision checker, so the *same* code picks and places a cube with different arms. Here we run it on the **Panda** and the **Kinova Gen3**.\n",
+    "\n",
+    "For each robot the scene is derived from its home end-effector pose: the cube is placed along the gripper's approach axis (so the pregrasp is reachable), on a small table, and the grasp uses the home orientation. Each plan is rendered as an inline animation; the held cube follows the gripper because a grasp is just a tree edge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cc63750",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pybullet as p\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.animation as animation\n",
+    "from IPython.display import HTML, display\n",
+    "from spatialmath import SE3\n",
+    "\n",
+    "from prpl_kinematics.collision import PyBulletCollisionChecker\n",
+    "from prpl_kinematics.geometry.shapes import BoxShape\n",
+    "from prpl_kinematics.manipulation import Pick, Place\n",
+    "from prpl_kinematics.planning import BiRRTPlanner\n",
+    "from prpl_kinematics.robots import make_panda, make_kinova\n",
+    "from prpl_kinematics.tree.joints import FixedJoint\n",
+    "from prpl_kinematics.tree.kinematic_tree import Edge, Node\n",
+    "from prpl_kinematics.tree.state import KinematicState\n",
+    "from prpl_kinematics.visualization import CameraParams, PyBulletRenderer, capture_image\n",
+    "\n",
+    "\n",
+    "def pick_and_place(make_robot, manipulator=\"arm\", approach=0.12, place_shift=(0.12, 0.0, 0.0)):\n",
+    "    \"\"\"Run Pick then Place with a home-derived cube/table scene; return (robot, plan, cube_pos).\"\"\"\n",
+    "    robot = make_robot()\n",
+    "    robot_links = set(robot.tree.nodes)  # everything not added below is the robot\n",
+    "    manip = robot.manipulators[manipulator]\n",
+    "    home_ee = robot.tree.forward_kinematics(manip.ee_frame, robot.home)\n",
+    "    rotation = np.asarray(home_ee.R)\n",
+    "    cube_pos = np.asarray(home_ee.t) + approach * rotation[:, 2]\n",
+    "    grasp = SE3.Rt(rotation, [0, 0, 0])\n",
+    "    placement = SE3(*(cube_pos + np.array(place_shift)))\n",
+    "\n",
+    "    table = BoxShape(size=(0.4, 0.5, 0.02))\n",
+    "    robot.tree.add_node(Node(\"table\", visuals=[table], collisions=[table]))\n",
+    "    robot.tree.add_edge(Edge(robot.tree.root, \"table\", FixedJoint(\n",
+    "        name=\"tf\", origin=SE3(cube_pos[0] + place_shift[0] / 2, cube_pos[1], cube_pos[2] - 0.055))))\n",
+    "    cube = BoxShape(size=(0.05, 0.05, 0.08))\n",
+    "    robot.tree.add_node(Node(\"cube\", visuals=[cube], collisions=[cube]))\n",
+    "    robot.tree.add_edge(Edge(robot.tree.root, \"cube\", FixedJoint(name=\"cf\", origin=SE3(*cube_pos))))\n",
+    "\n",
+    "    checker = PyBulletCollisionChecker(p.connect(p.DIRECT))\n",
+    "    checker.load(robot.tree)\n",
+    "    checker.ignore(robot.allowed_collision_pairs)\n",
+    "    checker.ignore([(\"cube\", \"table\")])  # the cube rests on the table\n",
+    "    checker.ignore([(link, \"cube\") for link in robot_links])  # the gripper grasps the cube\n",
+    "    planner = BiRRTPlanner(robot.groups[manip.group], checker.in_collision, np.random.default_rng(0), num_iters=2000)\n",
+    "\n",
+    "    state = KinematicState.from_tree(robot.tree, robot.home)\n",
+    "    pick = Pick(robot, checker, planner, \"cube\", \"table\", [grasp], manipulator=manipulator).plan(state)\n",
+    "    assert pick is not None, \"pick failed\"\n",
+    "    place = Place(robot, checker, planner, \"cube\", \"table\", [placement], manipulator=manipulator).plan(pick[-1])\n",
+    "    assert place is not None, \"place failed\"\n",
+    "    return robot, pick + place, cube_pos\n",
+    "\n",
+    "\n",
+    "def show(robot, plan, cube_pos):\n",
+    "    \"\"\"Render a plan (applying each state's edges so the grasp follows) as an inline animation.\"\"\"\n",
+    "    renderer = PyBulletRenderer(p.connect(p.DIRECT))\n",
+    "    renderer.load(robot.tree)\n",
+    "    camera = CameraParams(target=tuple(float(v) for v in cube_pos), distance=1.1, yaw=55.0, pitch=-25.0)\n",
+    "    images = []\n",
+    "    for plan_state in plan:\n",
+    "        renderer.render(plan_state.apply(robot.tree))\n",
+    "        images.append(capture_image(renderer.physics_client_id, camera))\n",
+    "    fig, ax = plt.subplots(figsize=(4, 3))\n",
+    "    ax.axis(\"off\")\n",
+    "    canvas = ax.imshow(images[0])\n",
+    "    anim = animation.FuncAnimation(\n",
+    "        fig, lambda i: [canvas.set_data(images[i]) or canvas], frames=len(images), interval=40, blit=True)\n",
+    "    plt.close(fig)\n",
+    "    return HTML(anim.to_jshtml())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "827790ac",
+   "metadata": {},
+   "source": [
+    "## Panda"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b64db36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show(*pick_and_place(make_panda, approach=0.12, place_shift=(0.14, 0.0, 0.0)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cff69338",
+   "metadata": {},
+   "source": [
+    "## Kinova Gen3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2959408",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show(*pick_and_place(make_kinova, approach=0.12, place_shift=(0.0, 0.16, 0.0)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/prpl-kinematics/src/prpl_kinematics/collision.py
+++ b/prpl-kinematics/src/prpl_kinematics/collision.py
@@ -14,7 +14,7 @@ discovered with :meth:`PyBulletCollisionChecker.pairs_in_collision` and passed t
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 
 import pybullet as p
 
@@ -91,11 +91,24 @@ class PyBulletCollisionChecker:
         for pair in pairs:
             self._ignored.add(frozenset(pair))
 
-    def in_collision(self, config: Configuration, max_distance: float = 0.0) -> bool:
-        """Whether any non-ignored shape pair is within ``max_distance``."""
+    def in_collision(
+        self,
+        config: Configuration,
+        max_distance: float = 0.0,
+        ignored_nodes: Collection[str] = (),
+    ) -> bool:
+        """Whether any non-ignored shape pair is within ``max_distance``.
+
+        ``ignored_nodes`` excludes any pair touching one of those nodes -- used
+        during a grasp to disregard the target object and its support surface.
+        """
         self._position(config)
         for index, (body_a, node_a) in enumerate(self._bodies):
+            if node_a in ignored_nodes:
+                continue
             for body_b, node_b in self._bodies[index + 1 :]:
+                if node_b in ignored_nodes:
+                    continue
                 if node_a == node_b or frozenset({node_a, node_b}) in self._ignored:
                     continue
                 if self._closest_points(body_a, body_b, max_distance):

--- a/prpl-kinematics/src/prpl_kinematics/manipulation.py
+++ b/prpl-kinematics/src/prpl_kinematics/manipulation.py
@@ -1,0 +1,221 @@
+"""Pick and place primitives over the KinematicTree stack.
+
+A grasp is just an edge: picking re-parents the object onto the gripper
+(``tree.attach``), so the held object follows forward kinematics and a plan is a
+``list[KinematicState]`` whose object edge flips at the grasp. Collision logic
+follows pybullet-helpers: motion-plan to a pregrasp against all obstacles, then
+descend and retreat while disregarding the target object and its support surface
+(the gripper must contact the object and is near the surface).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol, runtime_checkable
+
+from spatialmath import SE3
+
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.planning.configuration_space import ConfigurationSpace
+from prpl_kinematics.planning.motion_planner import MotionPlanner
+from prpl_kinematics.robots.robot import Robot
+from prpl_kinematics.tree.kinematic_tree import Configuration
+from prpl_kinematics.tree.state import KinematicState
+
+
+@runtime_checkable
+class Primitive(Protocol):
+    """A manipulation primitive: turn a starting state into a plan, or fail."""
+
+    def plan(self, state: KinematicState) -> list[KinematicState] | None:
+        """A plan (sequence of states) achieving the primitive, or ``None``."""
+        raise NotImplementedError
+
+
+class Pick:
+    """Pick an object off a surface with a generated grasp.
+
+    ``grasps`` yields the gripper pose in the object frame; the first grasp whose
+    pregrasp is reachable, descent is collision-free, and retreat lifts the held
+    object clear is used.
+    """
+
+    def __init__(
+        self,
+        robot: Robot,
+        checker: PyBulletCollisionChecker,
+        planner: MotionPlanner,
+        object_frame: str,
+        surface_frame: str,
+        grasps: Iterable[SE3],
+        manipulator: str = "arm",
+        approach_distance: float = 0.12,
+        descend_resolution: float = 0.02,
+    ) -> None:
+        self._robot = robot
+        self._checker = checker
+        self._planner = planner
+        self._object = object_frame
+        self._surface = surface_frame
+        self._grasps = grasps
+        self._manipulator = robot.manipulators[manipulator]
+        self._group = robot.groups[self._manipulator.group]
+        self._approach = approach_distance
+        self._resolution = descend_resolution
+
+    def plan(self, state: KinematicState) -> list[KinematicState] | None:
+        """A pick plan ending with the object grasped, or ``None``."""
+        tree = self._robot.tree
+        ee = self._manipulator.ee_frame
+        ik = self._manipulator.ik
+        ignore = {self._object, self._surface}
+        for grasp in self._grasps:
+            config = state.apply(tree)  # restore the un-grasped scene each attempt
+            object_world = tree.forward_kinematics(self._object, config)
+            grasp_world = object_world * grasp
+            pregrasp_world = grasp_world * SE3(0.0, 0.0, -self._approach)
+
+            pregrasp_cfg = ik.solve(pregrasp_world, config)
+            if pregrasp_cfg is None:
+                continue
+            grasp_cfg = ik.solve(grasp_world, pregrasp_cfg)
+            if grasp_cfg is None:
+                continue
+
+            approach = self._planner.plan(config, pregrasp_cfg)
+            if approach is None:
+                continue
+            descend = self._segment(config, pregrasp_cfg, grasp_cfg, ignore)
+            if descend is None:
+                continue
+
+            plan = [
+                KinematicState.from_tree(tree, c) for c in [config, *approach, *descend]
+            ]
+            tree.attach(
+                self._object, ee, tree.relative_pose(ee, self._object, grasp_cfg)
+            )
+            retreat = self._segment(config, grasp_cfg, pregrasp_cfg, ignore)
+            if retreat is None:
+                continue
+            plan += [KinematicState.from_tree(tree, c) for c in retreat]
+            return plan
+        return None
+
+    def _segment(
+        self,
+        base: Configuration,
+        start: Configuration,
+        end: Configuration,
+        ignore: set[str],
+    ) -> list[Configuration] | None:
+        """Collision-free straight segment of the manipulator group, or ``None``."""
+        return _straight_segment(
+            self._checker, self._group, base, start, end, ignore, self._resolution
+        )
+
+
+class Place:
+    """Place a held object onto a surface at a target object pose.
+
+    ``placements`` yields the object's target pose in the world frame.
+    """
+
+    def __init__(
+        self,
+        robot: Robot,
+        checker: PyBulletCollisionChecker,
+        planner: MotionPlanner,
+        object_frame: str,
+        surface_frame: str,
+        placements: Iterable[SE3],
+        manipulator: str = "arm",
+        approach_distance: float = 0.12,
+        descend_resolution: float = 0.02,
+    ) -> None:
+        self._robot = robot
+        self._checker = checker
+        self._planner = planner
+        self._object = object_frame
+        self._surface = surface_frame
+        self._placements = placements
+        self._manipulator = robot.manipulators[manipulator]
+        self._group = robot.groups[self._manipulator.group]
+        self._approach = approach_distance
+        self._resolution = descend_resolution
+
+    def plan(self, state: KinematicState) -> list[KinematicState] | None:
+        """A place plan ending with the object released onto the surface, or
+        ``None``."""
+        tree = self._robot.tree
+        ee = self._manipulator.ee_frame
+        ik = self._manipulator.ik
+        ignore = {self._object, self._surface}
+        for placement in self._placements:
+            config = state.apply(tree)  # restore the held-object scene each attempt
+            ee_from_object = tree.relative_pose(ee, self._object, config)
+            place_world = placement * ee_from_object.inv()
+            preplace_world = place_world * SE3(0.0, 0.0, -self._approach)
+
+            preplace_cfg = ik.solve(preplace_world, config)
+            if preplace_cfg is None:
+                continue
+            place_cfg = ik.solve(place_world, preplace_cfg)
+            if place_cfg is None:
+                continue
+
+            approach = self._planner.plan(config, preplace_cfg)
+            if approach is None:
+                continue
+            descend = _straight_segment(
+                self._checker,
+                self._group,
+                config,
+                preplace_cfg,
+                place_cfg,
+                ignore,
+                self._resolution,
+            )
+            if descend is None:
+                continue
+
+            plan = [
+                KinematicState.from_tree(tree, c) for c in [config, *approach, *descend]
+            ]
+            tree.attach(self._object, tree.root, placement)  # release onto the surface
+            retreat = _straight_segment(
+                self._checker,
+                self._group,
+                config,
+                place_cfg,
+                preplace_cfg,
+                ignore,
+                self._resolution,
+            )
+            if retreat is None:
+                continue
+            plan += [KinematicState.from_tree(tree, c) for c in retreat]
+            return plan
+        return None
+
+
+def _straight_segment(
+    checker: PyBulletCollisionChecker,
+    group: ConfigurationSpace,
+    base: Configuration,
+    start: Configuration,
+    end: Configuration,
+    ignore: set[str],
+    resolution: float,
+) -> list[Configuration] | None:
+    """Interpolate ``group`` from ``start`` to ``end``, collision-checking each step."""
+    waypoints = group.interpolate(
+        group.to_vector(start), group.to_vector(end), resolution
+    )
+    configs: list[Configuration] = []
+    for vector in waypoints:
+        config = {**dict(base), **group.to_configuration(vector)}
+        if checker.in_collision(config, ignored_nodes=ignore):
+            return None
+        configs.append(config)
+    return configs

--- a/prpl-kinematics/src/prpl_kinematics/tree/kinematic_tree.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/kinematic_tree.py
@@ -74,6 +74,23 @@ class KinematicTree:
         """All frames, keyed by name."""
         return self._nodes
 
+    @property
+    def edges(self) -> Mapping[str, Edge]:
+        """Incoming edges, keyed by child name (the root has none)."""
+        return self._edges
+
+    def set_edge(self, edge: Edge) -> None:
+        """Set ``edge.child``'s incoming edge, replacing any existing one.
+
+        Unlike :meth:`add_edge` (which forbids replacement), this re-parents a
+        node to an arbitrary joint -- used to restore a :class:`KinematicState`.
+        """
+        if edge.parent not in self._nodes:
+            raise ValueError(f"Unknown parent: {edge.parent}")
+        if edge.child not in self._nodes:
+            raise ValueError(f"Unknown child: {edge.child}")
+        self._edges[edge.child] = edge
+
     def add_node(self, node: Node) -> None:
         """Register a frame.
 

--- a/prpl-kinematics/src/prpl_kinematics/tree/state.py
+++ b/prpl-kinematics/src/prpl_kinematics/tree/state.py
@@ -1,32 +1,51 @@
-"""KinematicState: a restorable snapshot of a tree's configuration.
+"""KinematicState: a restorable snapshot of a tree's configuration and structure.
 
-A state captures the joint values for every actuated joint of a tree, so a
-configuration can be saved and later reapplied for forward kinematics.
+A state captures the joint values of every actuated joint *and* the tree's edges
+(each node's parent and joint). Because a grasp is just an edge -- ``attach``
+re-parents an object onto a gripper -- snapshotting the edges captures grasps for
+free: two states differ in an object's incoming edge across a pick or place.
+:meth:`KinematicState.apply` restores both the structure and the configuration.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from prpl_kinematics.tree.joints import JointValues
-from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
+from prpl_kinematics.tree.joints import Joint, JointValues
+from prpl_kinematics.tree.kinematic_tree import (
+    Configuration,
+    Edge,
+    KinematicTree,
+)
 
 
 @dataclass(frozen=True)
 class KinematicState:
-    """An immutable snapshot of all actuated joint values."""
+    """An immutable snapshot of actuated joint values and tree structure."""
 
     joint_values: dict[str, tuple[float, ...]]
+    edges: dict[str, tuple[str, Joint]] = field(default_factory=dict)
 
     @classmethod
     def from_tree(cls, tree: KinematicTree, config: Configuration) -> KinematicState:
-        """Snapshot ``config`` over the actuated joints of ``tree``."""
+        """Snapshot ``config`` over the actuated joints and ``tree``'s edges."""
         values: dict[str, tuple[float, ...]] = {}
         for name in tree.actuated_joint_names():
             num_dof = tree.joint(name).num_dof
             values[name] = tuple(config.get(name, [0.0] * num_dof))
-        return cls(values)
+        edges = {child: (edge.parent, edge.joint) for child, edge in tree.edges.items()}
+        return cls(values, edges)
 
     def as_configuration(self) -> dict[str, JointValues]:
         """Return the snapshot as a configuration mapping for forward kinematics."""
         return {name: list(vals) for name, vals in self.joint_values.items()}
+
+    def apply(self, tree: KinematicTree) -> dict[str, JointValues]:
+        """Restore this state's edges onto ``tree`` and return its configuration.
+
+        Re-parents nodes to match the snapshot (restoring any grasp), then hands back
+        the configuration for forward kinematics.
+        """
+        for child, (parent, joint) in self.edges.items():
+            tree.set_edge(Edge(parent=parent, child=child, joint=joint))
+        return self.as_configuration()

--- a/prpl-kinematics/tests/test_manipulation.py
+++ b/prpl-kinematics/tests/test_manipulation.py
@@ -1,0 +1,109 @@
+"""Unit tests for the Pick and Place manipulation primitives."""
+
+import os
+
+import numpy as np
+import pytest
+from spatialmath import SE3
+
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.geometry.shapes import BoxShape
+from prpl_kinematics.manipulation import Pick, Place, Primitive
+from prpl_kinematics.planning import BiRRTPlanner
+from prpl_kinematics.robots import make_panda
+from prpl_kinematics.tree.joints import FixedJoint
+from prpl_kinematics.tree.kinematic_tree import Edge, Node
+from prpl_kinematics.tree.state import KinematicState
+from prpl_kinematics.visualization import (
+    CameraParams,
+    PyBulletRenderer,
+    capture_image,
+    save_video,
+)
+
+_GRASP = SE3.Rx(np.pi)  # top-down: gripper z points down at the cube
+_PLACEMENT = SE3(0.5, 0.2, 0.25)  # move the cube 20 cm along +y
+
+
+def _scene(physics_client_id):
+    robot = make_panda()
+    table = BoxShape(size=(0.4, 0.6, 0.02))
+    robot.tree.add_node(Node("table", visuals=[table], collisions=[table]))
+    robot.tree.add_edge(
+        Edge(robot.tree.root, "table", FixedJoint(name="tf", origin=SE3(0.5, 0.0, 0.2)))
+    )
+    cube = BoxShape(size=(0.05, 0.05, 0.08))
+    robot.tree.add_node(Node("cube", visuals=[cube], collisions=[cube]))
+    robot.tree.add_edge(
+        Edge(robot.tree.root, "cube", FixedJoint(name="cf", origin=SE3(0.5, 0.0, 0.25)))
+    )
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(robot.tree)
+    checker.ignore(robot.allowed_collision_pairs)
+    checker.ignore([("cube", "table")])  # the cube rests on the table
+    # The gripper grasps (contacts) the cube; allow that contact.
+    gripper = ["panda_hand", "panda_leftfinger", "panda_rightfinger"]
+    checker.ignore([(link, "cube") for link in gripper])
+    planner = BiRRTPlanner(
+        robot.groups["arm"],
+        checker.in_collision,
+        np.random.default_rng(0),
+        num_iters=1000,
+    )
+    state = KinematicState.from_tree(robot.tree, robot.home)
+    return robot, checker, planner, state
+
+
+def test_primitives_conform_to_protocol(physics_client_id):
+    """Pick and Place satisfy the Primitive protocol."""
+    robot, checker, planner, _ = _scene(physics_client_id)
+    pick = Pick(robot, checker, planner, "cube", "table", [_GRASP])
+    place = Place(robot, checker, planner, "cube", "table", [_PLACEMENT])
+    assert isinstance(pick, Primitive) and isinstance(place, Primitive)
+
+
+def test_pick_attaches_object_to_gripper(physics_client_id):
+    """Picking re-parents the cube onto the gripper: its edge flips at the grasp."""
+    robot, checker, planner, state = _scene(physics_client_id)
+    plan = Pick(robot, checker, planner, "cube", "table", [_GRASP]).plan(state)
+    assert plan is not None
+    assert plan[0].edges["cube"][0] == robot.tree.root  # starts on the table/base
+    assert plan[-1].edges["cube"][0] == "tool_link"  # ends held by the gripper
+
+
+def test_place_releases_object_onto_surface(physics_client_id):
+    """Placing detaches the held cube back to the base at the target pose."""
+    robot, checker, planner, state = _scene(physics_client_id)
+    picked = Pick(robot, checker, planner, "cube", "table", [_GRASP]).plan(state)
+    assert picked is not None
+    placed = Place(robot, checker, planner, "cube", "table", [_PLACEMENT]).plan(
+        picked[-1]
+    )
+    assert placed is not None
+    assert placed[-1].edges["cube"][0] == robot.tree.root
+    cube_pose = robot.tree.forward_kinematics("cube", placed[-1].apply(robot.tree))
+    assert np.allclose(np.asarray(cube_pose.t), [0.5, 0.2, 0.25], atol=1e-6)
+
+
+def test_pick_and_place_video(physics_client_id, render_client_id, make_videos):
+    """With --make-videos: render the cube being picked and placed."""
+    if not make_videos:
+        pytest.skip("pass --make-videos to render the video")
+    robot, checker, planner, state = _scene(physics_client_id)
+    pick_plan = Pick(robot, checker, planner, "cube", "table", [_GRASP]).plan(state)
+    assert pick_plan is not None
+    place_plan = Place(robot, checker, planner, "cube", "table", [_PLACEMENT]).plan(
+        pick_plan[-1]
+    )
+    assert place_plan is not None
+
+    renderer = PyBulletRenderer(render_client_id)
+    renderer.load(robot.tree)
+    camera = CameraParams(target=(0.5, 0.1, 0.3), distance=1.4, yaw=55.0, pitch=-25.0)
+    # Apply each state's edges (so the grasp follows the gripper) then render.
+    frames = []
+    for plan_state in pick_plan + place_plan:
+        renderer.render(plan_state.apply(robot.tree))
+        frames.append(capture_image(render_client_id, camera))
+    save_video(frames, "panda_pick_place.mp4", fps=20)
+    assert os.path.exists("panda_pick_place.mp4")


### PR DESCRIPTION
## Summary

Adds the **Manipulation** milestone — `Pick` and `Place` primitives built on the tree stack.

The key idea: **a grasp is just an edge.** `Pick` re-parents the object onto the gripper with `tree.attach`, so the held object follows forward kinematics for free, and a plan is a `list[KinematicState]` whose object edge flips from the surface to the gripper at the grasp (and back at release). No parallel "attachment" bookkeeping — the tree already represents grasps.

- **`KinematicState` now snapshots the tree's edges** (parent + joint per node), not just joint values, and `apply(tree)` restores them. So a state captures grasps, and a plan replays structure + configuration. (`tree` gains an `edges` accessor and `set_edge`.)
- **`Primitive` protocol** (`plan(state) -> list[KinematicState] | None`); `Pick` and `Place` conform.
- **`Pick`** motion-plans to a pregrasp against all obstacles, then descends and retreats while disregarding the target object and its support surface (the gripper must contact the object and is near the surface) — following pybullet-helpers' collision logic. `PyBulletCollisionChecker.in_collision` gains `ignored_nodes` for this. **`Place`** is the symmetric release.

## Tests
- `Pick`/`Place` conform to `Primitive`.
- Picking flips the cube's edge to `tool_link` (grasped); placing flips it back to the base at the target pose (verified by FK).
- `--make-videos` renders a Panda picking a cube off a table and placing it 20 cm away (the cube follows the gripper, then is set down).

72 passed, 5 skipped; `./run_ci_checks.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
