### PR TITLE
prpl-kinematics: descend/retreat via numerical Cartesian following

### DIFF
--- a/prpl-kinematics/src/prpl_kinematics/manipulation.py
+++ b/prpl-kinematics/src/prpl_kinematics/manipulation.py
@@ -6,6 +6,12 @@ A grasp is just an edge: picking re-parents the object onto the gripper
 follows pybullet-helpers: motion-plan to a pregrasp against all obstacles, then
 descend and retreat while disregarding the target object and its support surface
 (the gripper must contact the object and is near the surface).
+
+The descend and retreat are straight Cartesian lines tracked by differential
+``NumericalIK`` (via ``follow_end_effector_path``), seeded continuously so the arm
+stays on one IK branch -- unlike joint-space interpolation between two independent
+analytic solutions, which can swing the arm through obstacles when the solver picks
+different branches for the pregrasp and grasp.
 """
 
 from __future__ import annotations
@@ -13,12 +19,15 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Protocol, runtime_checkable
 
+import numpy as np
 from spatialmath import SE3
 
 from prpl_kinematics.collision import PyBulletCollisionChecker
-from prpl_kinematics.planning.configuration_space import ConfigurationSpace
+from prpl_kinematics.ik.follow import follow_end_effector_path
+from prpl_kinematics.ik.numerical import NumericalIK
+from prpl_kinematics.planning.joint_space import JointSpace
 from prpl_kinematics.planning.motion_planner import MotionPlanner
-from prpl_kinematics.robots.robot import Robot
+from prpl_kinematics.robots.robot import Manipulator, Robot
 from prpl_kinematics.tree.kinematic_tree import Configuration
 from prpl_kinematics.tree.state import KinematicState
 
@@ -59,9 +68,9 @@ class Pick:
         self._surface = surface_frame
         self._grasps = grasps
         self._manipulator = robot.manipulators[manipulator]
-        self._group = robot.groups[self._manipulator.group]
         self._approach = approach_distance
         self._resolution = descend_resolution
+        self._follow_ik = _follow_ik(robot, self._manipulator)
 
     def plan(self, state: KinematicState) -> list[KinematicState] | None:
         """A pick plan ending with the object grasped, or ``None``."""
@@ -78,16 +87,21 @@ class Pick:
             pregrasp_cfg = ik.solve(pregrasp_world, config)
             if pregrasp_cfg is None:
                 continue
-            grasp_cfg = ik.solve(grasp_world, pregrasp_cfg)
-            if grasp_cfg is None:
-                continue
-
             approach = self._planner.plan(config, pregrasp_cfg)
             if approach is None:
                 continue
-            descend = self._segment(config, pregrasp_cfg, grasp_cfg, ignore)
+            descend = _cartesian_segment(
+                self._follow_ik,
+                self._checker,
+                pregrasp_world,
+                grasp_world,
+                pregrasp_cfg,
+                ignore,
+                self._resolution,
+            )
             if descend is None:
                 continue
+            grasp_cfg = descend[-1]
 
             plan = [
                 KinematicState.from_tree(tree, c) for c in [config, *approach, *descend]
@@ -95,24 +109,20 @@ class Pick:
             tree.attach(
                 self._object, ee, tree.relative_pose(ee, self._object, grasp_cfg)
             )
-            retreat = self._segment(config, grasp_cfg, pregrasp_cfg, ignore)
+            retreat = _cartesian_segment(
+                self._follow_ik,
+                self._checker,
+                grasp_world,
+                pregrasp_world,
+                grasp_cfg,
+                ignore,
+                self._resolution,
+            )
             if retreat is None:
                 continue
             plan += [KinematicState.from_tree(tree, c) for c in retreat]
             return plan
         return None
-
-    def _segment(
-        self,
-        base: Configuration,
-        start: Configuration,
-        end: Configuration,
-        ignore: set[str],
-    ) -> list[Configuration] | None:
-        """Collision-free straight segment of the manipulator group, or ``None``."""
-        return _straight_segment(
-            self._checker, self._group, base, start, end, ignore, self._resolution
-        )
 
 
 class Place:
@@ -140,9 +150,9 @@ class Place:
         self._surface = surface_frame
         self._placements = placements
         self._manipulator = robot.manipulators[manipulator]
-        self._group = robot.groups[self._manipulator.group]
         self._approach = approach_distance
         self._resolution = descend_resolution
+        self._follow_ik = _follow_ik(robot, self._manipulator)
 
     def plan(self, state: KinematicState) -> list[KinematicState] | None:
         """A place plan ending with the object released onto the surface, or
@@ -160,35 +170,32 @@ class Place:
             preplace_cfg = ik.solve(preplace_world, config)
             if preplace_cfg is None:
                 continue
-            place_cfg = ik.solve(place_world, preplace_cfg)
-            if place_cfg is None:
-                continue
-
             approach = self._planner.plan(config, preplace_cfg)
             if approach is None:
                 continue
-            descend = _straight_segment(
+            descend = _cartesian_segment(
+                self._follow_ik,
                 self._checker,
-                self._group,
-                config,
+                preplace_world,
+                place_world,
                 preplace_cfg,
-                place_cfg,
                 ignore,
                 self._resolution,
             )
             if descend is None:
                 continue
+            place_cfg = descend[-1]
 
             plan = [
                 KinematicState.from_tree(tree, c) for c in [config, *approach, *descend]
             ]
             tree.attach(self._object, tree.root, placement)  # release onto the surface
-            retreat = _straight_segment(
+            retreat = _cartesian_segment(
+                self._follow_ik,
                 self._checker,
-                self._group,
-                config,
+                place_world,
+                preplace_world,
                 place_cfg,
-                preplace_cfg,
                 ignore,
                 self._resolution,
             )
@@ -199,23 +206,38 @@ class Place:
         return None
 
 
-def _straight_segment(
+def _follow_ik(robot: Robot, manipulator: Manipulator) -> NumericalIK:
+    """A differential IK over the manipulator's arm group, for Cartesian following."""
+    group = robot.groups[manipulator.group]
+    assert isinstance(group, JointSpace), "Cartesian following needs a JointSpace arm"
+    return NumericalIK(robot.tree, group, manipulator.ee_frame)
+
+
+def _cartesian_segment(
+    follow_ik: NumericalIK,
     checker: PyBulletCollisionChecker,
-    group: ConfigurationSpace,
-    base: Configuration,
-    start: Configuration,
-    end: Configuration,
+    start_pose: SE3,
+    end_pose: SE3,
+    seed: Configuration,
     ignore: set[str],
     resolution: float,
 ) -> list[Configuration] | None:
-    """Interpolate ``group`` from ``start`` to ``end``, collision-checking each step."""
-    waypoints = group.interpolate(
-        group.to_vector(start), group.to_vector(end), resolution
-    )
-    configs: list[Configuration] = []
-    for vector in waypoints:
-        config = {**dict(base), **group.to_configuration(vector)}
+    """Follow a straight Cartesian line ``start_pose`` -> ``end_pose`` with numerical
+    IK.
+
+    The end-effector tracks evenly spaced poses, each solved seeded from the previous
+    (the first from ``seed``), so the arm stays on one continuous branch instead of
+    jumping between the analytic solver's solutions. Returns ``None`` if the follow
+    fails or any configuration collides (ignoring ``ignore`` -- the grasped object and
+    its support surface).
+    """
+    distance = float(np.linalg.norm(np.asarray(end_pose.t) - np.asarray(start_pose.t)))
+    steps = max(1, int(np.ceil(distance / resolution)))
+    poses = [start_pose.interp(end_pose, (i + 1) / steps) for i in range(steps)]
+    configs = follow_end_effector_path(follow_ik, poses, seed)
+    if configs is None:
+        return None
+    for config in configs:
         if checker.in_collision(config, ignored_nodes=ignore):
             return None
-        configs.append(config)
     return configs


### PR DESCRIPTION
## Manipulation: descend/retreat via numerical Cartesian following

`Pick`/`Place` built the descend and retreat by **joint-space interpolation between two independently-solved analytic IK configs** (pregrasp→grasp, preplace→place). For a redundant arm the analytic solver can return the two endpoints on **different IK branches**, so the straight joint-space line swings the end effector far off the intended path — e.g. sweeping a Vega arm through its own torso between a 12 cm pregrasp and grasp.

### Change
Interpolate a straight **Cartesian** line of end-effector poses and track it with a differential `NumericalIK` via `follow_end_effector_path`, seeded continuously so the arm stays on one IK branch:
- The analytic IK still handles the **global pregrasp/preplace reach**.
- `NumericalIK` handles the **local, continuous descent/retreat**.
- The grasp/place config is simply the last config of the followed descent (no separate analytic grasp solve).

This is the division `follow_end_effector_path` was built for (global analytic + local differential), and it's embodiment-agnostic.

### Tests
- `./run_ci_checks.sh`: 80 passed, 6 skipped (Panda `test_manipulation` pick/place unchanged in behavior, now via Cartesian following).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
