### PR TITLE
prpl-kinematics: natural gravity-stable Vega home pose

### DIFF
--- a/prpl-kinematics/src/prpl_kinematics/robots/vega.py
+++ b/prpl-kinematics/src/prpl_kinematics/robots/vega.py
@@ -26,6 +26,14 @@ def _gripper_joints(side: str) -> list[str]:
     return [f"{side}_gripper_j1", f"{side}_gripper_j2"]
 
 
+# A natural, gravity-stable home for the left arm (j1..j7): arms forward and down,
+# grippers at chest height. Chosen to minimize static gravity torque (the arms hold
+# themselves) while keeping every joint well inside its limits. The right arm
+# mirrors it across the body via these per-joint sign flips.
+_LEFT_ARM_HOME = [1.83, 0.51, 0.0, -2.04, 0.0, 0.27, 0.0]
+_ARM_MIRROR = [-1, -1, -1, 1, 1, -1, -1]
+
+
 def make_vega() -> Robot:
     """Assemble a bimanual Dexmate Vega 1U Robot (with parallel-jaw grippers)."""
     tree = load_urdf(str(get_assets_path() / "urdf" / "vega" / "vega_1u_gripper.urdf"))
@@ -45,8 +53,13 @@ def make_vega() -> Robot:
         )
         for side_name, prefix in [("left", "L"), ("right", "R")]
     }
+    arm_home: dict[str, list[float]] = {}
+    for i, (left, mirror) in enumerate(zip(_LEFT_ARM_HOME, _ARM_MIRROR), start=1):
+        arm_home[f"L_arm_j{i}"] = [left]
+        arm_home[f"R_arm_j{i}"] = [left * mirror]
     home: Configuration = {
-        name: [0.0] * tree.joint(name).num_dof for name in tree.actuated_joint_names()
+        name: arm_home.get(name, [0.0] * tree.joint(name).num_dof)
+        for name in tree.actuated_joint_names()
     }
     return Robot(
         name="vega-1u",


### PR DESCRIPTION
## Natural, gravity-stable Vega home

The home was the all-zero **T-pose**: both arms straight out horizontally, sitting right at the reach boundary — high static gravity torque (the arms would sag a lot under gravity) and a poor manipulation start.

Replace it with a natural pose: **arms forward and down, elbows out, grippers at chest height**, chosen by minimizing static gravity torque while keeping joints away from their limits.

### How it was chosen
Optimized the left-arm config to minimize the **static gravity torque** (gradient of the arm's potential energy from the URDF link masses — low ⇒ the arm nearly holds itself) plus a **joint-limit-centeredness** penalty, with soft bands keeping the grippers forward and at a usable height. The right arm mirrors it.

| pose | gravity torque² | max joint-limit frac |
|---|---|---|
| T-pose (old) | 7.60 | 0.85 |
| **this** | **2.16** | **0.60** |

Symmetric, self-collision-free. Dexmate ships no suggested home/retract (checked the full `dexmate_urdf` package — no SRDF `group_state`, no pose constants, no SDK), so this is our own.

### Tests
- `./run_ci_checks.sh`: 80 passed, 6 skipped (IK still solves seeded from the new home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
