### PR TITLE
prpl-kinematics: remove OMPLPlanner false seed, add seed_ompl (#496)

### DIFF
--- a/prpl-kinematics/notebooks/motion_planner_comparison.ipynb
+++ b/prpl-kinematics/notebooks/motion_planner_comparison.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "from prpl_kinematics.collision import PyBulletCollisionChecker\n",
     "from prpl_kinematics.geometry.shapes import BoxShape\n",
-    "from prpl_kinematics.planning import BiRRTPlanner, OMPLPlanner\n",
+    "from prpl_kinematics.planning import BiRRTPlanner, OMPLPlanner, seed_ompl\n",
     "from prpl_kinematics.robots import make_panda\n",
     "from prpl_kinematics.tree.joints import FixedJoint\n",
     "from prpl_kinematics.tree.kinematic_tree import Edge, Node\n",
@@ -60,7 +60,7 @@
    "source": [
     "## Planning time\n",
     "\n",
-    "Plan with each planner several times (varying the random seed) and compare the mean wall-clock time and path length. `BiRRTPlanner` wraps `prpl_utils.BiRRT`; `OMPLPlanner` wraps OMPL's `RRTConnect` and simplifies the result."
+    "Plan with each planner several times and compare the mean wall-clock time and path length. `BiRRTPlanner` takes a genuine per-instance `rng`, so we vary its seed across trials. OMPL's RNG is **process-global** (see `seed_ompl`): a per-instance seed couldn't be honored, so we seed it once and let the repeated runs draw independent samples from that stream."
    ]
   },
   {
@@ -72,8 +72,8 @@
    "source": [
     "def benchmark(make_planner, trials=5):\n",
     "    times, lengths, paths = [], [], []\n",
-    "    for seed in range(trials):\n",
-    "        planner = make_planner(np.random.default_rng(seed))\n",
+    "    for trial in range(trials):\n",
+    "        planner = make_planner(trial)\n",
     "        t0 = time.perf_counter()\n",
     "        path = planner.plan(start, goal)\n",
     "        times.append(time.perf_counter() - t0)\n",
@@ -83,11 +83,14 @@
     "    return times, lengths, paths\n",
     "\n",
     "\n",
+    "# BiRRT has a real per-instance rng, so each trial gets its own seed.\n",
     "birrt_times, birrt_lengths, birrt_paths = benchmark(\n",
-    "    lambda rng: BiRRTPlanner(arm, checker.in_collision, rng, num_iters=1000)\n",
+    "    lambda trial: BiRRTPlanner(arm, checker.in_collision, np.random.default_rng(trial), num_iters=1000)\n",
     ")\n",
+    "# OMPL's RNG is process-global: seed once; the repeated runs are independent draws.\n",
+    "seed_ompl(0)\n",
     "ompl_times, ompl_lengths, ompl_paths = benchmark(\n",
-    "    lambda rng: OMPLPlanner(arm, checker.in_collision, rng, timeout=5.0)\n",
+    "    lambda trial: OMPLPlanner(arm, checker.in_collision, timeout=5.0)\n",
     ")\n",
     "\n",
     "print(f\"{'planner':<8} {'mean time (ms)':>16} {'mean path length':>18}\")\n",

--- a/prpl-kinematics/src/prpl_kinematics/planning/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/__init__.py
@@ -4,7 +4,7 @@ from prpl_kinematics.planning.birrt import BiRRTPlanner
 from prpl_kinematics.planning.configuration_space import ConfigurationSpace
 from prpl_kinematics.planning.joint_space import JointSpace
 from prpl_kinematics.planning.motion_planner import MotionPlanner
-from prpl_kinematics.planning.ompl_planner import OMPLPlanner
+from prpl_kinematics.planning.ompl_planner import OMPLPlanner, seed_ompl
 from prpl_kinematics.planning.se2_space import SE2Space
 
 __all__ = [
@@ -14,4 +14,5 @@ __all__ = [
     "MotionPlanner",
     "OMPLPlanner",
     "SE2Space",
+    "seed_ompl",
 ]

--- a/prpl-kinematics/src/prpl_kinematics/planning/ompl_planner.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/ompl_planner.py
@@ -21,31 +21,48 @@ from prpl_kinematics.tree.kinematic_tree import Configuration
 
 ou.setLogLevel(ou.LogLevel.LOG_ERROR)
 
-# OMPL's RNG is process-global and can only be seeded before its first use, so
-# we seed it once (from the first planner's seed) rather than per ``plan`` call.
-_ompl_seeded: set[bool] = set()
+# OMPL's RNG is process-global: ``ou.RNG.setSeed`` only takes effect before the
+# RNG's first use. ``seed_ompl`` records the one seed applied this process and
+# refuses a conflicting re-seed rather than silently dropping it.
+_ompl_seed: list[int] = []
 
 
-def _seed_ompl_once(seed: int) -> None:
-    if not _ompl_seeded:
-        ou.RNG.setSeed(seed)
-        _ompl_seeded.add(True)
+def seed_ompl(seed: int) -> None:
+    """Seed OMPL's process-global RNG, once per process.
+
+    OMPL's RNG is shared across every ``OMPLPlanner`` and only honors a seed set
+    before its first use, so call this once, before constructing any planner.
+    Re-calling with the same seed is a no-op; re-calling with a *different* seed
+    raises -- the second seed could not take effect, so a silent no-op would be a
+    reproducibility trap. To collect IID samples, seed once and run repeatedly
+    (consecutive draws from the seeded stream are independent); for fully
+    reproducible per-seed runs, use one process per seed.
+    """
+    if _ompl_seed:
+        if _ompl_seed[0] != seed:
+            raise RuntimeError(
+                f"OMPL's RNG is process-global and already seeded with "
+                f"{_ompl_seed[0]}; it cannot be re-seeded to {seed} in the same "
+                f"process. Use one process per seed for reproducible per-seed runs."
+            )
+        return
+    ou.RNG.setSeed(int(seed))
+    _ompl_seed.append(int(seed))
 
 
 class OMPLPlanner:
     """Plans with OMPL's RRTConnect over a ConfigurationSpace.
 
-    Caveat: OMPL's RNG is process-global, so only the *first* planner's ``rng``
-    seeds it; later instances' seeds are ignored. This makes ``rng`` a partly
-    false affordance for multi-seed experiments -- to be reworked into an
-    explicit one-time ``seed_ompl`` (see the deferred design issue).
+    Unlike :class:`BiRRTPlanner`, this takes no per-instance ``rng``: OMPL's RNG is
+    process-global (see :func:`seed_ompl`), so a per-instance seed could not be
+    honored. Seed the process once with ``seed_ompl`` for reproducibility, or leave
+    it unseeded for OMPL's default.
     """
 
     def __init__(
         self,
         space: ConfigurationSpace,
         collision_fn: Callable[[Configuration], bool],
-        rng: np.random.Generator,
         timeout: float = 5.0,
         simplify: bool = True,
     ) -> None:
@@ -53,7 +70,6 @@ class OMPLPlanner:
         self._collision_fn = collision_fn
         self._timeout = timeout
         self._simplify = simplify
-        _seed_ompl_once(int(rng.integers(2**31)))
 
     def plan(
         self, start: Configuration, goal: Configuration

--- a/prpl-kinematics/tests/planning/test_ompl_planner.py
+++ b/prpl-kinematics/tests/planning/test_ompl_planner.py
@@ -1,6 +1,7 @@
 """Unit tests for OMPL-backed motion planning."""
 
 import numpy as np
+import pytest
 from spatialmath import SE3
 
 from prpl_kinematics.collision import PyBulletCollisionChecker
@@ -10,6 +11,8 @@ from prpl_kinematics.planning import (
     JointSpace,
     MotionPlanner,
     OMPLPlanner,
+    ompl_planner,
+    seed_ompl,
 )
 from prpl_kinematics.tree.joints import FixedJoint, PrismaticJoint
 from prpl_kinematics.tree.kinematic_tree import Edge, KinematicTree, Node
@@ -43,7 +46,7 @@ def test_planners_conform_to_motion_planner(physics_client_id):
     checker.load(_gantry_tree())
     space = JointSpace(_gantry_tree(), ["jx", "jy"])
     rng = np.random.default_rng(0)
-    assert isinstance(OMPLPlanner(space, checker.in_collision, rng), MotionPlanner)
+    assert isinstance(OMPLPlanner(space, checker.in_collision), MotionPlanner)
     assert isinstance(BiRRTPlanner(space, checker.in_collision, rng), MotionPlanner)
 
 
@@ -55,7 +58,7 @@ def test_ompl_solves_around_obstacle(physics_client_id):
     space = JointSpace(tree, ["jx", "jy"])
     start = {"jx": [0.0], "jy": [0.0]}
     goal = {"jx": [5.0], "jy": [5.0]}
-    planner = OMPLPlanner(space, checker.in_collision, np.random.default_rng(0))
+    planner = OMPLPlanner(space, checker.in_collision)
     path = planner.plan(start, goal)
     assert path is not None
     assert path[0] == start and path[-1] == goal
@@ -68,7 +71,22 @@ def test_ompl_returns_none_when_start_in_collision(physics_client_id):
     checker = PyBulletCollisionChecker(physics_client_id)
     checker.load(tree)
     space = JointSpace(tree, ["jx", "jy"])
-    planner = OMPLPlanner(
-        space, checker.in_collision, np.random.default_rng(0), timeout=1.0
-    )
+    planner = OMPLPlanner(space, checker.in_collision, timeout=1.0)
     assert planner.plan({"jx": [2.5], "jy": [2.5]}, {"jx": [5.0], "jy": [5.0]}) is None
+
+
+def test_seed_ompl_rejects_conflicting_reseed():
+    """seed_ompl is idempotent for the same seed and raises on a different one.
+
+    OMPL's RNG is process-global, so a second, different seed cannot take effect;
+    seed_ompl makes that loud instead of silently dropping it.
+    """
+    # Resetting the process-global seed state is exactly what this test needs.
+    ompl_planner._ompl_seed.clear()  # pylint: disable=protected-access
+    try:
+        seed_ompl(123)
+        seed_ompl(123)  # same seed: no-op
+        with pytest.raises(RuntimeError):
+            seed_ompl(456)
+    finally:
+        ompl_planner._ompl_seed.clear()  # pylint: disable=protected-access


### PR DESCRIPTION
## Remove OMPLPlanner's false per-instance seed; add `seed_ompl` (closes #496)

OMPL's RNG is **process-global** — `ou.RNG.setSeed` only takes effect before the RNG's first use. `OMPLPlanner` took a per-instance `rng` (to mirror `BiRRTPlanner`), but only the *first* planner's seed was applied; every later one was silently dropped. A loop like `for seed in range(K): OMPLPlanner(..., rng=default_rng(seed)).plan(...)` looked like K seeded runs but wasn't — a quiet reproducibility trap.

### Change
- **Drop `OMPLPlanner`'s `rng` parameter.**
- Add **`prpl_kinematics.planning.seed_ompl(seed)`**: seeds OMPL's global RNG once, and **raises** if re-called with a different seed in the same process (loud, not silent). Same-seed re-call is a no-op.
- Documented the model: to collect IID samples, **seed once and run repeatedly** (consecutive draws are independent); for reproducible per-seed runs, **one process per seed**.
- `BiRRTPlanner` keeps its genuine per-instance `rng` — the asymmetry is now honest and explicit.

### Notebook
`motion_planner_comparison.ipynb`: BiRRT varies its seed per trial; OMPL is seeded once with `seed_ompl(0)`, then the repeated runs draw independent samples. Markdown updated to explain why.

### Tests
- New `test_seed_ompl_rejects_conflicting_reseed` (idempotent same-seed, raises on a different seed).
- `OMPLPlanner` call sites updated to drop `rng`.
- `./run_ci_checks.sh`: 82 passed, 6 skipped. Comparison notebook executes (`--nbmake`).

### Acceptance
✅ `OMPLPlanner` no longer accepts a per-instance seed it can't honor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
