### PR TITLE
prpl-kinematics: bimanual Vega handover (pick → hand over → place)

### DIFF
--- a/prpl-kinematics/scripts/render_vega_handover_blender.py
+++ b/prpl-kinematics/scripts/render_vega_handover_blender.py
@@ -1,0 +1,178 @@
+"""Render the Vega pick -> handover -> place plan through Blender (high fidelity).
+
+This is a standalone render script, deliberately NOT a pytest test: the Blender
+render takes several minutes, so it must never run as part of the test suite / CI.
+Run it directly to (re)generate ``vega_pick_handover_place_blender.mp4``::
+
+    python scripts/render_vega_handover_blender.py
+
+The scene and plan mirror ``tests/test_manipulation.py`` (the left arm picks a bar
+by one end, hands the far end to the right arm, which lays it flat on the table);
+the fast PyBullet preview of the same plan lives there as a ``--make-videos`` test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pybullet as p
+from spatialmath import SE3
+
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.geometry.shapes import BoxShape
+from prpl_kinematics.manipulation import Handover, Pick, Place
+from prpl_kinematics.planning import BiRRTPlanner
+from prpl_kinematics.robots import Robot, make_vega
+from prpl_kinematics.tree.joints import FixedJoint
+from prpl_kinematics.tree.kinematic_tree import Edge, Node
+from prpl_kinematics.tree.state import KinematicState
+from prpl_kinematics.visualization import (
+    BlenderRenderer,
+    CameraParams,
+    render_states,
+    save_video,
+)
+
+_PlannerFactory = Callable[[str], BiRRTPlanner]
+_Scene = tuple[
+    Robot, PyBulletCollisionChecker, _PlannerFactory, KinematicState, SE3, float
+]
+
+_BAR_LENGTH = 0.22  # the grasped object is a long bar (its local z axis)
+_GIVE_END = 0.07  # the left gripper grasps this far toward the +z end of the bar
+_TAKE_END = -0.07  # the right gripper takes the opposite (-z) end
+_HANDOVER_POSES = [SE3(0.66, 0.0, 0.80) * SE3.Rx(-np.pi / 2)]  # bar horizontal, world Y
+_RECEIVE_GRASPS = [
+    SE3.Rt((SE3.Ry(np.pi / 2) * SE3.Rz(np.pi / 2)).R, [0, 0, _TAKE_END]),
+    SE3.Rt((SE3.Ry(np.pi / 2) * SE3.Rz(-np.pi / 2)).R, [0, 0, _TAKE_END]),
+]
+_CAMERA = CameraParams(
+    target=(0.60, 0.0, 0.60),
+    distance=1.95,
+    yaw=80.0,
+    pitch=-16.0,
+    fov=50.0,
+    width=640,
+    height=480,
+)
+
+
+def _scene(physics_client_id: int) -> _Scene:
+    """The Vega bar-on-table scene; returns robot, checker, planner factory, state."""
+    robot = make_vega()
+    robot_links = set(robot.tree.nodes)
+    left = robot.manipulators["left"]
+    home_ee = robot.tree.forward_kinematics(left.ee_frame, robot.home)
+    rotation = np.asarray(home_ee.R)
+    # Roll 90 deg about the approach axis so the jaws straddle the bar.
+    rolled = (SE3.Rt(rotation, [0, 0, 0]) * SE3.Rz(np.pi / 2)).R
+    pick_grasp = SE3.Rt(rolled, [0, 0, _GIVE_END])
+    grasp_world = np.asarray(home_ee.t) + 0.20 * rotation[:, 2]
+    bar_center = grasp_world - np.array([0, 0, _GIVE_END])
+    table_top = bar_center[2] - _BAR_LENGTH / 2
+
+    table = BoxShape(size=(0.34, 0.95, 0.02))
+    robot.tree.add_node(Node("table", visuals=[table], collisions=[table]))
+    robot.tree.add_edge(
+        Edge(
+            robot.tree.root,
+            "table",
+            FixedJoint(name="tf", origin=SE3(bar_center[0], 0.05, table_top - 0.01)),
+        )
+    )
+    bar_shape = BoxShape(size=(0.05, 0.05, _BAR_LENGTH))
+    robot.tree.add_node(Node("cube", visuals=[bar_shape], collisions=[bar_shape]))
+    robot.tree.add_edge(
+        Edge(robot.tree.root, "cube", FixedJoint(name="cf", origin=SE3(*bar_center)))
+    )
+
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(robot.tree)
+    checker.ignore(robot.allowed_collision_pairs)
+    checker.ignore([("cube", "table")])
+    checker.ignore([(link, "cube") for link in robot_links])
+
+    def planner(group: str) -> BiRRTPlanner:
+        return BiRRTPlanner(
+            robot.groups[group],
+            checker.in_collision,
+            np.random.default_rng(0),
+            num_iters=2000,
+        )
+
+    state = KinematicState.from_tree(robot.tree, robot.home)
+    return robot, checker, planner, state, pick_grasp, table_top
+
+
+def _plan(
+    robot: Robot,
+    checker: PyBulletCollisionChecker,
+    planner: _PlannerFactory,
+    state: KinematicState,
+    pick_grasp: SE3,
+    table_top: float,
+) -> list[KinematicState]:
+    """The full left-pick -> handover -> right-place plan."""
+    pick = Pick(
+        robot,
+        checker,
+        planner("left_arm"),
+        "cube",
+        "table",
+        [pick_grasp],
+        manipulator="left",
+        approach_distance=0.20,
+    ).plan(state)
+    assert pick is not None, "pick failed"
+    handover = Handover(
+        robot,
+        checker,
+        planner("left_arm"),
+        planner("right_arm"),
+        "cube",
+        _HANDOVER_POSES,
+        _RECEIVE_GRASPS,
+        from_manipulator="left",
+        to_manipulator="right",
+        approach_distance=0.08,
+    ).plan(pick[-1])
+    assert handover is not None, "handover failed"
+    bar_rest_z = table_top + 0.025
+    placements = [
+        SE3(px, py, bar_rest_z) * SE3.Ry(np.pi / 2)
+        for px in (0.60, 0.66)
+        for py in (-0.16, -0.22)
+    ]
+    place = Place(
+        robot,
+        checker,
+        planner("right_arm"),
+        "cube",
+        "table",
+        placements,
+        manipulator="right",
+        approach_distance=0.12,
+    ).plan(handover[-1])
+    assert place is not None, "place failed"
+    return pick + handover + place
+
+
+def main() -> None:
+    """Build the scene, plan, render through Blender, and write the video."""
+    physics_client_id = p.connect(p.DIRECT)
+    robot, checker, planner, state, pick_grasp, table_top = _scene(physics_client_id)
+    plan = _plan(robot, checker, planner, state, pick_grasp, table_top)
+    renderer = BlenderRenderer(samples=48)
+    renderer.load(robot.tree)
+    # render_states restores each state's grasp edges so the held bar follows the
+    # gripper through the handover.
+    frames = render_states(renderer, plan, robot.tree, _CAMERA)
+    path = "vega_pick_handover_place_blender.mp4"
+    save_video(frames, path, fps=20)
+    print(f"wrote {path} ({len(frames)} frames)")
+    p.disconnect(physics_client_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/prpl-kinematics/src/prpl_kinematics/manipulation.py
+++ b/prpl-kinematics/src/prpl_kinematics/manipulation.py
@@ -207,6 +207,130 @@ class Place:
         return None
 
 
+class Handover:
+    """Pass a held object from one manipulator to the other.
+
+    The object starts grasped by ``from_manipulator``. The giving arm carries it
+    to a handover pose between the arms; the receiving arm reaches a pregrasp and
+    descends along the grasp's approach axis until the receiving gripper takes the
+    object (it re-parents from the giving gripper onto the receiving one); then the
+    giving arm withdraws to its rest pose. ``handover_poses`` yields the object's
+    world pose during the transfer and ``grasps`` the receiving gripper's pose in
+    the object frame; the first combination whose carry, receive, descent, and
+    withdrawal all succeed is used.
+
+    Because the object is just a tree edge, no second object is needed: only the
+    edge's parent flips, mid-air, from one gripper to the other. The two arms move
+    one at a time (carry, then receive, then withdraw), so each phase is a single
+    arm's collision-checked motion against an otherwise static scene. The giving
+    arm withdraws by motion-planning back to ``give_rest`` rather than by a straight
+    Cartesian pull: at a centered handover the redundant arm is near full stretch,
+    and a Cartesian retreat swings its elbow into the torso, whereas the planner
+    routes around it.
+    """
+
+    def __init__(
+        self,
+        robot: Robot,
+        checker: PyBulletCollisionChecker,
+        give_planner: MotionPlanner,
+        receive_planner: MotionPlanner,
+        object_frame: str,
+        handover_poses: Iterable[SE3],
+        grasps: Iterable[SE3],
+        from_manipulator: str = "left",
+        to_manipulator: str = "right",
+        approach_distance: float = 0.12,
+        descend_resolution: float = 0.02,
+        give_rest: Configuration | None = None,
+    ) -> None:
+        self._robot = robot
+        self._checker = checker
+        self._give_planner = give_planner
+        self._receive_planner = receive_planner
+        self._object = object_frame
+        self._handover_poses = handover_poses
+        self._grasps = grasps
+        self._giver = robot.manipulators[from_manipulator]
+        self._taker = robot.manipulators[to_manipulator]
+        self._approach = approach_distance
+        self._resolution = descend_resolution
+        self._give_rest = robot.home if give_rest is None else give_rest
+        self._give_space = robot.groups[self._giver.group]
+        self._give_follow = _follow_ik(robot, self._giver)
+        self._take_follow = _follow_ik(robot, self._taker)
+
+    def plan(self, state: KinematicState) -> list[KinematicState] | None:
+        """A handover plan ending with the object held by the receiving arm, or
+        ``None``."""
+        tree = self._robot.tree
+        give_ee, take_ee = self._giver.ee_frame, self._taker.ee_frame
+        ignore = {self._object}
+        for handover_pose in self._handover_poses:
+            config: Configuration = state.apply(tree)  # restore the scene each attempt
+            # Carry the object to the handover pose by moving the giving arm; the
+            # object follows because it is parented onto the giving gripper.
+            ee_from_object = tree.relative_pose(give_ee, self._object, config)
+            give_target = handover_pose * ee_from_object.inv()
+            give_cfg = _reach(self._give_follow, self._giver.ik, give_target, config)
+            if give_cfg is None:
+                continue
+            carry = self._give_planner.plan(config, give_cfg)
+            if carry is None:
+                continue
+            config = carry[-1]
+
+            for grasp in self._grasps:
+                grasp_world = handover_pose * grasp
+                pregrasp_world = grasp_world * SE3(0.0, 0.0, -self._approach)
+
+                pregrasp_cfg = _reach(
+                    self._take_follow, self._taker.ik, pregrasp_world, config
+                )
+                if pregrasp_cfg is None:
+                    continue
+                approach = self._receive_planner.plan(config, pregrasp_cfg)
+                if approach is None:
+                    continue
+                descend = _cartesian_segment(
+                    self._take_follow,
+                    self._checker,
+                    pregrasp_world,
+                    grasp_world,
+                    pregrasp_cfg,
+                    ignore,
+                    self._resolution,
+                )
+                if descend is None:
+                    continue
+                grasp_cfg = descend[-1]
+
+                plan = [
+                    KinematicState.from_tree(tree, c)
+                    for c in [*carry, *approach, *descend]
+                ]
+                # The receiving gripper takes the object: flip its parent edge.
+                tree.attach(
+                    self._object,
+                    take_ee,
+                    tree.relative_pose(take_ee, self._object, grasp_cfg),
+                )
+                # Withdraw the giving arm to its rest pose (keeping the receiving
+                # arm, now holding the object, where it is).
+                rest_cfg = {
+                    **grasp_cfg,
+                    **self._give_space.to_configuration(
+                        self._give_space.to_vector(self._give_rest)
+                    ),
+                }
+                withdraw = self._give_planner.plan(grasp_cfg, rest_cfg)
+                if withdraw is None:
+                    continue
+                plan += [KinematicState.from_tree(tree, c) for c in withdraw]
+                return plan
+        return None
+
+
 def _follow_ik(robot: Robot, manipulator: Manipulator) -> NumericalIK:
     """A differential IK over the manipulator's arm group, for Cartesian following."""
     group = robot.groups[manipulator.group]

--- a/prpl-kinematics/src/prpl_kinematics/robots/vega.py
+++ b/prpl-kinematics/src/prpl_kinematics/robots/vega.py
@@ -34,6 +34,10 @@ def _gripper_joints(side: str) -> list[str]:
 # independently (Vega's arms are not a simple sign-flip mirror of each other).
 _LEFT_ARM_HOME = [1.809, 0.636, -0.244, -2.04, 0.841, 0.129, -0.833]
 _RIGHT_ARM_HOME = [-1.043, -1.278, -0.793, -1.778, -0.148, -0.396, 0.417]
+# Rest the parallel jaws open (each finger is revolute over [0, 0.785]); like the
+# Panda's open home, this is the ready-to-grasp pose, and a grasp closes on the
+# object rather than starting clamped shut through it.
+_GRIPPER_OPEN = 0.6
 
 
 def make_vega() -> Robot:
@@ -55,12 +59,15 @@ def make_vega() -> Robot:
         )
         for side_name, prefix in [("left", "L"), ("right", "R")]
     }
-    arm_home: dict[str, list[float]] = {}
+    rest: dict[str, list[float]] = {}
     for i, (left, right) in enumerate(zip(_LEFT_ARM_HOME, _RIGHT_ARM_HOME), start=1):
-        arm_home[f"L_arm_j{i}"] = [left]
-        arm_home[f"R_arm_j{i}"] = [right]
+        rest[f"L_arm_j{i}"] = [left]
+        rest[f"R_arm_j{i}"] = [right]
+    for side in ("L", "R"):
+        for finger in _gripper_joints(side):
+            rest[finger] = [_GRIPPER_OPEN]
     home: Configuration = {
-        name: arm_home.get(name, [0.0] * tree.joint(name).num_dof)
+        name: rest.get(name, [0.0] * tree.joint(name).num_dof)
         for name in tree.actuated_joint_names()
     }
     return Robot(

--- a/prpl-kinematics/tests/test_manipulation.py
+++ b/prpl-kinematics/tests/test_manipulation.py
@@ -8,9 +8,9 @@ from spatialmath import SE3
 
 from prpl_kinematics.collision import PyBulletCollisionChecker
 from prpl_kinematics.geometry.shapes import BoxShape
-from prpl_kinematics.manipulation import Pick, Place, Primitive
+from prpl_kinematics.manipulation import Handover, Pick, Place, Primitive
 from prpl_kinematics.planning import BiRRTPlanner
-from prpl_kinematics.robots import make_panda
+from prpl_kinematics.robots import make_panda, make_vega
 from prpl_kinematics.tree.joints import FixedJoint
 from prpl_kinematics.tree.kinematic_tree import Edge, Node
 from prpl_kinematics.tree.state import KinematicState
@@ -107,3 +107,207 @@ def test_pick_and_place_video(physics_client_id, render_client_id, make_videos):
         frames.append(capture_image(render_client_id, camera))
     save_video(frames, "panda_pick_place.mp4", fps=20)
     assert os.path.exists("panda_pick_place.mp4")
+
+
+# A bimanual left->right handover on Vega: the giving (left) arm picks a bar near
+# one end, carries it to a handover pose where it lies horizontal between the arms,
+# the receiving (right) arm takes the *other* end, the left arm withdraws, and the
+# right arm lays the bar flat on the other side of the table. Grasping opposite ends
+# (and resting the jaws open) keeps the two grippers clear of each other -- their
+# mutual collisions are NOT masked here, so the planner rejects any interpenetration.
+# The geometry is tuned so the left arm reaches the centre without its elbow fouling
+# the torso; the primitives still search their candidate lists.
+_BAR_LENGTH = 0.22  # the grasped object is a long bar (its local z axis)
+_GIVE_END = 0.07  # the left gripper grasps this far toward the +z end of the bar
+_TAKE_END = -0.07  # the right gripper takes the opposite (-z) end
+# The bar lies horizontal along world Y at the handover, so each arm keeps to its
+# own side (left holds the +y end, right the -y end) instead of crossing over.
+_HANDOVER_POSES = [SE3(0.66, 0.0, 0.80) * SE3.Rx(-np.pi / 2)]
+_RECEIVE_GRASPS = [
+    SE3.Rt((SE3.Ry(np.pi / 2) * SE3.Rz(np.pi / 2)).R, [0, 0, _TAKE_END]),
+    SE3.Rt((SE3.Ry(np.pi / 2) * SE3.Rz(-np.pi / 2)).R, [0, 0, _TAKE_END]),
+]
+
+
+def _vega_handover_scene(physics_client_id):
+    """A Vega scene with a wide table and a bar the left arm can pick by one end.
+
+    Returns the robot, checker, a per-group planner factory, the start state, the left-
+    arm pick grasp, and the table's top surface height.
+    """
+    robot = make_vega()
+    robot_links = set(robot.tree.nodes)  # everything not added below is the robot
+    left = robot.manipulators["left"]
+    home_ee = robot.tree.forward_kinematics(left.ee_frame, robot.home)
+    rotation = np.asarray(home_ee.R)
+    # Roll 90 deg about the approach axis so the jaws straddle the bar (fingers on
+    # opposite faces) rather than splaying along it; grasp near the +z end.
+    rolled = (SE3.Rt(rotation, [0, 0, 0]) * SE3.Rz(np.pi / 2)).R
+    pick_grasp = SE3.Rt(rolled, [0, 0, _GIVE_END])
+    # Place the standing bar so the left arm's end grasp lands at its home EE pose.
+    grasp_world = np.asarray(home_ee.t) + 0.20 * rotation[:, 2]
+    bar_center = grasp_world - np.array([0, 0, _GIVE_END])
+    table_top = bar_center[2] - _BAR_LENGTH / 2  # the bar stands on the table
+
+    table = BoxShape(size=(0.34, 0.95, 0.02))
+    robot.tree.add_node(Node("table", visuals=[table], collisions=[table]))
+    robot.tree.add_edge(
+        Edge(
+            robot.tree.root,
+            "table",
+            FixedJoint(name="tf", origin=SE3(bar_center[0], 0.05, table_top - 0.01)),
+        )
+    )
+    bar_shape = BoxShape(size=(0.05, 0.05, _BAR_LENGTH))
+    robot.tree.add_node(Node("cube", visuals=[bar_shape], collisions=[bar_shape]))
+    robot.tree.add_edge(
+        Edge(robot.tree.root, "cube", FixedJoint(name="cf", origin=SE3(*bar_center)))
+    )
+
+    checker = PyBulletCollisionChecker(physics_client_id)
+    checker.load(robot.tree)
+    checker.ignore(robot.allowed_collision_pairs)
+    checker.ignore([("cube", "table")])  # the bar rests on the table
+    checker.ignore([(link, "cube") for link in robot_links])  # a gripper grasps it
+
+    def planner(group):
+        return BiRRTPlanner(
+            robot.groups[group],
+            checker.in_collision,
+            np.random.default_rng(0),
+            num_iters=2000,
+        )
+
+    state = KinematicState.from_tree(robot.tree, robot.home)
+    return robot, checker, planner, state, pick_grasp, table_top
+
+
+def test_handover_conforms_to_protocol(physics_client_id):
+    """Handover satisfies the Primitive protocol."""
+    robot, checker, planner, _, _, _ = _vega_handover_scene(physics_client_id)
+    handover = Handover(
+        robot,
+        checker,
+        planner("left_arm"),
+        planner("right_arm"),
+        "cube",
+        _HANDOVER_POSES,
+        _RECEIVE_GRASPS,
+    )
+    assert isinstance(handover, Primitive)
+
+
+def test_handover_transfers_object_between_grippers(physics_client_id):
+    """A handover flips the cube's parent edge from the left gripper to the right."""
+    robot, checker, planner, state, grasp, _ = _vega_handover_scene(physics_client_id)
+    picked = Pick(
+        robot,
+        checker,
+        planner("left_arm"),
+        "cube",
+        "table",
+        [grasp],
+        manipulator="left",
+        approach_distance=0.20,
+    ).plan(state)
+    assert picked is not None
+    assert picked[-1].edges["cube"][0] == "L_ee"  # held by the left gripper
+    handed = Handover(
+        robot,
+        checker,
+        planner("left_arm"),
+        planner("right_arm"),
+        "cube",
+        _HANDOVER_POSES,
+        _RECEIVE_GRASPS,
+        from_manipulator="left",
+        to_manipulator="right",
+        approach_distance=0.08,
+    ).plan(picked[-1])
+    assert handed is not None
+    assert handed[0].edges["cube"][0] == "L_ee"  # starts on the left gripper
+    assert handed[-1].edges["cube"][0] == "R_ee"  # ends on the right gripper
+
+
+# Frames the bimanual scene: the action runs from the table top up to the raised
+# handover, so the camera looks slightly down on the whole spread.
+_PLAN_CAMERA = CameraParams(
+    target=(0.60, 0.0, 0.60),
+    distance=1.95,
+    yaw=80.0,
+    pitch=-16.0,
+    fov=50.0,
+    width=640,
+    height=480,
+)
+
+
+def _pick_handover_place(robot, checker, planner, state, grasp, table_top):
+    """The full left-pick -> handover -> right-place plan for the Vega scene."""
+    pick = Pick(
+        robot,
+        checker,
+        planner("left_arm"),
+        "cube",
+        "table",
+        [grasp],
+        manipulator="left",
+        approach_distance=0.20,
+    ).plan(state)
+    assert pick is not None
+    handover = Handover(
+        robot,
+        checker,
+        planner("left_arm"),
+        planner("right_arm"),
+        "cube",
+        _HANDOVER_POSES,
+        _RECEIVE_GRASPS,
+        from_manipulator="left",
+        to_manipulator="right",
+        approach_distance=0.08,
+    ).plan(pick[-1])
+    assert handover is not None
+    # Lay the bar flat on the table's right side (long axis along world x).
+    bar_rest_z = table_top + 0.025
+    placements = [
+        SE3(px, py, bar_rest_z) * SE3.Ry(np.pi / 2)
+        for px in (0.60, 0.66)
+        for py in (-0.16, -0.22)
+    ]
+    place = Place(
+        robot,
+        checker,
+        planner("right_arm"),
+        "cube",
+        "table",
+        placements,
+        manipulator="right",
+        approach_distance=0.12,
+    ).plan(handover[-1])
+    assert place is not None
+    return pick + handover + place
+
+
+def test_vega_pick_handover_place_video(
+    physics_client_id, render_client_id, make_videos
+):
+    """With --make-videos: left picks, hands the bar to right, right places it."""
+    if not make_videos:
+        pytest.skip("pass --make-videos to render the video")
+    robot, checker, planner, state, grasp, table_top = _vega_handover_scene(
+        physics_client_id
+    )
+    plan = _pick_handover_place(robot, checker, planner, state, grasp, table_top)
+
+    renderer = PyBulletRenderer(render_client_id)
+    renderer.load(robot.tree)
+    frames = []
+    for plan_state in plan:
+        renderer.render(plan_state.apply(robot.tree))
+        frames.append(capture_image(render_client_id, _PLAN_CAMERA))
+    save_video(frames, "vega_pick_handover_place.mp4", fps=20)
+    assert os.path.exists("vega_pick_handover_place.mp4")
+    # A high-fidelity Blender render of this same plan is produced by the standalone
+    # scripts/render_vega_handover_blender.py (kept out of the test suite because the
+    # Blender render takes several minutes).


### PR DESCRIPTION


https://github.com/user-attachments/assets/340c8a94-abe1-4d63-98a3-883995fe34ee



## Summary

Adds a **bimanual handover** capability for Vega: a new `Handover` manipulation primitive plus a demo where the left arm picks a bar, hands the far end to the right arm, and the right arm lays it on the table.

A handover is just a tree edge flipping parent from one gripper to the other, mid-air. The primitive runs three single-arm phases — **carry** (giving arm brings the object to a handover pose), **receive** (taking arm reaches a pregrasp and descends onto it), **withdraw** (giving arm retreats) — reusing the existing `_reach` / `_cartesian_segment` helpers. The giving arm withdraws by **motion-planning back to rest** rather than a Cartesian pull: a centered handover puts the redundant arm near full stretch, where a straight retreat swings its elbow into the torso.

## Details

- **Grippers rest open at home** (`make_vega`), matching the Panda convention. They were sitting fully closed (0.0), so grasps rendered as a closed fist clamped through the object and two grippers could never share one.
- **Opposite-ends grasp**: the bar is presented horizontal along the robot's left-right axis, so each arm holds its own end and the bodies never cross. The pick grasp is rolled 90° so the jaws straddle the bar instead of splaying along it.
- **Gripper-vs-gripper collisions are enforced** (not masked), so the planner rejects any interpenetration.

## Tests / CI

- `tests/test_manipulation.py`: `Handover` conforms to the `Primitive` protocol; a handover flips the bar's edge `L_ee → R_ee`; a `--make-videos` PyBullet render of the full pick → handover → place plan.
- `scripts/render_vega_handover_blender.py`: a **standalone** high-fidelity Blender render of the same plan, deliberately **not** a pytest test (the render takes several minutes, so it never runs in CI).
- `./run_ci_checks.sh` green: black, mypy, pylint, and the full suite (84 passed / 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
