### PR TITLE
prpl-kinematics: add ssik analytic IK backend (solves Vega's 7R arm)

### DIFF
--- a/prpl-kinematics/notebooks/vega_ik_comparison.ipynb
+++ b/prpl-kinematics/notebooks/vega_ik_comparison.ipynb
@@ -1,0 +1,310 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4bf500b7",
+   "metadata": {},
+   "source": [
+    "# Analytic IK for the Vega arm: `ssik` vs the bundled EAIK solver\n",
+    "\n",
+    "Vega's 7-DOF arm has a **non-spherical wrist** (a *non-SRS* 7R chain), so no textbook closed-form 6R/7R solver applies. `prpl_kinematics` ships [`VegaArmIK`](../src/prpl_kinematics/robots/vega_ik.py), which works around this by locking two joints, grid-searching them, and running EAIK on the residual 5R chain.\n",
+    "\n",
+    "[`ssik`](https://pypi.org/project/ssik/) (Personal Robotics Lab) solves exactly this non-SRS 7R class analytically. This notebook checks that `ssik` reaches Vega's targets and benchmarks it against `VegaArmIK`. The backend is selected with `make_vega(ik=...)`.\n",
+    "\n",
+    "> Requires the optional extra: `pip install \"prpl_kinematics[ssik]\"` (`ssik` needs `numpy>=2`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1631dc78",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T15:49:48.012266Z",
+     "iopub.status.busy": "2026-06-02T15:49:48.012182Z",
+     "iopub.status.idle": "2026-06-02T15:49:50.208030Z",
+     "shell.execute_reply": "2026-06-02T15:49:50.207233Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "pybullet build time: Mar 13 2026 19:11:34\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "left-arm IK: VegaArmIK (eaik) vs SSIKSolver (ssik)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "from prpl_kinematics.robots import make_vega\n",
+    "\n",
+    "eaik = make_vega(ik=\"eaik\")  # bundled lock-and-grid-search over EAIK\n",
+    "ssik = make_vega(ik=\"ssik\")  # the ssik analytic solver\n",
+    "LEFT = [f\"L_arm_j{i}\" for i in range(1, 8)]\n",
+    "RIGHT = [f\"R_arm_j{i}\" for i in range(1, 8)]\n",
+    "print(\"left-arm IK:\",\n",
+    "      type(eaik.manipulators['left'].ik).__name__, \"(eaik) vs\",\n",
+    "      type(ssik.manipulators['left'].ik).__name__, \"(ssik)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1396276b",
+   "metadata": {},
+   "source": [
+    "## Correctness: round-trip a known pose\n",
+    "\n",
+    "Take a joint configuration, use its forward kinematics as the IK target, and solve from the home seed. We report how closely the solved configuration's FK matches the target (each solver returns the branch nearest the seed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f6089bd3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T15:49:50.210039Z",
+     "iopub.status.busy": "2026-06-02T15:49:50.209812Z",
+     "iopub.status.idle": "2026-06-02T15:49:54.450272Z",
+     "shell.execute_reply": "2026-06-02T15:49:54.449840Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "left  VegaArmIK  position error = 1.55e-05\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "left  ssik       position error = 4.72e-16\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "right VegaArmIK  position error = 2.39e-05\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "right ssik       position error = 4.58e-16\n"
+     ]
+    }
+   ],
+   "source": [
+    "truth_q = [0.3, -0.4, 0.2, -1.0, 0.1, 0.6, -0.3]\n",
+    "for side, joints in [(\"left\", LEFT), (\"right\", RIGHT)]:\n",
+    "    truth = {**dict(eaik.home), **{n: [v] for n, v in zip(joints, truth_q)}}\n",
+    "    for name, robot in [(\"VegaArmIK\", eaik), (\"ssik\", ssik)]:\n",
+    "        m = robot.manipulators[side]\n",
+    "        target = robot.tree.forward_kinematics(m.ee_frame, truth)\n",
+    "        sol = m.ik.solve(target, robot.home)\n",
+    "        reached = robot.tree.forward_kinematics(m.ee_frame, sol)\n",
+    "        err = np.linalg.norm(np.asarray(reached.t) - np.asarray(target.t))\n",
+    "        print(f\"{side:5s} {name:10s} position error = {err:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "296324c1",
+   "metadata": {},
+   "source": [
+    "## Benchmark: success rate, speed, accuracy\n",
+    "\n",
+    "Sample random in-limit configurations, use their forward kinematics as targets, and solve each from the home seed with both backends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4a27b269",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T15:49:54.451634Z",
+     "iopub.status.busy": "2026-06-02T15:49:54.451549Z",
+     "iopub.status.idle": "2026-06-02T15:50:15.770075Z",
+     "shell.execute_reply": "2026-06-02T15:50:15.769560Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "solver         success    ms/solve   max pos err\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VegaArmIK        30/30      354.8       8.9e-05\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ssik             30/30      355.3       2.5e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng = np.random.default_rng(0)\n",
+    "tree = eaik.tree\n",
+    "lower = np.array([tree.joint(n).lower_limits[0] for n in LEFT])\n",
+    "upper = np.array([tree.joint(n).upper_limits[0] for n in LEFT])\n",
+    "num_targets = 30\n",
+    "targets = []\n",
+    "for _ in range(num_targets):\n",
+    "    q = lower + (upper - lower) * rng.random(7)\n",
+    "    cfg = {**dict(eaik.home), **{n: [float(v)] for n, v in zip(LEFT, q)}}\n",
+    "    targets.append(tree.forward_kinematics(\"L_ee\", cfg))\n",
+    "\n",
+    "\n",
+    "def benchmark(robot):\n",
+    "    \"\"\"Success count, mean ms/solve, and worst position error over targets.\"\"\"\n",
+    "    m = robot.manipulators[\"left\"]\n",
+    "    solved, errors = 0, []\n",
+    "    start = time.perf_counter()\n",
+    "    for target in targets:\n",
+    "        sol = m.ik.solve(target, robot.home)\n",
+    "        if sol is None:\n",
+    "            continue\n",
+    "        reached = robot.tree.forward_kinematics(\"L_ee\", sol)\n",
+    "        err = np.linalg.norm(np.asarray(reached.t) - np.asarray(target.t))\n",
+    "        if err < 1e-3:\n",
+    "            solved += 1\n",
+    "            errors.append(err)\n",
+    "    ms = 1e3 * (time.perf_counter() - start) / len(targets)\n",
+    "    return solved, ms, max(errors)\n",
+    "\n",
+    "\n",
+    "print(f\"{'solver':12s}{'success':>10s}{'ms/solve':>12s}{'max pos err':>14s}\")\n",
+    "for name, robot in [(\"VegaArmIK\", eaik), (\"ssik\", ssik)]:\n",
+    "    ok, ms, mx = benchmark(robot)\n",
+    "    print(f\"{name:12s}{ok:>7d}/{num_targets:<2d}{ms:>11.1f}{mx:>14.1e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b21d4d",
+   "metadata": {},
+   "source": [
+    "`ssik` reaches every target at ~machine precision, far tighter than the grid-search EAIK (which sits near its `1e-4` tolerance), at comparable speed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42206fb7",
+   "metadata": {},
+   "source": [
+    "## Visual check\n",
+    "\n",
+    "Drive both Vega arms to `ssik`-solved targets and render the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fda043c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T15:50:15.771492Z",
+     "iopub.status.busy": "2026-06-02T15:50:15.771395Z",
+     "iopub.status.idle": "2026-06-02T15:50:17.312996Z",
+     "shell.execute_reply": "2026-06-02T15:50:17.312538Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZcAAAE2CAYAAACtJt9GAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAKoVJREFUeJzt3Qd0nGedLvBnqjRNGvVm9eYqO25ppDgkJE6WDVlYblhuSEInZTnANpbl3j0Lezmw5ewusCQEEhYCBJaEJIR0EhOcTeISt8S2XCRbktXrjGY0M5pyz/8dz1iyJWtkf5oiPb+cOZry6dOn4nnytv+ri0QiERAREWlIr+XJiIiIGC5ERLQg2HIhIiLNMVyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHPGRA/sa/dq/9WJiCjjlNRa5zyGLRciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIhIcwwXIiLSHMOFiIg0x3AhIiLNMVyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIhIcwwXIiLSHMOFiIg0x3AhIiLNMVyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIhIcwwXIiLSHMOFiIg0x3AhIiLNMVyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIhIcwwXIiLSHMOFiIg0x3AhIiLNMVyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIhIcwwXIiLSHMOFiIg0x3AhIiLNMVyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIhIcwwXIiLSHMOFiIg0x3AhIiLNMVyIiEhzRu1PSUTzEQj4EY5EYNDrYTKZ+cOjRYHhQpRCo64R/OGtV+Gd8KB6WS0uW/8e/j5oUWC4EKVIOBzGya52uD0uGPQGLK9fdc4xHu84vBNedd9qscJmtafgSonmj+FClCLBUBBH2g5FH+gAS7blnGOOnzyKd1r3wWwyY8sVNzBcKGNwQJ8oRQaH+1XrZTaTkwEMjw6p+0ajEXm5BUm8OqKLw3AhSoFgcBLH2lsRCofUY6vFBp1++j9HCZbuvi7+figjMVyIUmDUNYqu3s744+a6Farra6p3jxyI36+uqIVOp0vqNRJdDIYLURqSgfwJX3QgXxQVlDBcKKMwXIiSLBKJ4NCxd+KPZ2qRDI0MYsw9muQrI9IOw4UoBeHiHnfFg0XGW6RlEiOD/J09J8/8I9Xp2WqhjMNwIUqy9s7j8VaJBI2MtThz8uKvy3N9A73x8CktLkdpUTl/T5RRGC5ESRYKBVWAxKYY46xusbaOowhM+tV9OU4CxmAw8PdEGYXhQpREwWAQPf3d8ccqPKa8Lo9d7rH4+he9/twuMTlm74HdeOq3jyMUCsWDiiidcIU+URJFEMFkeDL+WMKhZcX6+OM3dmzHW3tfR0lJ6ZnPiUxfaLln/y78/Te+rAJIZwBuueEDbNlQ2mHLhSiJwuEQhocHVQtm27bfYXR0RI25BEOTaDt1FIOuPhQXnxncl1ZLY+1ydV9aKG/v3Ymvf+urmJjw4pZb/hib1l/GYKG0xHAhSiKDwYg1zevw+vbX8PTTT+CRR76PwaEBtHUdxah7GEXFxSpQnM48lJaWITfXiVyHUwXLgXf34h+++RW1Bub22/83Vq9cy4F+SlvsFiNKokg4jP6+Puzd87Z6PDg4gN9tfx6XXXaFas3s27cHOTm5GB93o7CwSIWL0WSC2+vCRNiDD9z2IbjdLhQWFqsqyly1T+mK4UKURN293bjz0/9LBYl0f1mtNjz11ONoazsGl8uF3bt34Kab/ggtLevUc031K+DN9aCz7wT0Bj0KCgpgsVhQUlgGp8PJ3x2lLXaLESXRv/7HN+DzTahZYBaLVQ3xS6j09HTj8OGDkIlfb775OtqPt6nFlf6ADx197epjT08PPB4P7DY7Nq65lLtWUlpjuBAlyZhrFD193fFy+qdOdaluMZ/Ph+PHj2FiYgIjI8M4ePAd/ODh78Hv9cM/6YPX61HBIl1lsi5mVVMLB/Ep7bFbjChJjhw7jDd3bFf3ZYBeyu6Pj0/C6/WqVow89vujiyc9nnE8/OMHcMcdH4fRaFKvyXKXXEceSorKOdZCaY8tF6IkWb92E26+8dZznpf1KhImsWCJOXLkMDo6Tqjpy7JC32az49JLroAl69wdK4nSDcOFKEkkID7/ub9AVlZ2QsfL+MrDD38fY2OjMjSDptoVsFsdC36dRFpgtxjRAvH7fQiGQrBZbfHnSkvLYbPZIJtOyuC9jLecj2d8HC3LL0F5+TJUldewO4wyBsOFSGOdpzqw7bWX8YfXX8XJznZ86u57cdv7P4wIQhifGMLNN9+I5uYmZJnNePa5F7Br126Mj4/PeK6WNeuwvHEV8pz5/D1RRtFFEqx619d+Zlc8IpqZrF/5kz+7CTt2vRF/Ts3wWtGiph2Pe8fQ1taO0tJS2G023PqB98M15sKx48exd+9+DA8PTzvfX33hq/ji/X/DHzellZJamUZ/fgwXIg09/9JvcM8XPqGmDydKusk+8fG7kJPjwA8f/hEGB4dgMppUa+UH//lTXLJ2I39HlHHhwm4xIg3t2bd7XsESG7h/4MGHUF9Xh7vuvBP1lWtw5eXXqIWWOY5c/n4oI3G2GJGGCguKUF62bN6fFwgEcOjwYUTCOtxy0wdUqyU3x8kBfMpYDBciDX3yrnvw+M+ewxfu+2uYTKZpr8nYi9p58jyeeuoZ/j5oUWC3GJGGpEpxbXUdPnXXvaiqrMHe/W9jeGRIvXbtdVvgnfDiySd/peqJHT3aes7nf/kv/i9/H7QocECfaIHJhExf0IVd+3egv39A7T7pdo+rqsdPPPFLVU9MvOeKa/GD7/4UzlxWO6b0xgF9ojQQDAWw/9Ab8IyPwGQMwW63qEWUUlZf9m555JEH4ff58dEP38lgoUWD3WJEC8w74VZ1w6QSsrRavJ5JGPQ6GAwmWLKz8cFbb8e9n/4iSktK+bugRYPhQrSApOhk90CbKqcfDIamvBKB0RDG9dduwcrGTfwd0KLD2WJECzjW4vaMYGC4R7Vczt6SWKoh59gL+POnRYnhQrQAJDhc48N458gu+CYmVNBUlNZOOybHkY/Sokr+/GlRYrgQLYDA5AQOte+B1+eFzx9EBHp09bSrVfcxdrsduimPiRYT/mUTaUxaKX0jnQgE/GrlfbQ0rA46vRE2ey50Oj2ysixwWPP4s6dFiwP6RBoHy+h4P/qHek4P4gfV87HxFqkjBp0BNqsTy+sv4c+eFi22XIg0DJYxzyDaOg+phZEy7VhKwJxdBkaCZsLnwfDoAH/2tGix5UKkEZdnCK1t+9A/0B8PERnYl3CxWKL73kvgSGvGkm2DM4czxWjxYrgQaWAyGEB7ZyuGhoeQm5uLkpKSeGumq6tLBY0EixSuNBgMWF7fMm1wn2ixYbgQXSQJkP7Bbpzq7UR2djby8vLi61okQKqrq1WgjI6Ooru7W31Odtbcmy0RZTKGC9FFCkfCOHh0jwqTgoIC+Hw+1R0m5L4M7JvNZni9XtV6iUpod3GijMVwoQwUAfThM/dPv0/LB11EupqS3N2kvjDiLRYJELlNTk7GA0WeJ1pKGC6UEd1OoYgfYf2EeiMPhgOYDHgwPDyC4eFh9brcduzYjUm/Dn+09QOoq2pO3piGDrBarap1Ii2VWLBIi+VMS2XK4Wpa8vRSMESLDcOF0p7U5zrR/Q4iCOHIkaN4661d2LN3P8bH3QiffvMuKS1DVlY2Tpxox9O/fRL/9I//jg1rL0vaany7ww6v16NCTrrEZPHkTMEiKsvq4LDnJuXaiFKF01UorYXCIRw/eRDtJ9tw4MA7+P5Dj+DVba+hpeUSFBeXoq+/Dx6vF9dff5PaH8Xv96mFiu0dh5JyfRP+cZzoPqS+roSK3GLdYjPTwZptg17Hf3q0uLHlQmnN43Wh49Qx9abt8/nhcrlRWVmFdevWY3CwHw6HA1aLBX19vapbKpl8AQ/aTh3E6NiwWrsSa7XI/diA/tmyzFmor1mZ1OskSgWGC6U1o9pQy65CJqarqxP/+q/fVLW71HRfgwm///0rag1JY2MTmhtWoqK8ZsGvzTU+iv6BXjW+IsEipMUiwSKP7dYc5DicGHMPY8LnVd/LupWXwaA3LPi1EaUaw4XSmtViR1lxNdo6DqOgsAh6vQyEG9S6EVlTIuESq9slLYasrCx89lP3omZZ44JOPR5x9ePYiYOqCy7WSokFTIxc1/L6tep5f8CnwiUvl6vyaWlgxy+lNZ9/AsNjg/JODYPBiKuuukrNApsaKlPHOaR7bGR0aEGuRUIiGPajZ7AdgUk/XO5R9TVjs9XO5vaM4XDbPjhsuSjKL2Ww0JLClgulNfk//lFXNCzkDVxmYc02nhE9BujoOoHB/pFpz0tL56ortpxTRHJe1xKcwKmBY+jpPYXJQFBNNphLb/8p9A91o6Sw4oK/LlEmYrhQRlm1aiX27Nmr1pPM5oWXf4snnnjinHC5+srr4uHSsnodPvKnd0qDCCVlRTBbdQgGgHAg2iLSwaA+qkH6SAhu3yB6B05hYLAv+rUjQHlJtdoA7HxhFw6HEAxFy+4TLSUMF0ob8iZ94N192PaHl6d1i0lBSHmTt9lsuOKKK9TAvTyeuid97H5dXe2Miyel++rV116KP37plefwb9/9ljr2y1/+Mm6++WZ1jJzHZDTDnp2nNvPyBz3oH+7C6Nioqg0WW78i1zow3B2/lli3WGzGWOyxjBlJtxjRUsNwoZTQ6aWEi5RuOT1WoQP+8f/9Hzz2y0cxNDw44+dI6+PFF1+Ey+VCYWERrrrqaoRCQYyMjGDz5s1Yv/4SDA0N4dChQ2pg/3wlV9T4yemNvB599FFVXFKmNQupahzKDcITGMPY2AjGxsbgdrvPWRgZ+/yy4koMjfTFWyixoJOvUVpYgRy7U6sfG1HGYLhQUkUiYQR1E9AZQtDpo4sO5SaLCm+46Vo0r6zDQw89hCNHjpwTDvLGPjgYDZ7R0RGsWrUCa9euRX9/vzqHlIKRN/aGhgZV56u3tzehazp+/Dj27dunziX7ruTk5KiaYC5Xr5oNJt1gMt14Nj39ndNaSzLVWPZraapdzbEWWrIYLpRUY+Mj6OhrRX5+nnpDjs38klZJY2OjusmMsGeeeQZf+9rXVGthJvLm/9hjj6kgiG3EFbN9+3aMj4/P67qcTme8NL6ElZxfgiXWOjmf2PdhMpmxrLRWrW9ZVloDnS76vREtRQwXSippBUj9r56ebuTn56twkJX18qYu4xexN+qtW7fixIkT+OEPfzjruaT7SwIgFi6yQZecr7W1FStXrlStDTmXtIDeeeedcz5fus6ktXLfffehrKxMBZl0uUmwTF0YORsJDmdOPrKzLWiqWQOTKUuVdmGgEDFcKNnVjcPRMikSMj09PerNXPZAiVUVltlcEjTy8b3vfS9+85vfqJbEXCREamtr1blvv/12fPjDH45v1iXh8sorr8Qfx7qwJJQuv/xyNVAv1yGtnbmmOse+VnaWBU21a1BatAxZ5mzNfkZEiwVbLpQ0EURwpO3AmceRiHpDl1aCBIy0OkS0i8mElpYW1aI4X7gcPXoUxcXFqKysjHdjxcZxpi60vOaaa+LdbyK2x4qMy0iwxPZhmYsMzi8rq0VtZbMaW2ErhWhmXKFPSTUZPHdgXN7YBwYG1IB8bPBcAsZut+MrX/mK6rqSLrOzSTjt3LlThYuUgpH9U6TlITc5p9zkObnFxlCklSJfRwJLvqZMEJi+Q+TsTEYTNrZchcaaVTAajAwWovNgy4XSgrQ45E1eQkJaLXJfWh/r16/Hk08+qWaQSRfZ4cOHVfjIcdIKiY3ZSKDEphfHWi5T15/EqhXLTT5fwiSRwXoRW0wpZ8rOsi7wT4JocWC4UFqQN29505eWS6zMS2xXRxn4v+OOO/Cxj30ML7zwArZt26bGVaTLTNa1xIJiao2xqeESe13OP9d4ymzBQkTzw3ChtCGBIosVJQSkS0taJ0Ktmj890C8D8Bs3boyHSKwbLbYy/uxwiT03X/HWCoOF6IIwXCipzrcDo7yRx8ZNZIwl1k0m4REbiJ+6+l3uyywzGTuJmVp65ULMNUAvi0CJaG4c0KekkXKQK5rWzHlcbCaXzCSTmVwyAC8D8VKGJTZlODZQH1tRH2uxXGiwSKjkOvJgybaoMZyZQiYYnERbkrZPJsp0DBdKGnm/NhhMqKmpQVVVVUKzrWIzvyRQpMtMwkVucl+ekzGYs1foz5esrF/TvAmb116DptoWhILRApbSejr7Grt6T8DjdV/U1yNaChgulEQ6OCxODA+NqWCYaXrxXGID9LEBfykX093dfUFXEyvZsqZ5o9q5UioYV5XXo7iwPD7wf3aFZY93HF19JzgWQzQHjrlQUtmsDly54XoMDPWgfzgaClNbB5FwdDqxbBDm9XnmPF+iixilqys28B+rZyar61c3bUCW2RI/j3xc1bge4x433J7RGc8le7hUl9dzWjLReegiCXZS97V7EzmMSBOu8VF093Xg5Klj8Pnn/7c3tdSLFKWUrjPpSpNxGyndIqFSkFcCsylrxs8/0XUU+w/vnHEAX869unkDapc1cyElLUkltXOv92K3GKUlKbPSXLcG11y6Ff29Q/FFkrFZYrHgOLvbSlonzz77rFqNL/uyFBUVqWCJLpwMo7qiARvXXIXSospZg0XIcXZrdH+Xs8k1HGk/gIGRbnaPEc2CLRdKe339vbjtI+/D6NiImpL8wQ9+UE1BFhI0UpSyo6NDPZaxEtk8TForUrq/vr4+PrZy1+33IMfhVDXB5iIBIvu07Nz/mvpaMr4jHyW0Yo19u92hWkDF+RVswdCSUpJAy4XhQmnP55vAhvcsn3WHykRYrTa8vb0VTmdewp/jD/iwa/8fMBGITn0+e3W/BJvD7sDKxvXIybNBH86CQWeEQW9i2BCWerhwQJ/SnhbFVy5kyy4ppV9ZVoe9h96csftLnnO5Xdh/eAdKS0tVi0ieKy+qg9NeFP26CW8WNvX83GCMMh/DhdKeLoUBVVlei3AkjHeO7EYoNHOhS6kkIN1yUsVZWjeBwCRKisZQ7KyG0WA+7/nDkRDCCMCQHUQ4ElHTsyWkQj4jJM9UzbVAQE1EkIVC+bmFMBj4z5bSH/9KKe2lsmykbFUsg/tyFQdadyMcnrlOmUyflgCQ8R0JmzHXKLzlXtRWrIReZ1TVCc4WCofQ2r4Ho+6heIVmCRfZIdNmsyEvL089lnU9/WP96uOIawANVSuhT2DciCiVGC6U9lLdSSRdW9UVjSpo9h3aMWt9sdgCTyGhkFeQi7B5HEaDFaFANCLldSllI8ERQgjtHcdVWZl8ZxFc7hEVOLEuOJlAIBWhJbBi2wWMTY4h156PksKKJP4EiOaP4UKUYMDI6n1x8OjbcOY5VRma2N4wU0kYyDRomVkmU6jlsRwn4SAz2WRBZ99Ih9qoTIJFSEmZqcEipAUknyNTqaUEjsyUi86S4xYAlP4YLpT2JnwTF7+eJBJRXVUyffhCys6cacE0oH/4FLw+t+q6itU+i63+FxIssd01p5b/n7pZmbw+dfaZzEybiZxfOBwOVaBTAmZi0q2659g1RumM4UJp7dkXnsZPfv4whkeGLuo83gkvtmzdjC/c/ze47zNfvKipwjIteXTsTGkYecOXcZJYkMiaGDkmNo5yMdWaYwEjrSQJRQk0f9CDAVcnCnMqE1qzQ5QKXKFPae0/H/o3vPraS5qcSwLmV7/++UWfx5I9fY5/bNOy2G6YEiyxx3LTasMxae3IpIGenm4cOf7uBZXFIUoWhgulNdlfxWg0IZ20LN+Movyyc55PdOdKaTXJbT5TiiXAPJ5xTAYmkOd0oKS4AP7g2LyvnShZ2C1Gae2RBx7DM889iV88/ije2LH9os5VU1WHre97/0Vfkyyu3NRyFQ4e24ue/o5Zx0tiXW+xKsxSMLMwr1R1o0nrp6KkFq1t+9VA/kykcrTPP6Huq83Qgn6YTXo1UUDO5/IMwmEphMkY3Q6aKJ2w/AulPelq2rHrf3DkWCueffFpbHvt5Qs6z5/+yZ/h2//8kObVm6UE/+BI77TnZbC9uKAs2sKRloqanmyC3ZqT8Lnd46Po6GnDqb4TCIcCmJjwwmiMzhiTsRerzQqbJRdlBU2wZts0/b6Izoe1xSjj9fb14N+/+y38/Fc/UTXGLkZjfbMKmPs/+yVNa3+dryvsYr+OnPvg0T1o7zyEyUm/es5kMsJqs8NoNCMSMeFk+0m4R734xMc+g6ysbNY1owXHcKGM97Nf/he++Df3aHa+5sYV2Pb8zox6A5Zpx94JD3bsfQVj7mHo9AYUFJSpxZjf+953cejQu5gMTKK4uATf+Zcf4IrLrk71JdMix8KVlJE6T3XA74+OYzz84we0PXfXSTzz/JN4/9bbkCmki81uy0FT7SV48fdP4NVt29Dd3aemJ3d2nowf191zCj/8rwewft0mZGdbUnrNRBzQp7QhXUA7d7+JT977UQwM9sefu1jSSpE1IqtXrsUtN96KyooqZBqZ0PDz//4J3jzPpAaZOPD8y89g34E92Lzx8oxqndHiwwF9Shsu1xiuvnGDGmfR0ormVfjZI0+qMirO3MT3c0kX/QN9+NinPoS9+9+e9Ri73YbP//l92Lt3H060n8KX/vxvp71eWlKmWjREWmC3GGUUKW0v+6NoretUB949tB/Xb7kJmWjfgbdnDRaHw47s7Gxs3XojWo8cxfMvvKSmLX/8cx+Jrw+SrQA2b7gcD377x2rdEFEysFuM0opep/26Xve4G6e6O5Gp6moa0FDfhGPHj0x7Xior33/f51TX4Xe++z2MjJwpSSOttLKyZWrqskzlPnBwL/7yb+/HRz78MWzctBlGvQn602uo2X1GC4Er9Clt5DhycP9nv5jqy0g79XWN+NEDv0BjQzMu23wlrrvmBjTUNSE7O0u9/u3vTA+WWKkYr9eDpqYVaG5egfr6Rjzx9C/wiXv+DI89/mPsb92N7pFO+EO+WRdxEl0MtlworWZFzWeP+6VEWi4/evAXauzEZrWj7cQxfPbP70JXV68qzX82aY3cdtuHsGHDZhQVFamKyq+//ge88MKzqmD/ocMHcbLjJFavXoNcuxN5tkJVBJOtGNIKw4UoQ9TXNsbv11bX47ePv6q2EXjssccQQLQ0f4yUmCkrq1CTJOQmWw1cf/2N2Lz5cvT19ajtAKRls3PnWygtLUN9XQOctnw4LLkMGNIEw4UoA0kLw2QyoaPzxDndWuXlFbj77k+f3lgsanzcjd27d6pWjLwug/3Dw0Oq+6y3twejoyOorqpBzbJ62LMdMJuiXW5EF4pjLkQZ7OGfPKgC4gwJHbOqQxYIRDckk1aMkOO6urpw6NBB1f3Y1LQcVosVlZXVmJwMoKPzJI6dbEVn/wn4AhdXaoeILReiDHb2MkkpaCmzx/bt3YWuU914z5XX4O67Po3Ozg709J1CQUGBChxprRQXF2P16haE/GFYTFbkFxRg59tvnN4hU4e68kZ2kdEFY7gQZbDP3/NX2LN/t5qmLCv06+sb1PPHjh9XO1i+8upLuPrqLSgpLMUlKzfAZDbjgR/+B+obGuGw5+JkxwlYsqxY3bQO1mwr8q7Kg8FohNmcxWChi8JwIcrwWWSy581H7rwVldXVuP/+LyISjuDRH/8Iz734DG655Y8xMjqsdsesqaiHzWLHl+6Lrt6XQDIjG2adWdVyy7HnwJmbn+pviRYJhgtRhpM1L9dd9z4UlRShr68XliwLVqxYhb0HduPSzVegMK8I/UN98Po808rfSDDJjWghMFyIMlxn90ls2nwp9AZ9dPGkz4st11yPwuJCOHJyMDAcLQIqZftlPIZrWSgZOFuMKMPlOHLVDLFgMBgPDim5X1RUMq2q9LtHDiCillASLTyGC1GGy3U4VUFKGdCPhUnr8YOor25UWw1osW0B0XwxXIgWgeUNq05PIY6ShZUVJZWwWx3x1szY6KhaLEmUDAwXogwn4VFaVIaSojJIjkhLRaYh9w70oLaqQVVIlmOeefZJPPH0L1N9ubREMFyIFoEsczYqSpbBarGp1fmPP/5L/PLxn6rWi8lgZtcYJR3DhWiRqKmsh9FghM1mV6vvPR4PzGYzaivrVctl3br1cLtdauCfaKExXIgWCQmWFQ2rkZUVXV2/7523VWl+GY9Z3rASxcUl+NVTj2FgMDo1mWghMVworVQuq1ZTa2n+JFCqKmpQWVaDyy67QrVc3C6XmkVWVV6DwoIiOJ1O/mgpKRgulFa2XH0DaqrrUn0ZGUtK6S+vX6k2FJOw2X9orxpvKcgrwuZ1V2DTxsvwymsvpvoyaQlguBAtMnabA5deciUaG5rwwku/jT9fVlyBr/7l13H7h+5I6fXR0sDyL0SLtHvsn7/+nWl7vcjzBl10bxeihcZwIVqEJEimFqkkSjZ2ixERkeYYLkREpDmGCxERaY7hQkREmmO4EBGR5hgulHZkbxIiymwMF0q7KbT/8o3vorG+OdWXQkQXgeFCaaehvgk/ffjX+Ie/+yYa6ppSfTlEdAEYLpSWqiqr8am778XT//0yvvbVb6mii5/5+P245j3vTfWlEVECGC6U1l1k+XkF+ORd92D7y3vxd3/9NaxZvTbVl0VECWD5F8qQUiYsFU+USdhyoYwrye+w56T6MohoDgwXyiibNlwGm82W6ssgojkwXIiISHMMF1oSQuGw2pGRiJKD4UJLwre/989wuV2pvgyiJYPhQkuCyzWGSDic6ssgWjIYLrQksEOMKLkYLkREpDmGCxERaY7hQkuCLtUXQLTEMFxoSeCYC1FyMVyIiEhzDBdaEtgtRpRcDBdaEtgtRpRcDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhZbOVGR9iPPGiJKE4UJLgy4Cg9UDGCRgiGihMVxoyfB6vQj4A6m+DKIlgeFCGcVoMOLuOz5zQZ87MDAAt9ut+TUR0bkYLpRR9Ho9Guub5/154XAYPT29C3JNRHQuhgstCRIufX19qb4MoiWD4UJERJpjuFDGqa9rxM033QydLrFax3Jcc3MzTCbTgl8bEUUZT38kSi5dGDq17mTak4iEDHMWyG9uXIG77/w4bA4L3nzjLXR2dc14XFlZKTZsWI9NmzbCYbfDbDZr+A0Q0fkwXCgFItCbAtBn+ac/GwEiQfmTnLtFYjAB1225FhvWX4JHfvRjtLYeUc9nZ2erFspNN96AlrUtKCwoUM9XV1chNKmDw+44vZCSO7wQLSSGCyWfLgKd2X/u0zpAZwrO+CkRSZ7TXVzqoz6sPubm5uKTn/g4XnzpJTVoLy2VZRUVMBqN07rNCgryUVtbC51uEpFgBJHQPP/0IzpEghfSrcYQo6WJ4UJJp58hWObS29uLQGASVVWVKjRycnLgcrnVwki73YY/ue0Ds36u0WhAdrZFTWMWKsBmCbHZqGwLz++6JcDCiQaSOv/cXYJEmUIXif0v4Rz62r0LfzW0+OlDMFg80Onntzekx+NBX1+/6vYqKipUXV8jI6N488034fF44y2bGAkgk8mIgoIC1NfXobS0FJOTk/D5/Ghvb8fKlSvSaoBfLj80Ll12nGND6a+k1jrnMQwXShoJgK7eIwjpPeqxxWJBeXnZvM7R3d2No0ePq0F6q9WCUCiE48fbsH//gfgx0lUmLZyGhnoVMpOTQXR0dKCr6xQqKspV2BgMhoRnmyUDw4UWW7iwW4ySGi7vtu7FhC8aLjIuYrfb53UOCQcZnD948CDq6urgdOaisbEhGlxdp1BbW6NmiZlMZrhcLgwMDGJoaAiFhYW49NJNsNlsC/TdEdFUbLlQ0oQjYfzuD09g3Ou66HNJq8Tn8yE/Pw+NjY3x8RRpyfT39+PkyU41QUACR7rEsrISn4ZcU1OtWj/zcfYEgvliy4UyCVsulFZ00GFl0wbs2PvqRZ9LAqO4uAhjYy4cO3Y8Pn7S1dUFq9WKlSuXY3x8XIWLdKXNR0dHJ/T6xINCp9NjxYrl8xrDke7ArKyseV0XUSZhtxgljfyfvUF/8X9y0sUlU4tl3ERaLtIl9vbbe9Qg/apVq5CX51RfS9a+yPTk+ZLWT2ie277s27d/XsdLy0iuP0buX9ryPphMDBxaHBgulFEkNOrra6ettpeAuf766+KvCwmccHh+M9KSaWxsbNpjCd1wYhM3iTICw4UyTlFR0bTHM411jIyMqC4yIkoNhgslVb6zCBWltRh1D6mVg9IFpdYPhkIIBAKw2xznhIXfP4HJYHQHSZkNNleNMGm1eL0TF9QlRkTaYLhQUpnN2Vi36kq8c2QvQgjC6cyD3e5Ab28Pjh87ii2X36pmXk01MNyD0bFBdb+4zDltrGI2MlU5Ntg+19B8RP5jlxSRphgulHTB4CRajx3GybZ2/ORnD6uw+PSn70VJSZmqfnJ2y6W4oFzdoAvBYBtPaDW/LJw0Gk3YcvkfwyBVLs/D5R5Ge2drwtc/ONwTb0kR0cwYLpQSE14P/uvRH2BkZFiVdAkG5671pTcn9obe3d2jao7ZLA5kZ1lVyJyPJduKkqJlCV/78Gj/vMLlROcRjLqkGxDwB3ynqwNEX5OuO71OHuvTqmIA0cViuFBKvPHm6ypYxMaNl6Kqqlp1j80uouqSzfX+O7V7q6l+LQwG7f/E853F8zq+uKDidGVKYNf+t1BZWwm93qCudXIyAIR08Li9MBm53wwtHgwXSjqD3gCH7UyQtLUdw+DggPq/99noDEHoDHMvPpHKybG9XWTRZjq0BqLXEL0OaaHtemsnHvj+t9HTewq33vIhvOfqa7CsNFrtmWixYLhQ0mVlZaNmWX38cUNDEwoLilBf1aiCZ+ZWS3jOVouQGWfRWWe5KCqYX1HMZJDWyrMvPI1du99Sj0dHRxAKRseHiBYThgulXGfnSWxquRzLyqtm/b/3RPeAOXjwkBrHMJuyYLXMryhmUszw/eXmOFFbeSZsiRYDbh5BKbFsWZXawEsEfAFVuHHWbiHZdVI39+p1abFMTEyo+ysa1iMdrWleC4cjJ/7Y5R2D3qzHuM+d0usi0hpbLpQSt73/T5HjyFHFJevrGlG1rHqWIyPQm/wJdYmNjo5iYGAg3vWWjqwWG4rzS+OP9RE9hvoH0W/rg6P6TOgQZTqGC6WEtFKu33LT3AfKWItpcl7nznXkw2xKz3CRach5ufnxx1KR4PqrtnIwnxYdhgulNZ10iSU4UH7w4GF1vzC/VK1dyRSJVBwgyjQMF0prMpCfSJdYKBTGxIQXRoNR1S5LZ1ddeS3+/Z8eVPfrahpSfTlEC4LhQulLH0poIF+0tbVhfNyjZok5cwqQzhrrm9WNaDHjbDFKUxHojJMJdYvJ1GOpJyYsMv2YixGJUo7hQmkr0bUtfr8fx4+3qfuNNatnWYhJRMnEcKG0lEipl5ihoWiNsiyzBTbr+eqTEVGyMFwoLakusQRLbZ082aFmiznsznkXlSSihcFwofSjC6tClYmQUIlVQtafp/AlESUX/zVS+tGFoyVfEtDfP4C+vj51f2XThgW+MCJKFMOF0kxEbQqWSJeYtFhkbUusUKXciCg9MFwovciGYPPoEpMqyKJ6WVN6VkEmWqK4iJLSitfnhnu0Z87jCgoK4PcHEAyemVXGzbaI0gfDhdJKb28v9h18c87j8vKcmJycVGtcpDusqpxlVIjSCcOFMtLIyOi0wo92G8vVE6UTjrlQxltefwl0nIZMlFYYLpTxzOZsjrcQpRmGC2U0mSFmt7JLjCjdMFwoozlsuchx5KX6MojoLAwXymiyvoWI0g/DhdJKriMfObYiTPiCqK5uRGdnD8xZdgSDutM3WTwZPVYHHZw5ham+ZCKaAaciU1oJBYHvPfgAautrkZNTCIvVCY9HFkvG6sHoUL2sEc31K9QjS7Y1pddLRDNjuFBaee7Fp7H9f7ahtLwULpcLNpsNQWmunFZVUYP1qy+F0cg/XaJ0xm4xShv+gB+79+yY9XUpUjkxPsFgIcoADBdKGxIezzz/FIqLS9DSsu6c1zs6TuJw68GUXBsRzQ/DhdKGjJ/ccuOtMJuzkJOTixUrVsJqtanXQqEQfve7F2AymlJ9mUSUAIYLpY2srCxsXL8ZHs84ent7cOzYUbW/i3j33f2IhIA7P/qpVF8mESWAo6KUVm664f148XfP4de//hW2br0F27f/HmVlFTh+7Ci+9Pm/RXZ2dqovkYgSoIvENiCfQ1+7N5HDiC6a/EnKjLFDre+ebrcADbWNuO7a97GGGFEaKKmdewkAw4WIiDQPF465EBGR5hguRESkOYYLERFpjuFCRESaY7gQEZHmGC5ERKQ5hgsREWmO4UJERJpjuBARkeYYLkREpDmGCxERaY7hQkREmmO4EBGR5hKuikxERJQotlyIiEhzDBciItIcw4WIiDTHcCEiIs0xXIiISHMMFyIi0hzDhYiINMdwISIizTFciIgIWvv/ql+L5Xb///MAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 500x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pybullet as p\n",
+    "\n",
+    "from prpl_kinematics.visualization import (\n",
+    "    CameraParams, PyBulletRenderer, capture_image)\n",
+    "\n",
+    "goal_q = {\"left\": [0.3, -0.4, 0.2, -1.0, 0.1, 0.6, -0.3],\n",
+    "          \"right\": [-0.3, 0.4, -0.2, -1.0, -0.1, 0.6, 0.3]}\n",
+    "config = dict(ssik.home)\n",
+    "for side, joints in [(\"left\", LEFT), (\"right\", RIGHT)]:\n",
+    "    m = ssik.manipulators[side]\n",
+    "    truth = {**dict(ssik.home), **{n: [v] for n, v in zip(joints, goal_q[side])}}\n",
+    "    target = ssik.tree.forward_kinematics(m.ee_frame, truth)\n",
+    "    config.update(ssik.manipulators[side].ik.solve(target, ssik.home))\n",
+    "\n",
+    "renderer = PyBulletRenderer(p.connect(p.DIRECT))\n",
+    "renderer.load(ssik.tree)\n",
+    "renderer.render(config)\n",
+    "camera = CameraParams(target=(0.4, 0.0, 1.0), distance=2.2, yaw=50.0,\n",
+    "                      pitch=-12.0, width=640, height=480)\n",
+    "image = capture_image(renderer.physics_client_id, camera)\n",
+    "plt.figure(figsize=(5, 4))\n",
+    "plt.axis(\"off\")\n",
+    "plt.imshow(image)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4122d1f",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "`ssik` solves Vega's non-SRS 7R arm analytically (with a short Newton refinement to close the joint-lock sweep), reaching targets at ~machine precision -- markedly tighter than the bundled grid-search EAIK, at comparable speed. Enable it with `make_vega(ik=\"ssik\")`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -10,7 +10,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 # Lists only what the code imports.
 dependencies = [
-   "numpy>=1.23.5,<2.0",
+   # numpy 2 is supported (the suite passes on it); the optional ssik extra
+   # requires numpy>=2, so the cap is not pinned below it.
+   "numpy>=1.23.5",
    "scipy>=1.10",
    "prpl_utils>=0.0.1",
    "spatialmath-python>=1.1.10",
@@ -23,6 +25,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Optional analytic IK backend (ssik); requires numpy>=2. See ik/ssik.py.
+ssik = ["ssik[urdf]>=1.2"]
 develop = [
     "black",
     "docformatter",
@@ -74,5 +78,6 @@ module = [
     "imageio.*",
     "eaik.*",
     "ompl.*",
+    "ssik.*",
 ]
 ignore_missing_imports = true

--- a/prpl-kinematics/src/prpl_kinematics/ik/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/ik/__init__.py
@@ -4,11 +4,13 @@ from prpl_kinematics.ik.follow import follow_end_effector_path
 from prpl_kinematics.ik.ikfast import IKFastInfo, IKFastSolver
 from prpl_kinematics.ik.interface import InverseKinematics
 from prpl_kinematics.ik.numerical import NumericalIK
+from prpl_kinematics.ik.ssik import SSIKSolver
 
 __all__ = [
     "InverseKinematics",
     "NumericalIK",
     "IKFastInfo",
     "IKFastSolver",
+    "SSIKSolver",
     "follow_end_effector_path",
 ]

--- a/prpl-kinematics/src/prpl_kinematics/ik/ssik.py
+++ b/prpl-kinematics/src/prpl_kinematics/ik/ssik.py
@@ -1,0 +1,92 @@
+"""Analytic inverse kinematics via the ``ssik`` library (optional dependency).
+
+``ssik`` (https://pypi.org/project/ssik/) solves 6R and 7R revolute arms
+analytically, including the non-spherical-wrist (non-SRS) 7R class that Vega's
+arm falls in -- the same geometry :class:`~prpl_kinematics.robots.vega_ik.VegaArmIK`
+handles with a lock-and-grid-search over EAIK. ssik's ``jointlock`` solver locks
+one joint, sweeps it, and solves the residual 6R in closed form; with its Newton
+refinement enabled it polishes each branch to machine precision (the lock sweep
+only samples the locked joint, so a generic 7R needs the polish to FK-close).
+
+``ssik`` is an optional dependency (it requires ``numpy>=2``), so it is imported
+lazily: importing this module never needs ssik, only constructing
+:class:`SSIKSolver` does. Conforms to the
+:class:`~prpl_kinematics.ik.interface.InverseKinematics` protocol.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+from spatialmath import SE3
+
+from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
+
+
+class SSIKSolver:
+    """Analytic IK via ssik for one revolute arm of a URDF-loaded robot.
+
+    The arm is the chain from the joint group's base link to ``ee_link``; ssik
+    parses it from ``urdf_path`` (its forward kinematics matches the tree's to
+    machine precision, so targets computed in the tree's frames map straight in).
+    """
+
+    def __init__(
+        self,
+        tree: KinematicTree,
+        arm_joints: Sequence[str],
+        ee_link: str,
+        urdf_path: str | Path,
+        tool_frame: str | None = None,
+        allow_refinement: bool = True,
+    ) -> None:
+        try:
+            # pylint: disable=import-outside-toplevel
+            from ssik import Manipulator
+        except ImportError as exc:  # pragma: no cover - exercised only without ssik
+            raise ImportError(
+                "SSIKSolver needs the optional 'ssik' package: `pip install "
+                '"ssik[urdf]"` (requires numpy>=2).'
+            ) from exc
+
+        self._tree = tree
+        self._arm_joints = list(arm_joints)
+        self._allow_refinement = allow_refinement
+
+        edges = [e for e in tree.path_from_root(ee_link) if e.joint.name in arm_joints]
+        self._base_frame = edges[0].parent
+        self._manipulator = Manipulator.from_urdf(
+            str(urdf_path), base=self._base_frame, ee=ee_link
+        )
+        tool = tool_frame if tool_frame is not None else ee_link
+        self._ee_from_tool = tree.relative_pose(ee_link, tool, {})
+
+    def solve(self, target_pose: SE3, seed: Configuration) -> Configuration | None:
+        """A configuration reaching ``target_pose`` (the tool frame), or ``None``.
+
+        ssik returns every analytic branch sorted by wrap-to-pi distance from the seed,
+        so the first solution is the seed-closest one -- the natural, away-from-limits
+        branch rather than an arbitrary contorted one.
+        """
+        ee_target = target_pose * self._ee_from_tool.inv()
+        in_base = (
+            self._tree.forward_kinematics(self._base_frame, seed).inv() * ee_target
+        )
+        seed_q = np.array([float(seed[name][0]) for name in self._arm_joints])
+        # max_solutions=1 with q_seed is ssik's trajectory-tracking idiom: it
+        # returns just the seed-closest branch and, on jointlock-7R arms,
+        # short-circuits the lock sweep -- the single config this interface needs.
+        solutions = self._manipulator.solve(
+            np.asarray(in_base.A),
+            q_seed=seed_q,
+            max_solutions=1,
+            respect_limits=True,
+            allow_refinement=self._allow_refinement,
+        )
+        if not solutions:
+            return None
+        best_q = np.asarray(solutions[0].q, dtype=float)
+        values = {name: [float(v)] for name, v in zip(self._arm_joints, best_q)}
+        return {**dict(seed), **values}

--- a/prpl-kinematics/src/prpl_kinematics/robots/vega.py
+++ b/prpl-kinematics/src/prpl_kinematics/robots/vega.py
@@ -10,6 +10,8 @@ two ``Manipulator``s, each with its own
 from __future__ import annotations
 
 from prpl_kinematics.collision import discover_allowed_pairs
+from prpl_kinematics.ik.interface import InverseKinematics
+from prpl_kinematics.ik.ssik import SSIKSolver
 from prpl_kinematics.loading import load_urdf
 from prpl_kinematics.planning.joint_space import JointSpace
 from prpl_kinematics.robots.robot import Manipulator, Robot
@@ -40,23 +42,33 @@ _RIGHT_ARM_HOME = [-1.043, -1.278, -0.793, -1.778, -0.148, -0.396, 0.417]
 _GRIPPER_OPEN = 0.6
 
 
-def make_vega() -> Robot:
-    """Assemble a bimanual Dexmate Vega 1U Robot (with parallel-jaw grippers)."""
-    tree = load_urdf(str(get_assets_path() / "urdf" / "vega" / "vega_1u_gripper.urdf"))
+def make_vega(ik: str = "eaik") -> Robot:
+    """Assemble a bimanual Dexmate Vega 1U Robot (with parallel-jaw grippers).
+
+    ``ik`` selects the per-arm analytic IK backend: ``"eaik"`` (default, the
+    bundled :class:`~prpl_kinematics.robots.vega_ik.VegaArmIK` lock-and-search) or
+    ``"ssik"`` (the optional :class:`~prpl_kinematics.ik.ssik.SSIKSolver`, which
+    requires the ``ssik`` package). Both solve Vega's non-SRS 7R arm.
+    """
+    urdf = get_assets_path() / "urdf" / "vega" / "vega_1u_gripper.urdf"
+    tree = load_urdf(str(urdf))
     groups = {
         "left_arm": JointSpace(tree, _arm_joints("L")),
         "right_arm": JointSpace(tree, _arm_joints("R")),
         "left_gripper": JointSpace(tree, _gripper_joints("L")),
         "right_gripper": JointSpace(tree, _gripper_joints("R")),
     }
+
+    def make_ik(prefix: str) -> InverseKinematics:
+        arm, ee, tool = _arm_joints(prefix), f"{prefix}_arm_l7", f"{prefix}_ee"
+        if ik == "ssik":
+            return SSIKSolver(tree, arm, ee, urdf, tool_frame=tool)
+        if ik == "eaik":
+            return VegaArmIK(tree, arm, ee, tool_frame=tool)
+        raise ValueError(f"unknown ik backend {ik!r}; expected 'eaik' or 'ssik'")
+
     manipulators = {
-        side_name: Manipulator(
-            f"{side_name}_arm",
-            f"{prefix}_ee",
-            VegaArmIK(
-                tree, _arm_joints(prefix), f"{prefix}_arm_l7", tool_frame=f"{prefix}_ee"
-            ),
-        )
+        side_name: Manipulator(f"{side_name}_arm", f"{prefix}_ee", make_ik(prefix))
         for side_name, prefix in [("left", "L"), ("right", "R")]
     }
     rest: dict[str, list[float]] = {}

--- a/prpl-kinematics/tests/ik/test_ssik.py
+++ b/prpl-kinematics/tests/ik/test_ssik.py
@@ -1,0 +1,74 @@
+"""Unit tests for the ssik-backed analytic IK solver.
+
+ssik is an optional dependency, so the whole module is skipped when it is not installed.
+It solves Vega's non-SRS 7R arm -- the case VegaArmIK works around -- analytically (with
+a Newton polish), matching the tree's forward kinematics.
+"""
+
+import numpy as np
+import pytest
+from spatialmath import SE3
+
+pytest.importorskip("ssik")
+
+# Imports follow the optional-dependency skip guard above.
+# pylint: disable=wrong-import-position
+from prpl_kinematics.ik import InverseKinematics, SSIKSolver
+from prpl_kinematics.robots import make_vega
+
+_LEFT = [f"L_arm_j{i}" for i in range(1, 8)]
+_RIGHT = [f"R_arm_j{i}" for i in range(1, 8)]
+_TRUTH = [0.3, -0.4, 0.2, -1.0, 0.1, 0.6, -0.3]
+
+
+def test_ssik_solver_conforms_to_protocol():
+    """SSIKSolver satisfies the InverseKinematics protocol."""
+    robot = make_vega(ik="ssik")
+    assert isinstance(robot.manipulators["left"].ik, SSIKSolver)
+    assert isinstance(robot.manipulators["left"].ik, InverseKinematics)
+
+
+def test_ssik_solves_both_vega_arms():
+    """Each arm's ssik solver reaches a reachable pose to machine precision."""
+    robot = make_vega(ik="ssik")
+    for side, joints in [("left", _LEFT), ("right", _RIGHT)]:
+        manipulator = robot.manipulators[side]
+        truth = {**dict(robot.home), **{n: [v] for n, v in zip(joints, _TRUTH)}}
+        target = robot.tree.forward_kinematics(manipulator.ee_frame, truth)
+        solution = manipulator.ik.solve(target, robot.home)
+        assert solution is not None
+        reached = robot.tree.forward_kinematics(manipulator.ee_frame, solution)
+        assert np.linalg.norm(np.asarray(reached.t) - np.asarray(target.t)) < 1e-6
+
+
+def test_ssik_solves_top_down_grasp():
+    """A top-down grasp (the case that stresses EAIK) solves cleanly."""
+    robot = make_vega(ik="ssik")
+    manipulator = robot.manipulators["left"]
+    target = SE3.Rt(SE3.Rx(np.pi).R, [0.35, 0.30, 0.85])  # gripper z-axis down
+    solution = manipulator.ik.solve(target, robot.home)
+    assert solution is not None
+    reached = robot.tree.forward_kinematics(manipulator.ee_frame, solution)
+    assert np.linalg.norm(np.asarray(reached.t) - np.asarray(target.t)) < 1e-2
+
+
+def test_ssik_solution_respects_joint_limits():
+    """The returned branch lies within the arm's joint limits."""
+    robot = make_vega(ik="ssik")
+    manipulator = robot.manipulators["left"]
+    truth = {**dict(robot.home), **{n: [v] for n, v in zip(_LEFT, _TRUTH)}}
+    target = robot.tree.forward_kinematics(manipulator.ee_frame, truth)
+    solution = manipulator.ik.solve(target, robot.home)
+    assert solution is not None
+    solved = np.array([solution[n][0] for n in _LEFT])
+    lower = np.array([robot.tree.joint(n).lower_limits[0] for n in _LEFT])
+    upper = np.array([robot.tree.joint(n).upper_limits[0] for n in _LEFT])
+    assert np.all(solved >= lower - 1e-6) and np.all(solved <= upper + 1e-6)
+
+
+def test_ssik_unreachable_target_returns_none():
+    """A pose far outside the workspace yields no solution rather than raising."""
+    robot = make_vega(ik="ssik")
+    manipulator = robot.manipulators["left"]
+    target = SE3(5.0, 5.0, 5.0)  # well outside the arm's reach
+    assert manipulator.ik.solve(target, robot.home) is None


### PR DESCRIPTION
Closes #508.

## Summary

Adds **ssik** as an analytic inverse-kinematics backend, and — the headline — **ssik solves Vega's 7-DOF arm to machine precision**. `VegaArmIK` only exists because Vega's wrist is non-spherical (non-SRS 7R), so it works around it with a lock-and-grid-search over EAIK. ssik's `jointlock.seven_r` solver targets exactly that class.

- New `SSIKSolver` (`src/prpl_kinematics/ik/ssik.py`) implementing the `InverseKinematics` protocol, built from the robot's URDF (`Manipulator.from_urdf`). Its FK matches our `KinematicTree` to ~4e-16, so world/tool targets map straight into ssik's base frame; the seed-closest branch is returned (`max_solutions=1` + `q_seed`).
- `make_vega(ik="ssik")` selects it; default stays `"eaik"` so the package works without ssik.

## Why `allow_refinement=True`

Vega is non-SRS 7R: ssik locks one joint and **samples it on a grid**, solving the residual 6R in closed form. A generic 7R has no sampled lock value that closes exactly, so the pure-algebraic pass returns 0 solutions. `allow_refinement=True` adds a short Newton/LM polish (≤15 iters, analytical Jacobian) that drives each near-miss to the true solution — structurally the same idea as `VegaArmIK`'s grid+Nelder-Mead, but cleaner.

## Notebook + benchmark

`notebooks/vega_ik_comparison.ipynb` (committed with executed outputs) demonstrates both backends via `make_vega(ik=...)`: a round-trip correctness check, a success/speed/accuracy benchmark, and a render of Vega at ssik-solved targets.

Benchmark (random reachable left-arm targets, seed = home):

| solver | success | mean | max position error |
|---|---|---|---|
| `VegaArmIK` (EAIK) | 30/30 | 355 ms | 8.9e-05 |
| `ssik` | 30/30 | 355 ms | **2.5e-15** |

ssik is ~10 orders more accurate at the same speed (both dominated by the 7R lock-sweep + refine). Note: ssik selects the seed-closest of its *grid-sampled* branches, so it isn't guaranteed to return the seed's own null-space branch — fine for one-shot IK, a continuity caveat for smooth Cartesian following.

## Dependency note ⚠️

ssik **requires numpy>=2**, while prpl-kinematics pinned `numpy<2.0`. The full suite passes on numpy 2.4.6, so the cap is dropped and ssik is added as the optional `[ssik]` extra (lazy import; tests `importorskip`). Since the monorepo shares one `.venv`, bumping to numpy 2 affects sibling packages — flagging for a look before merge.

## Tests / CI

`tests/ik/test_ssik.py` (kept for CI regression; notebooks aren't run by CI here): protocol conformance, both arms reach to <1e-6, the top-down grasp that stresses EAIK, joint limits, unreachable → None. `./run_ci_checks.sh` green (89 passed / 7 skipped, mypy + pylint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
