### PR TITLE
bilevel-planning: bump version to 0.1.3 for PyPI release

### DIFF
--- a/bilevel-planning/pyproject.toml
+++ b/bilevel-planning/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bilevel_planning"
-version = "0.1.2"
+version = "0.1.3"
 description = "Methods for robot planning with abstractions."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What

Bump `bilevel-planning` from `0.1.2` to `0.1.3` so it can be published to PyPI.

## Why

The published `0.1.2` on PyPI was uploaded **2026-04-06**, but a lot has merged since without a version bump — most importantly `BilevelPlanningGraph.export()` (#450, 2026-04-12) and the visualizer (#459–#465, #511, #512). Because local and PyPI are both `0.1.2`, PyPI would reject a re-upload, and downstream packages that install `bilevel_planning>=0.1.2` from PyPI get the stale pre-`export()` code.

Concretely, kinder-bilevel-planning's new obstruction2d visualizer example calls `export()` and its CI fails with `BilevelPlanningGraph has no attribute "export"` because CI resolves `0.1.2` from PyPI.

## After this merges

1. Publish `0.1.3` to PyPI (`uv build && uv publish` from `bilevel-planning/`).
2. Downstreams bump their pin to `bilevel_planning>=0.1.3`.

The release is additive and backward-compatible (new visualizer + `export()`), but note it carries ~2 months of accumulated changes since the `0.1.2` upload, not only `export()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
