### PR TITLE
bilevel-planning: declare runtime deps (relational_structs, prpl_utils, pyperplan)

### DIFF
--- a/bilevel-planning/pyproject.toml
+++ b/bilevel-planning/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
    "flask",
    "flask-cors",
    "pillow",
+   "relational_structs",
+   "prpl_utils",
+   "pyperplan",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Declare the runtime dependencies that `bilevel_planning` imports but never listed: `relational_structs`, `prpl_utils`, and `pyperplan`.

## Why

These are imported directly in source:
- `relational_structs` and `prpl_utils` — throughout (`bilevel_planning_graph.py`, `structs.py`, `utils.py`, …)
- `pyperplan` — in `utils.py` (PDDL heuristics)

In the monorepo they were satisfied implicitly — `relational_structs` via `prpl_requirements.txt` (editable `../relational-structs`), and `prpl_utils`/`pyperplan` transitively — so local installs worked. But a plain `pip install bilevel_planning` from PyPI **can't even import** `bilevel_planning.bilevel_planning_graph` (`ModuleNotFoundError: No module named 'prpl_utils'`). This surfaced while verifying the 0.1.3 wheel for release.

Declaring them explicitly matches the convention `relational_structs` itself uses (it lists its sibling deps in its own pyproject), and is correct practice since these are direct imports. Left bare to match the existing dependency style in this file.

## Verification

- Built the wheel and installed it into a **clean venv with nothing pre-provided** → it now auto-pulls `relational_structs 0.0.1`, `prpl_utils 0.0.7`, `pyperplan 2.1`, and `import bilevel_planning.bilevel_planning_graph` + `bilevel_planning.utils` both succeed.
- Monorepo unaffected: the editable siblings in the `.venv` still satisfy the bare requirements; `run_ci_checks.sh` passes (33 tests).

## Release note

This is metadata only. If **0.1.3 hasn't been published to PyPI yet**, merge this first and it rides along in the 0.1.3 build. If 0.1.3 is **already published**, this needs a follow-up version bump (0.1.4) to take effect on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
