### PR TITLE
bilevel-planning: render the full abstract search graph in the visualizer

### DIFF
--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -1,5 +1,6 @@
 """Bilevel planning graphs: primarily for visualization, analysis, debugging."""
 
+import heapq
 import pickle
 from collections import deque
 from pathlib import Path
@@ -554,6 +555,11 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         changes along the concrete path from the root, so the same abstract
         state reached at different depths becomes distinct nodes (see
         ``_abstract_depths``).
+
+        The abstract plane renders the entire abstract search graph -- every
+        abstract state and abstract-action edge the planner generated -- not
+        only the transitions the refiner instantiated with concrete states.
+        ``node.in_plan`` distinguishes the refined plan from the rest.
         """
         # ------------------------------------------------------------------
         # Phase 1: gather concrete node ids and the concrete->abstract map.
@@ -626,6 +632,10 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         # abstract graph into a DAG with no back-edges: revisiting an abstract
         # state (e.g. a plan that returns to the root abstract state) shows up
         # as a fresh node one layer deeper rather than an edge pointing back.
+        #
+        # The loop below renders only the abstract transitions the refiner
+        # actually instantiated with concrete states; the grafting pass that
+        # follows extends this to the entire abstract search graph.
         incoming_depth, last_mapped = self._abstract_depths(state_to_abstract)
 
         def abstract_nid(aid: int, depth: int) -> str:
@@ -644,28 +654,105 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         # Build the depth-stamped abstract nodes and the abstractor / abstract-
         # action edges from the mapped concrete states.
         abstract_node_to_aid: dict[str, int] = {}
+        abstract_node_depth: dict[str, int] = {}
         G_abstract: nx.DiGraph = nx.DiGraph()
         abstractor_edges: list[tuple[str, str]] = []
         abstract_action_specs: list[tuple[str, str, str | None]] = []
+        rendered_action_edges: set[tuple[str, str]] = set()
         for cid, aid in state_to_abstract.items():
             node_id = abstract_nid(aid, incoming_depth[cid])
             abstract_node_to_aid[node_id] = aid
+            abstract_node_depth[node_id] = incoming_depth[cid]
             G_abstract.add_node(node_id)
             abstractor_edges.append((concrete_nid(cid), node_id))
             parent_cid = last_mapped[cid]
             if parent_cid is not None:
                 parent_aid = state_to_abstract[parent_cid]
                 parent_node_id = abstract_nid(parent_aid, incoming_depth[parent_cid])
-                G_abstract.add_edge(parent_node_id, node_id)
-                name = abstract_action_name_by_pair.get((parent_aid, aid))
-                abstract_action_specs.append((parent_node_id, node_id, name))
+                if (parent_node_id, node_id) not in rendered_action_edges:
+                    rendered_action_edges.add((parent_node_id, node_id))
+                    G_abstract.add_edge(parent_node_id, node_id)
+                    name = abstract_action_name_by_pair.get((parent_aid, aid))
+                    abstract_action_specs.append((parent_node_id, node_id, name))
+
+        # Grafting pass: extend the abstract plane from the refiner-instantiated
+        # transitions above to the ENTIRE abstract search graph -- every abstract
+        # state in ``self.abstract_states`` and every edge in
+        # ``self.abstract_action_edges``, including branches the refiner never
+        # sampled a concrete state for. Nothing new is generated here: this only
+        # re-renders abstract states and actions the planner already explored.
+        #
+        # The same depth-unrolling rule applies: an edge into an already-seen
+        # abstract state spawns a fresh node one layer deeper rather than a
+        # back-edge. To keep this finite on cyclic abstract graphs, each abstract
+        # state is expanded (its outgoing edges followed) only at its shallowest
+        # rendered depth; deeper duplicates render as leaves. Processing nodes in
+        # nondecreasing depth order guarantees the shallowest occurrence of each
+        # abstract state is the one that gets expanded.
+        abstract_adj: dict[int, list[tuple[int, str | None]]] = {}
+        for src_abs, action, dst_abs in self.abstract_action_edges:
+            s_aid = self._abstract_state_to_id(src_abs)
+            d_aid = self._abstract_state_to_id(dst_abs)
+            abstract_adj.setdefault(s_aid, []).append(
+                (d_aid, _abstract_action_name(action))
+            )
+
+        # Min-heap of (depth, tiebreak, node_id); tiebreak keeps ordering stable
+        # and avoids comparing node-id strings.
+        heap: list[tuple[int, int, str]] = []
+        tiebreak = 0
+        for node_id, depth in abstract_node_depth.items():
+            heapq.heappush(heap, (depth, tiebreak, node_id))
+            tiebreak += 1
+        expanded_aids: set[int] = set()
+        while heap:
+            depth, _, node_id = heapq.heappop(heap)
+            aid = abstract_node_to_aid[node_id]
+            if aid in expanded_aids:
+                continue  # a shallower duplicate was already expanded
+            expanded_aids.add(aid)
+            for dst_aid, name in abstract_adj.get(aid, []):
+                dst_node = abstract_nid(dst_aid, depth + 1)
+                if (node_id, dst_node) in rendered_action_edges:
+                    continue
+                rendered_action_edges.add((node_id, dst_node))
+                if dst_node not in abstract_node_to_aid:
+                    abstract_node_to_aid[dst_node] = dst_aid
+                    abstract_node_depth[dst_node] = depth + 1
+                    G_abstract.add_node(dst_node)
+                    heapq.heappush(heap, (depth + 1, tiebreak, dst_node))
+                    tiebreak += 1
+                G_abstract.add_edge(node_id, dst_node)
+                abstract_action_specs.append((node_id, dst_node, name))
+
+        # Any abstract state disconnected from the instantiated roots (no path
+        # via abstract-action edges, e.g. a never-instantiated isolated state)
+        # still gets a node so the plane shows every abstract state.
+        rendered_aids = set(abstract_node_to_aid.values())
+        for aid in range(len(self.abstract_states)):
+            if aid not in rendered_aids:
+                node_id = abstract_nid(aid, 0)
+                abstract_node_to_aid[node_id] = aid
+                abstract_node_depth[node_id] = 0
+                G_abstract.add_node(node_id)
 
         # Lay out the abstract DAG (depth -> layer) and fit it into the concrete
-        # plane's xy bounds so the two planes line up.
+        # plane's xy bounds so the two planes line up. When the concrete plane is
+        # degenerate on an axis -- e.g. a single linear trajectory has zero
+        # x-extent -- fitting would squash the whole abstract plane onto that
+        # line and stack its branches on top of each other, so fall back to the
+        # abstract plane's own box (it now carries the full, possibly branching,
+        # search graph rather than a single refined path).
         abstract_layout = _hierarchical_layout(G_abstract)
-        if layout_pos:
-            concrete_xs = [p[0] for p in layout_pos.values()]
-            concrete_ys = [p[1] for p in layout_pos.values()]
+        concrete_xs = [p[0] for p in layout_pos.values()]
+        concrete_ys = [p[1] for p in layout_pos.values()]
+        concrete_has_extent = (
+            concrete_xs
+            and concrete_ys
+            and max(concrete_xs) - min(concrete_xs) > 1e-9
+            and max(concrete_ys) - min(concrete_ys) > 1e-9
+        )
+        if concrete_has_extent:
             abstract_pos = _fit_into_bounds(
                 abstract_layout,
                 min(concrete_xs),

--- a/bilevel-planning/tests/test_bilevel_planning_graph.py
+++ b/bilevel-planning/tests/test_bilevel_planning_graph.py
@@ -189,6 +189,85 @@ def test_export_roundtrip(tmp_path: Path):
         assert "atoms" not in n
 
 
+def test_export_full_abstract_graph(tmp_path: Path):
+    """The abstract plane renders the whole search graph, not just the refined path.
+
+    Mirrors the obstruction2d-o1-basic shape: the refiner only instantiates the
+    path root -> Holding(target) -> OnTarget, but the search also generated an
+    unrefined branch (Pick the obstruction) and an unrealized edge back to the
+    root (Place the target on the table). Both must show up: the branch as a new
+    leaf, and the back-edge as a duplicate root one layer deeper.
+    """
+    bpg: BilevelPlanningGraph = BilevelPlanningGraph()
+    states = [np.array([i], dtype=np.int64) for i in range(3)]
+    for s in states:
+        bpg.add_state_node(s)
+    root = _AtomsAbstractState(frozenset({"OnTable(t)", "OnTable(o)"}))
+    holding_t = _AtomsAbstractState(frozenset({"Holding(t)", "OnTable(o)"}))
+    holding_o = _AtomsAbstractState(frozenset({"Holding(o)", "OnTable(t)"}))
+    on_target = _AtomsAbstractState(frozenset({"OnTarget(t)", "OnTable(o)"}))
+    for a in (root, holding_t, holding_o, on_target):
+        bpg.add_abstract_state_node(a)
+
+    # Concrete (refined) path: root -> holding_t -> on_target.
+    bpg.add_state_abstractor_edge(states[0], root)
+    bpg.add_state_abstractor_edge(states[1], holding_t)
+    bpg.add_state_abstractor_edge(states[2], on_target)
+    bpg.add_action_edge(states[0], "step", states[1])
+    bpg.add_action_edge(states[1], "step", states[2])
+
+    # Full abstract search graph, including transitions never refined.
+    bpg.add_abstract_action_edge(root, "Pick(t)", holding_t)  # realized
+    bpg.add_abstract_action_edge(root, "Pick(o)", holding_o)  # unrefined branch
+    bpg.add_abstract_action_edge(holding_t, "Place->target", on_target)  # realized
+    bpg.add_abstract_action_edge(holding_t, "Place(t)", root)  # unrealized back-edge
+
+    path = tmp_path / "bundle.pkl"
+    bpg.export(path, final_state=states[-1])
+    with open(path, "rb") as f:
+        graph = pickle.load(f)["graph"]
+
+    # root (aid 0) at depth 0 and again at depth 2 (the unrolled back-edge);
+    # holding_t (1) and holding_o (2) at depth 1; on_target (3) at depth 2.
+    abstract_ids = sorted(n["id"] for n in graph["nodes"] if n["type"] == "abstract")
+    assert abstract_ids == ["s:0_0", "s:0_2", "s:1_1", "s:2_1", "s:3_2"]
+
+    aa = {
+        (e["source"], e["target"]): e.get("name")
+        for e in graph["edges"]
+        if e["type"] == "abstract_action"
+    }
+    assert aa == {
+        ("s:0_0", "s:1_1"): "Pick(t)",
+        ("s:0_0", "s:2_1"): "Pick(o)",
+        ("s:1_1", "s:3_2"): "Place->target",
+        ("s:1_1", "s:0_2"): "Place(t)",
+    }
+    # No edge points back to the depth-0 root; the back-edge is unrolled forward.
+    assert all(target != "s:0_0" for _, target in aa)
+
+    # The unrefined branch (Holding(o)) and the duplicate root carry no
+    # abstractor edge, since the refiner never sampled a concrete state there.
+    abstractor_targets = {
+        e["target"] for e in graph["edges"] if e["type"] == "abstractor"
+    }
+    assert "s:2_1" not in abstractor_targets
+    assert "s:0_2" not in abstractor_targets
+    assert {"s:0_0", "s:1_1", "s:3_2"} <= abstractor_targets
+
+    # The concrete plane here is a single linear chain (zero x-extent). The
+    # abstract plane must still spread its branches rather than collapsing them
+    # onto one column, so sibling nodes get distinct positions.
+    pos = {
+        n["id"]: tuple(n["position"][:2])
+        for n in graph["nodes"]
+        if n["type"] == "abstract"
+    }
+    assert pos["s:1_1"] != pos["s:2_1"]  # the two depth-1 branches
+    assert pos["s:3_2"] != pos["s:0_2"]  # the two depth-2 branches
+    assert len(set(pos.values())) == len(pos)  # no two abstract nodes coincide
+
+
 def test_abstract_state_atom_strs():
     """``_abstract_state_atom_strs`` extracts sorted atoms, else None."""
     assert _abstract_state_atom_strs("no-atoms-attr") is None


### PR DESCRIPTION
## Summary

The visualizer's abstract plane previously rendered only the abstract states and transitions the refiner actually instantiated with concrete states. Branches the abstract search explored but never refined were dropped — e.g. in an `obstruction2d-o1` instance where the obstruction does not block the goal, the search generates a `PickFromTable(obstruction0)` successor at the root, but it never appeared in the graph.

This PR renders the **entire abstract search graph** instead: every abstract state in `abstract_states` and every edge in `abstract_action_edges`.

## What changed

- **`_build_graph_payload` grafting pass** (`bilevel_planning_graph.py`): after building the refiner-instantiated abstract nodes/edges (unchanged), graft the rest of the abstract graph. Nothing new is generated at bundle time — this only re-renders abstract states and actions the planner already explored during `run()`.
  - The existing depth-unrolling is preserved: an edge into an already-seen abstract state spawns a fresh node one layer deeper (`s:<aid>_<depth>`) rather than a back-edge.
  - Each abstract state is expanded only at its shallowest rendered depth (processed via a depth-ordered heap), so cyclic abstract graphs stay finite and deeper duplicates render as leaves.
  - `node.in_plan` distinguishes the refined plan from the grafted remainder.
- **Layout fix**: when the concrete plane is degenerate on an axis (a single linear trajectory has zero x-extent), fitting the abstract plane into the concrete bounds squashed every abstract node onto one column, hiding the new branches. Fall back to the abstract plane's own box in that case. Behavior is unchanged when the concrete plane has real 2D extent.

## Effect

On the `obstruction2d-o1-basic` example the abstract plane now shows 5 nodes / 4 edges (the `Pick(obstruction0)` branch and the unrolled return-to-root) instead of the single 3-node path, with branches laid out distinctly.

## Testing

- Added `test_export_full_abstract_graph` covering: the unrefined branch and the unrolled back-edge are rendered, grafted nodes carry no abstractor edge, and sibling abstract nodes get distinct positions (the layout-collapse regression).
- Existing graph tests unchanged and passing.
- Full `./run_ci_checks.sh` green (autoformat, mypy, pylint, 37 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
