### PR TITLE
bilevel-planning: add run_sesame + export(constant_state)

### DIFF
--- a/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
+++ b/bilevel-planning/src/bilevel_planning/bilevel_planning_graph.py
@@ -13,6 +13,7 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from prpl_utils.utils import consistent_hash
+from relational_structs import ObjectCentricState
 
 from bilevel_planning.structs import Plan
 
@@ -869,11 +870,12 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
         self,
         path: Path,
         final_state: _X | None = None,
+        constant_state: ObjectCentricState | None = None,
         **kwargs,
     ) -> None:
         """Write a single pickle bundling graph topology and state objects.
 
-        The resulting pickle is a dict with two keys:
+        The resulting pickle is a dict with three keys:
 
           * ``"graph"``: the frontend-facing topology dict (nodes, edges,
             plan info, config) produced by ``_build_graph_payload``. The
@@ -882,12 +884,21 @@ class BilevelPlanningGraph(Generic[_X, _U, _S, _A]):
             ``"x:<display_id>"`` to the original state objects. Display
             ids are insertion-order indices into ``self.states``. The
             backend indexes into this dict when rendering a specific node.
+          * ``"constant_state"``: optional static objects (e.g. walls, a table)
+            that the environment keeps separate from the per-step state. It is
+            stored once here; the visualizer backend merges it into a state at
+            render time (mirroring how the env merges constants only when it
+            needs the full scene), so the renderer draws the full picture
+            without duplicating the static objects into every state.
         """
         graph_payload = self._build_graph_payload(final_state=final_state, **kwargs)
         states_payload: dict[str, _X] = {
             f"x:{idx}": state for idx, state in enumerate(self.states)
         }
-
-        bundle = {"graph": graph_payload, "states": states_payload}
+        bundle = {
+            "graph": graph_payload,
+            "states": states_payload,
+            "constant_state": constant_state,
+        }
         with open(path, "wb") as f:
             pickle.dump(bundle, f)

--- a/bilevel-planning/src/bilevel_planning/sesame.py
+++ b/bilevel-planning/src/bilevel_planning/sesame.py
@@ -1,0 +1,87 @@
+"""Convenience for running the SESAME bilevel planner from ``SesameModels``.
+
+Constructing a SESAME planner means wiring up a trajectory sampler, an abstract
+plan generator, an abstract successor function, and the planner itself -- all
+derived from the same ``SesameModels``. ``run_sesame`` does that wiring for you:
+pass the env models and an initial state, get back the plan and the bilevel
+planning graph.
+"""
+
+from typing import Hashable, TypeVar
+
+from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
+    AbstractPlanGenerator,
+)
+from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
+    RelationalHeuristicSearchAbstractPlanGenerator,
+)
+from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
+from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
+from bilevel_planning.structs import Plan, PlanningProblem, SesameModels
+from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
+    ParameterizedControllerTrajectorySampler,
+)
+from bilevel_planning.utils import (
+    RelationalAbstractSuccessorGenerator,
+    RelationalControllerGenerator,
+)
+
+_O = TypeVar("_O", bound=Hashable)
+_X = TypeVar("_X", bound=Hashable)
+_U = TypeVar("_U", bound=Hashable)
+
+
+def run_sesame(
+    env_models: SesameModels[_O, _X, _U],
+    initial_state: _X,
+    *,
+    seed: int = 0,
+    max_abstract_plans: int = 1,
+    samples_per_step: int = 5,
+    max_skill_horizon: int = 100,
+    heuristic_name: str = "hff",
+    timeout: float = 30.0,
+) -> tuple[Plan[_X, _U] | None, BilevelPlanningGraph]:
+    """Run the SESAME planner on ``initial_state`` using ``env_models``.
+
+    The goal is derived from ``env_models.goal_deriver(initial_state)``. Returns
+    ``(plan, bpg)`` where ``plan`` is ``None`` if no plan was found and ``bpg`` is
+    the bilevel planning graph (useful for visualization/analysis).
+    """
+    problem = PlanningProblem(
+        env_models.state_space,
+        env_models.action_space,
+        initial_state,
+        env_models.transition_fn,
+        env_models.goal_deriver(initial_state),
+    )
+    trajectory_sampler = ParameterizedControllerTrajectorySampler(
+        controller_generator=RelationalControllerGenerator(env_models.skills),
+        transition_function=env_models.transition_fn,
+        state_abstractor=env_models.state_abstractor,
+        max_trajectory_steps=max_skill_horizon,
+    )
+    abstract_plan_generator: AbstractPlanGenerator = (
+        RelationalHeuristicSearchAbstractPlanGenerator(
+            env_models.types,
+            env_models.predicates,
+            env_models.operators,
+            heuristic_name,
+            seed=seed,
+            precomputed_ground_operators=env_models.ground_operators,
+        )
+    )
+    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
+        env_models.operators,
+        precomputed_ground_operators=env_models.ground_operators,
+    )
+    planner = SesamePlanner(
+        abstract_plan_generator,
+        trajectory_sampler,
+        max_abstract_plans,
+        samples_per_step,
+        abstract_successor_fn,
+        env_models.state_abstractor,
+        seed=seed,
+    )
+    return planner.run(problem, timeout=timeout)

--- a/bilevel-planning/src/bilevel_planning/visualizer/app.py
+++ b/bilevel-planning/src/bilevel_planning/visualizer/app.py
@@ -56,6 +56,11 @@ RenderStateFn = Callable[[Any], np.ndarray]
 # from the renderer file.
 GRAPH_DATA: dict = {}
 STATE_DATA: dict = {}
+# Static objects (walls, table) the env keeps separate from the per-step state.
+# Stored once in the bundle and merged into a state at render time -- mirroring how
+# the env merges constants only when it needs the full scene (e.g. to render).
+# ``None`` when the bundle has no constant objects.
+CONSTANT_STATE: Any = None
 RENDER_FN: RenderStateFn | None = None
 
 # Name the renderer file must bind for ``load_renderer_from_path`` to pick
@@ -103,6 +108,12 @@ def create_app() -> Flask:
                 return jsonify({"error": f"Node ID not found: {node_id}"}), 404
 
             state = STATE_DATA[node_id]
+            if CONSTANT_STATE is not None:
+                # Merge the static objects in only for rendering (the env does the
+                # same), so the renderer sees the full scene without them being
+                # baked into every stored state.
+                state = state.copy()
+                state.data.update(CONSTANT_STATE.data)
             rgb_array = RENDER_FN(state)
             image = Image.fromarray(np.asarray(rgb_array).astype("uint8"))
 
@@ -180,7 +191,7 @@ def load_bundle_from_path(path: str | Path) -> int:
     Returns the number of states loaded. Raises ``ValueError`` if the file
     isn't a visualizer bundle.
     """
-    global GRAPH_DATA, STATE_DATA
+    global GRAPH_DATA, STATE_DATA, CONSTANT_STATE
     with open(path, "rb") as f:
         bundle = pickle.load(f)
     if not (isinstance(bundle, dict) and "graph" in bundle and "states" in bundle):
@@ -191,6 +202,7 @@ def load_bundle_from_path(path: str | Path) -> int:
         )
     GRAPH_DATA = bundle["graph"]
     STATE_DATA = bundle["states"]
+    CONSTANT_STATE = bundle.get("constant_state")
     return len(STATE_DATA)
 
 

--- a/bilevel-planning/tests/bilevel_planners/test_sesame_planner.py
+++ b/bilevel-planning/tests/bilevel_planners/test_sesame_planner.py
@@ -17,6 +17,8 @@ from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator i
     RelationalHeuristicSearchAbstractPlanGenerator,
 )
 from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
+from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
+from bilevel_planning.sesame import run_sesame
 from bilevel_planning.structs import (
     FunctionalGoal,
     GroundParameterizedController,
@@ -26,6 +28,7 @@ from bilevel_planning.structs import (
     PlanningProblem,
     RelationalAbstractGoal,
     RelationalAbstractState,
+    SesameModels,
     TransitionFailure,
 )
 from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
@@ -355,3 +358,96 @@ def test_relational_sesame():
     # )
 
     del bpg
+
+
+def test_run_sesame():
+    """``run_sesame`` builds the planner from ``SesameModels`` and returns (plan,
+    bpg)."""
+    grid_n = 4
+    state_space = Box(0.0, float(grid_n), shape=(2,))
+    action_space = Box(-0.5, 0.5, shape=(2,))
+    initial_state = np.array([0.0, 0.0])
+
+    def transition_fn(x, u):
+        return x + u
+
+    loc_type = Type("loc")
+    at = Predicate("at", [loc_type])
+    adjacent = Predicate("adjacent", [loc_type, loc_type])
+    loc_to_xy = lambda loc: tuple(map(int, loc.name[len("loc-") :].split("-")))
+
+    start = loc_type("?start")
+    end = loc_type("?end")
+    move_operator = LiftedOperator(
+        "move",
+        [start, end],
+        preconditions={at([start]), adjacent([start, end])},
+        add_effects={at([end])},
+        delete_effects={at([start])},
+    )
+
+    class GroundMoveController(GroundParameterizedController, MockController):
+        """Move deterministically (offset 0) from one cell to an adjacent one."""
+
+        def __init__(self, objects):
+            start_loc, end_loc = objects
+            sx, sy = loc_to_xy(start_loc)
+            ex, ey = loc_to_xy(end_loc)
+            MockController.__init__(self, (ex - sx, ey - sy), offset_mag=0.0)
+            GroundParameterizedController.__init__(self, objects)
+
+    move_skill = LiftedSkill(
+        move_operator, LiftedParameterizedController([start, end], GroundMoveController)
+    )
+
+    objects = {
+        loc_type(f"loc-{x}-{y}") for x in range(grid_n + 1) for y in range(grid_n + 1)
+    }
+    adjacent_atoms = set()
+    for x in range(grid_n + 1):
+        for y in range(grid_n + 1):
+            for dx, dy in [(-1, 0), (1, 0), (0, 1), (0, -1)]:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx <= grid_n and 0 <= ny <= grid_n:
+                    adjacent_atoms.add(
+                        adjacent([loc_type(f"loc-{x}-{y}"), loc_type(f"loc-{nx}-{ny}")])
+                    )
+
+    def state_abstractor(state):
+        x, y = round(state[0]), round(state[1])
+        loc = loc_type(f"loc-{x}-{y}")
+        return RelationalAbstractState({at([loc])} | adjacent_atoms, objects)
+
+    target = loc_type("loc-2-2")
+
+    def goal_deriver(state):
+        del state
+        return RelationalAbstractGoal({at([target])}, state_abstractor)
+
+    models = SesameModels(
+        observation_space=state_space,
+        state_space=state_space,
+        action_space=action_space,
+        transition_fn=transition_fn,
+        types={loc_type},
+        predicates={at, adjacent},
+        observation_to_state=lambda o: o,
+        state_abstractor=state_abstractor,
+        goal_deriver=goal_deriver,
+        skills={move_skill},
+    )
+
+    plan, bpg = run_sesame(
+        models,
+        initial_state,
+        seed=123,
+        max_abstract_plans=10,
+        samples_per_step=10,
+        max_skill_horizon=5,
+        timeout=10.0,
+    )
+    assert plan is not None
+    assert isinstance(bpg, BilevelPlanningGraph)
+    # Ended at the goal cell.
+    final = plan.states[-1]
+    assert (round(final[0]), round(final[1])) == (2, 2)

--- a/bilevel-planning/tests/test_bilevel_planning_graph.py
+++ b/bilevel-planning/tests/test_bilevel_planning_graph.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
+from relational_structs import Object, ObjectCentricState, Type
 
 from bilevel_planning.bilevel_planning_graph import (
     BilevelPlanningGraph,
@@ -104,7 +105,8 @@ def test_export_roundtrip(tmp_path: Path):
     with open(path, "rb") as f:
         bundle = pickle.load(f)
 
-    assert set(bundle.keys()) == {"graph", "states"}
+    assert set(bundle.keys()) == {"graph", "states", "constant_state"}
+    assert bundle["constant_state"] is None  # none passed
     graph = bundle["graph"]
     states = bundle["states"]
 
@@ -348,3 +350,43 @@ def test_export_abstract_depth_unrolling(tmp_path: Path):
     }
     # No abstract-action edge points back to the depth-0 root.
     assert all(target != "s:0_0" for _, target in aa)
+
+
+def test_export_stores_constant_state(tmp_path: Path):
+    """``export(constant_state=...)`` stores it once; the states are not mutated.
+
+    The static objects are merged into a state only at render time (by the visualizer
+    backend), so they are not baked into every stored state.
+    """
+    block_t = Type("block")
+    wall_t = Type("wall")
+    states = [
+        ObjectCentricState(
+            {Object("b", block_t): np.array([float(i)])}, {block_t: ["x"]}
+        )
+        for i in range(2)
+    ]
+    bpg: BilevelPlanningGraph = BilevelPlanningGraph()
+    for s in states:
+        bpg.add_state_node(s)
+    bpg.add_action_edge(states[0], "step", states[1])
+    constant_state = ObjectCentricState(
+        {Object("wall", wall_t): np.array([9.0])}, {wall_t: ["y"]}
+    )
+
+    path = tmp_path / "with_const.pkl"
+    bpg.export(path, final_state=states[-1], constant_state=constant_state)
+    with open(path, "rb") as f:
+        bundle = pickle.load(f)
+    # The constant state is stored once, separate from the per-step states.
+    assert "wall" in {o.name for o in bundle["constant_state"]}
+    # The stored states are unchanged -- no static objects baked into them.
+    for state in bundle["states"].values():
+        names = {o.name for o in state}
+        assert "b" in names and "wall" not in names
+
+    # Without constant_state, the bundle key is None.
+    path2 = tmp_path / "no_const.pkl"
+    bpg.export(path2, final_state=states[-1])
+    with open(path2, "rb") as f:
+        assert pickle.load(f)["constant_state"] is None

--- a/bilevel-planning/tests/visualizer/test_app.py
+++ b/bilevel-planning/tests/visualizer/test_app.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from PIL import Image
+from relational_structs import Object, ObjectCentricState, Type
 
 from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
 from bilevel_planning.visualizer import app as visualizer_app
@@ -45,10 +46,12 @@ def _reset_module_state():
     """
     visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
+    visualizer_app.CONSTANT_STATE = None
     visualizer_app.RENDER_FN = None
     yield
     visualizer_app.GRAPH_DATA = {}
     visualizer_app.STATE_DATA = {}
+    visualizer_app.CONSTANT_STATE = None
     visualizer_app.RENDER_FN = None
 
 
@@ -152,6 +155,46 @@ def test_visualize_unknown_node_returns_404(tmp_path: Path):
     client = app.test_client()
     resp = client.post("/api/visualize_state", json={"node_id": "x:doesnotexist"})
     assert resp.status_code == 404
+
+
+def test_visualize_merges_constant_state(tmp_path: Path):
+    """The backend merges the bundle's ``constant_state`` in before rendering."""
+    block_t, wall_t = Type("block"), Type("wall")
+    states = [
+        ObjectCentricState(
+            {Object("b", block_t): np.array([float(i)])}, {block_t: ["x"]}
+        )
+        for i in range(2)
+    ]
+    bpg: BilevelPlanningGraph = BilevelPlanningGraph()
+    for s in states:
+        bpg.add_state_node(s)
+    bpg.add_action_edge(states[0], "step", states[1])
+    constant_state = ObjectCentricState(
+        {Object("wall", wall_t): np.array([9.0])}, {wall_t: ["y"]}
+    )
+    bundle_path = tmp_path / "bundle.pkl"
+    bpg.export(bundle_path, final_state=states[-1], constant_state=constant_state)
+
+    # Renderer encodes the number of objects in the rendered state into the pixels.
+    renderer_path = _write_renderer(
+        tmp_path,
+        "import numpy as np\n"
+        "def render_state(state):\n"
+        "    return np.full((4, 4, 3), len(list(state)), dtype=np.uint8)\n",
+    )
+    load_bundle_from_path(bundle_path)
+    load_renderer_from_path(renderer_path)
+    node_id = next(iter(pickle.loads(bundle_path.read_bytes())["states"]))
+
+    client = create_app().test_client()
+    payload = client.post("/api/visualize_state", json={"node_id": node_id}).get_json()
+    png = base64.b64decode(payload["image"].split(",", 1)[1])
+    image = np.asarray(Image.open(io.BytesIO(png)))
+    # Two objects rendered (the block plus the merged-in wall), not one.
+    assert int(image[0, 0, 0]) == 2
+    # The stored state itself is untouched (one object).
+    assert len(list(visualizer_app.STATE_DATA[node_id])) == 1
 
 
 def test_load_bundle_rejects_wrong_shape(tmp_path: Path):


### PR DESCRIPTION
## Summary

Two additions to cut repetitive planner-setup boilerplate.

### `run_sesame` (new `bilevel_planning/sesame.py`)
Constructing a SESAME planner means wiring up a `ParameterizedControllerTrajectorySampler`, a `RelationalHeuristicSearchAbstractPlanGenerator`, a `RelationalAbstractSuccessorGenerator`, and the `SesamePlanner` — all from the same `SesameModels`. Every run script, example, and the `BilevelPlanningAgent` duplicated this ~30 lines. `run_sesame` does it once:

```python
plan, bpg = run_sesame(env_models, initial_state, max_abstract_plans=1,
                       samples_per_step=5, timeout=120.0)
```

### `export(..., constant_state=...)`
Some envs deliberately keep static objects (walls, table) **out** of the per-step state/observation, and only merge them in when they need the full scene (the kinematic2d env does this for collision checks and `render()`). The visualizer needs the full scene too, so `export` now takes an optional `constant_state` and **stores it once** in the bundle; the visualizer backend merges it into a state **at render time**, mirroring the env — rather than baking the static objects into every stored state. (This also replaces a hand-written `_bake_constants_into_states` post-processing pass in the callers.)

## Tests
- `test_run_sesame` — `run_sesame` returns `(plan, bpg)` that reaches the goal.
- `test_export_stores_constant_state` — the constant state is stored once and the per-step states are left untouched.
- `test_visualize_merges_constant_state` — the backend merges the constant state in before rendering.

Consumers (`BilevelPlanningAgent`, lab/example run scripts) are updated in a separate kinder-baselines PR (blocked on a `bilevel_planning` release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
