### PR TITLE
prpl-agent-utils: add a Pendulum pure-agent example notebook

### DIFF
--- a/prpl-agent-utils/.gitignore
+++ b/prpl-agent-utils/.gitignore
@@ -1,1 +1,2 @@
 red_team_workdir/
+examples/pendulum_sandbox/

--- a/prpl-agent-utils/README.md
+++ b/prpl-agent-utils/README.md
@@ -70,6 +70,16 @@ Authentication comes from `claude login` on the host (or
 `CLAUDE_CODE_OAUTH_TOKEN`); the operator's live `~/.claude` directory is never
 read or written by the sandboxed CLI.
 
+## Example
+
+`examples/pendulum_pure_agent.ipynb` works through the recipe in [*Now what? A
+recipe for after the problem
+setting*](https://tomsilver.github.io/blog/2026/now-whats-your-solution/) on
+gymnasium's `Pendulum-v1`: a random baseline, a pure agent method that writes and
+revises its own policy inside the sandbox, and an energy-shaping oracle. Install
+the extra dependencies with `pip install -e ".[examples]"`. Running it spends a
+few tens of cents of API budget.
+
 ## Red teaming the sandbox
 
 `integration_tests/red_team_sandbox.py` runs adversarial prompts against a real

--- a/prpl-agent-utils/examples/pendulum_pure_agent.ipynb
+++ b/prpl-agent-utils/examples/pendulum_pure_agent.ipynb
@@ -1,0 +1,640 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "22b151f0",
+   "metadata": {},
+   "source": [
+    "# The pure agent baseline on Pendulum\n",
+    "\n",
+    "This notebook follows the recipe in [*Now what? A recipe for after the problem\n",
+    "setting*](https://tomsilver.github.io/blog/2026/now-whats-your-solution/) on a\n",
+    "problem small enough to run end to end: swinging up an inverted pendulum.\n",
+    "\n",
+    "1. **A concrete problem.** Gymnasium's `Pendulum-v1`.\n",
+    "2. **The stupidest approach.** Uniformly random torques.\n",
+    "3. **The pure agent.** Every abstract method is implemented by handing its\n",
+    "   inputs to a coding agent, using `prpl-agent-utils`.\n",
+    "4. **An oracle.** Energy-shaping swing-up with a PD catch, written with full\n",
+    "   knowledge of the dynamics.\n",
+    "\n",
+    "Running the pure agent costs real API budget (a few tens of cents at the\n",
+    "defaults below) and takes several minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "db796921",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:11:54.598054Z",
+     "iopub.status.busy": "2026-07-28T19:11:54.597956Z",
+     "iopub.status.idle": "2026-07-28T19:11:54.653666Z",
+     "shell.execute_reply": "2026-07-28T19:11:54.653187Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import abc\n",
+    "import importlib.util\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import gymnasium as gym\n",
+    "import numpy as np\n",
+    "\n",
+    "from prpl_agent_utils import ClaudeCodeAgent\n",
+    "\n",
+    "ENV_ID = \"Pendulum-v1\"\n",
+    "MAX_STEPS = 200\n",
+    "TRAIN_SEEDS = list(range(5))\n",
+    "EVAL_SEEDS = list(range(100, 120))\n",
+    "\n",
+    "# The agent runs in a Docker container by default; build the image once with\n",
+    "# `bash docker/build.sh`. Set to False to run the CLI directly on the host.\n",
+    "USE_DOCKER = True\n",
+    "SANDBOX_DIR = Path(\"pendulum_sandbox\")\n",
+    "NUM_AGENT_ROUNDS = 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77335265",
+   "metadata": {},
+   "source": [
+    "## Step 1: a concrete problem\n",
+    "\n",
+    "`Pendulum-v1` gives an observation of $(\\cos\\theta, \\sin\\theta,\n",
+    "\\dot\\theta)$ with $\\theta = 0$ upright, takes a torque in $[-2, 2]$, and pays\n",
+    "a cost $-(\\theta^2 + 0.1\\dot\\theta^2 + 0.001u^2)$ at every one of 200 steps.\n",
+    "The pendulum starts near the bottom, and the torque limit is too small to lift\n",
+    "it directly, so a solution has to pump energy in over several swings.\n",
+    "\n",
+    "The interface is the part that matters for the recipe. A `Method` learns from\n",
+    "training problems, prepares for a new problem, and produces an action for each\n",
+    "observation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "47f9968e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:11:54.655508Z",
+     "iopub.status.busy": "2026-07-28T19:11:54.655364Z",
+     "iopub.status.idle": "2026-07-28T19:11:54.659322Z",
+     "shell.execute_reply": "2026-07-28T19:11:54.658889Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class Method(abc.ABC):\n",
+    "    \"\"\"A method for solving a sequential decision-making problem.\"\"\"\n",
+    "\n",
+    "    @abc.abstractmethod\n",
+    "    def train(self, train_seeds: list[int]) -> None:\n",
+    "        \"\"\"Learn whatever you want from the training problems.\"\"\"\n",
+    "\n",
+    "    @abc.abstractmethod\n",
+    "    def reset(self, obs: np.ndarray, info: dict) -> None:\n",
+    "        \"\"\"Prepare to solve a new problem.\"\"\"\n",
+    "\n",
+    "    @abc.abstractmethod\n",
+    "    def step(self, obs: np.ndarray) -> np.ndarray:\n",
+    "        \"\"\"Given the current observation, return the next action.\"\"\"\n",
+    "\n",
+    "\n",
+    "def evaluate(method: Method, seeds: list[int]) -> tuple[float, float]:\n",
+    "    \"\"\"Return the mean and standard deviation of returns over the seeds.\"\"\"\n",
+    "    env = gym.make(ENV_ID)\n",
+    "    returns = []\n",
+    "    for seed in seeds:\n",
+    "        obs, info = env.reset(seed=seed)\n",
+    "        method.reset(obs, info)\n",
+    "        total = 0.0\n",
+    "        for _ in range(MAX_STEPS):\n",
+    "            obs, reward, terminated, truncated, info = env.step(method.step(obs))\n",
+    "            total += float(reward)\n",
+    "            if terminated or truncated:\n",
+    "                break\n",
+    "        returns.append(total)\n",
+    "    env.close()\n",
+    "    return float(np.mean(returns)), float(np.std(returns))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86c6e357",
+   "metadata": {},
+   "source": [
+    "## Step 2: the stupidest possible approach\n",
+    "\n",
+    "Random torques. This is here to check that the metric separates good behavior\n",
+    "from bad: if random actions scored well, the problem or the metric would be\n",
+    "wrong."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cd4d4e06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:11:54.660689Z",
+     "iopub.status.busy": "2026-07-28T19:11:54.660597Z",
+     "iopub.status.idle": "2026-07-28T19:11:54.765231Z",
+     "shell.execute_reply": "2026-07-28T19:11:54.764711Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "random: -1354.5 +/- 298.9\n"
+     ]
+    }
+   ],
+   "source": [
+    "class RandomMethod(Method):\n",
+    "    \"\"\"Sample a uniformly random torque at every step.\"\"\"\n",
+    "\n",
+    "    def __init__(self, seed: int = 0) -> None:\n",
+    "        self._action_space = gym.make(ENV_ID).action_space\n",
+    "        self._action_space.seed(seed)\n",
+    "\n",
+    "    def train(self, train_seeds: list[int]) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def reset(self, obs: np.ndarray, info: dict) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def step(self, obs: np.ndarray) -> np.ndarray:\n",
+    "        return self._action_space.sample()\n",
+    "\n",
+    "\n",
+    "random_result = evaluate(RandomMethod(), EVAL_SEEDS)\n",
+    "print(f\"random: {random_result[0]:.1f} +/- {random_result[1]:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "395cd355",
+   "metadata": {},
+   "source": [
+    "## Step 2.5: the pure agent\n",
+    "\n",
+    "The blog's version of this step queries an agent inside `step`:\n",
+    "\n",
+    "```python\n",
+    "def step(self, obs: Observation) -> Action:\n",
+    "    prompt = PROMPT_TEMPLATE.format(...)\n",
+    "    response = query_agent(prompt)\n",
+    "    return parse_action(response)\n",
+    "```\n",
+    "\n",
+    "That is not workable here, and the reason is worth stating plainly: `Pendulum-v1`\n",
+    "runs at 20 Hz, so a single episode is 200 actions and an evaluation is 4000. No\n",
+    "agent closes that loop at the necessary rate or price. This is one of the\n",
+    "limitations the blog points to when it argues where research remains\n",
+    "competitive, and a pendulum is enough to run into it.\n",
+    "\n",
+    "So the pure agent writes the policy instead of being the policy. During `train`,\n",
+    "it authors `policy.py` in its sandbox; we evaluate that file on the training\n",
+    "seeds and hand the score back; it revises. `step` then calls the function it\n",
+    "wrote. The agent's sandbox and its conversation both persist across the calls to\n",
+    "`query`, so each round builds on the last.\n",
+    "\n",
+    "The prompt names the environment, which is a large hint: the agent has certainly\n",
+    "read about pendulum swing-up. That is the honest version of this baseline, and\n",
+    "the blog's warning applies — if it does well, the problem may be too easy rather\n",
+    "than the method too good."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "23ab9ffb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:11:54.766543Z",
+     "iopub.status.busy": "2026-07-28T19:11:54.766458Z",
+     "iopub.status.idle": "2026-07-28T19:11:54.772737Z",
+     "shell.execute_reply": "2026-07-28T19:11:54.772356Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "INITIAL_PROMPT = \"\"\"\\\n",
+    "Write a file `policy.py` in the current directory containing a control policy \\\n",
+    "for the gymnasium environment {env_id}.\n",
+    "\n",
+    "The file must define exactly this function:\n",
+    "\n",
+    "    def policy(obs):\n",
+    "        # obs is a numpy array [cos(theta), sin(theta), theta_dot],\n",
+    "        # with theta = 0 upright.\n",
+    "        # Return a numpy array of shape (1,) holding a torque in [-2, 2].\n",
+    "\n",
+    "Only `numpy` may be imported. The function must be deterministic and fast: it is \\\n",
+    "called 200 times per episode. Do not run anything; the policy is evaluated \\\n",
+    "outside this sandbox and you will be told the score.\n",
+    "\n",
+    "The score is the mean return over {num_seeds} episodes of {max_steps} steps, \\\n",
+    "where each step pays -(theta^2 + 0.1*theta_dot^2 + 0.001*torque^2). Random \\\n",
+    "torques score about -1200. Higher is better.\n",
+    "\"\"\"\n",
+    "\n",
+    "FEEDBACK_PROMPT = \"\"\"\\\n",
+    "Your policy scored a mean return of {score:.1f} over the training episodes.\n",
+    "\n",
+    "Revise `policy.py` to score higher. Keep the same function signature.\n",
+    "\"\"\"\n",
+    "\n",
+    "ERROR_PROMPT = \"\"\"\\\n",
+    "Your policy could not be evaluated: {error}\n",
+    "\n",
+    "Fix `policy.py`. Keep the same function signature.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "class PureAgentMethod(Method):\n",
+    "    \"\"\"A method whose policy is written by a coding agent in its sandbox.\"\"\"\n",
+    "\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        sandbox_dir: Path,\n",
+    "        num_rounds: int = 3,\n",
+    "        use_docker: bool = True,\n",
+    "    ) -> None:\n",
+    "        self._agent = ClaudeCodeAgent(\n",
+    "            sandbox_dir,\n",
+    "            use_docker=use_docker,\n",
+    "            max_budget_usd_per_query=1.0,\n",
+    "        )\n",
+    "        self._num_rounds = num_rounds\n",
+    "        self._policy_fn = None\n",
+    "        self.history: list[tuple[int, float | None, str | None]] = []\n",
+    "\n",
+    "    def train(self, train_seeds: list[int]) -> None:\n",
+    "        prompt = INITIAL_PROMPT.format(\n",
+    "            env_id=ENV_ID, num_seeds=len(train_seeds), max_steps=MAX_STEPS\n",
+    "        )\n",
+    "        for round_idx in range(self._num_rounds):\n",
+    "            self._agent.query(prompt)\n",
+    "            policy_fn, error = self._load_policy()\n",
+    "            score: float | None = None\n",
+    "            if error is None:\n",
+    "                assert policy_fn is not None\n",
+    "                try:\n",
+    "                    score = evaluate(_FixedPolicyMethod(policy_fn), train_seeds)[0]\n",
+    "                    self._policy_fn = policy_fn\n",
+    "                except Exception as exc:  # the policy ran but misbehaved\n",
+    "                    error = f\"{type(exc).__name__}: {exc}\"\n",
+    "            self.history.append((round_idx, score, error))\n",
+    "            print(f\"round {round_idx}: score={score}, error={error}\")\n",
+    "            if error is not None:\n",
+    "                prompt = ERROR_PROMPT.format(error=error)\n",
+    "            else:\n",
+    "                assert score is not None\n",
+    "                prompt = FEEDBACK_PROMPT.format(score=score)\n",
+    "\n",
+    "    def _load_policy(self):\n",
+    "        \"\"\"Import `policy.py` from the sandbox; return (function, error).\"\"\"\n",
+    "        path = self._agent.sandbox_dir / \"policy.py\"\n",
+    "        if not path.exists():\n",
+    "            return None, \"policy.py was not created\"\n",
+    "        try:\n",
+    "            spec = importlib.util.spec_from_file_location(\"agent_policy\", path)\n",
+    "            assert spec is not None and spec.loader is not None\n",
+    "            module = importlib.util.module_from_spec(spec)\n",
+    "            sys.modules[\"agent_policy\"] = module\n",
+    "            spec.loader.exec_module(module)\n",
+    "            policy_fn = module.policy\n",
+    "            probe = np.array([1.0, 0.0, 0.0])\n",
+    "            action = np.asarray(policy_fn(probe), dtype=np.float64).reshape(1)\n",
+    "            assert np.isfinite(action).all()\n",
+    "        except Exception as exc:\n",
+    "            return None, f\"{type(exc).__name__}: {exc}\"\n",
+    "        return policy_fn, None\n",
+    "\n",
+    "    def reset(self, obs: np.ndarray, info: dict) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def step(self, obs: np.ndarray) -> np.ndarray:\n",
+    "        assert self._policy_fn is not None, \"train() must produce a policy first\"\n",
+    "        action = np.asarray(self._policy_fn(obs), dtype=np.float64).reshape(1)\n",
+    "        return np.clip(action, -2.0, 2.0)\n",
+    "\n",
+    "\n",
+    "class _FixedPolicyMethod(Method):\n",
+    "    \"\"\"Wrap a plain policy function so it can be evaluated as a Method.\"\"\"\n",
+    "\n",
+    "    def __init__(self, policy_fn) -> None:\n",
+    "        self._policy_fn = policy_fn\n",
+    "\n",
+    "    def train(self, train_seeds: list[int]) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def reset(self, obs: np.ndarray, info: dict) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def step(self, obs: np.ndarray) -> np.ndarray:\n",
+    "        action = np.asarray(self._policy_fn(obs), dtype=np.float64).reshape(1)\n",
+    "        return np.clip(action, -2.0, 2.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "597116af",
+   "metadata": {},
+   "source": [
+    "The agent is sandboxed while it writes the policy, but loading `policy.py` here\n",
+    "runs its code in this notebook's process. The sandbox protects the authoring\n",
+    "step, not the evaluation step. Evaluating inside the container too, and passing\n",
+    "only the score back, would close that gap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ed9d8129",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:11:54.773994Z",
+     "iopub.status.busy": "2026-07-28T19:11:54.773922Z",
+     "iopub.status.idle": "2026-07-28T19:18:16.961972Z",
+     "shell.execute_reply": "2026-07-28T19:18:16.961473Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 0: score=-143.36494786121958, error=None\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 1: score=-142.73398565730787, error=None\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 2: score=-142.60222849514494, error=None\n",
+      "pure agent: -184.2 +/- 75.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent_method = PureAgentMethod(\n",
+    "    SANDBOX_DIR, num_rounds=NUM_AGENT_ROUNDS, use_docker=USE_DOCKER\n",
+    ")\n",
+    "agent_method.train(TRAIN_SEEDS)\n",
+    "agent_result = evaluate(agent_method, EVAL_SEEDS)\n",
+    "print(f\"pure agent: {agent_result[0]:.1f} +/- {agent_result[1]:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "df8589e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:18:16.963664Z",
+     "iopub.status.busy": "2026-07-28T19:18:16.963535Z",
+     "iopub.status.idle": "2026-07-28T19:18:16.965851Z",
+     "shell.execute_reply": "2026-07-28T19:18:16.965495Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "import numpy as np\n",
+      "\n",
+      "# Pendulum-v1 physical constants (see gym's pendulum.py dynamics):\n",
+      "#   theta_ddot = (3*g / (2*l)) * sin(theta) + (3 / (m*l**2)) * u\n",
+      "# with theta = 0 at the (unstable) upright equilibrium.\n",
+      "_G = 10.0\n",
+      "_L = 1.0\n",
+      "_M = 1.0\n",
+      "_MAX_TORQUE = 2.0\n",
+      "_K = 3.0 * _G / (2.0 * _L)   # = 15.0, gravity coefficient\n",
+      "_B = 3.0 / (_M * _L ** 2)    # = 3.0,  torque coefficient\n",
+      "_E_TOP = _K                  # conserved energy 0.5*thetadot^2 + K*cos(theta) at rest, upright\n",
+      "\n",
+      "# Switch to a linear stabilizer once close enough to upright to hold statically\n",
+      "# (max torque can balance gravity there: K*theta < B*MAX_TORQUE for theta < 0.4).\n",
+      "_ANGLE_THRESH = 0.3\n",
+      "_SPEED_THRESH = 2.0\n",
+      "\n",
+      "# LQR gains for the linearized balance dynamics theta_ddot = K*theta + B*u,\n",
+      "# solved for the *actual* per-step cost weights Q = diag(1, 0.1), R = 0.001\n",
+      "# (continuous-time ARE, solved in closed form), so the stabilizer directly\n",
+      "# minimizes theta^2 + 0.1*theta_dot^2 + 0.001*u^2 near the top rather than\n",
+      "# using an arbitrarily chosen pole location: u = -(KP*theta + KD*theta_dot).\n",
+      "_KP = 37.016\n",
+      "_KD = 11.166\n",
+      "\n",
+      "\n",
+      "def policy(obs):\n",
+      "    cos_th = obs[0]\n",
+      "    sin_th = obs[1]\n",
+      "    theta_dot = obs[2]\n",
+      "    theta = np.arctan2(sin_th, cos_th)\n",
+      "\n",
+      "    if abs(theta) < _ANGLE_THRESH and abs(theta_dot) < _SPEED_THRESH:\n",
+      "        # Near the top: direct linear stabilization.\n",
+      "        u = -(_KP * theta + _KD * theta_dot)\n",
+      "    else:\n",
+      "        # Bang-bang energy-shaping swing-up (Astrom-Furuta): since\n",
+      "        # dE/dt = B*u*theta_dot, commanding full torque with\n",
+      "        # sign(theta_dot)*sign(E_top - E) drives dE/dt toward the\n",
+      "        # fastest possible convergence of E to the upright energy,\n",
+      "        # without the proportional law's dead zone near turning points.\n",
+      "        energy_error = _E_TOP - (0.5 * theta_dot ** 2 + _K * cos_th)\n",
+      "        td_sign = 1.0 if theta_dot >= 0.0 else -1.0\n",
+      "        e_sign = 1.0 if energy_error >= 0.0 else -1.0\n",
+      "        u = _MAX_TORQUE * td_sign * e_sign\n",
+      "\n",
+      "    u = np.clip(u, -_MAX_TORQUE, _MAX_TORQUE)\n",
+      "    return np.array([u], dtype=np.float64)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((SANDBOX_DIR / \"policy.py\").read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15f90ce4",
+   "metadata": {},
+   "source": [
+    "## Step 3: an oracle\n",
+    "\n",
+    "The oracle uses privileged knowledge: the exact dynamics gymnasium implements,\n",
+    "$\\ddot\\theta = \\frac{3g}{2l}\\sin\\theta + \\frac{3}{ml^2}u$. Pumping energy\n",
+    "toward the value it has standing upright, then catching it with a PD controller,\n",
+    "is the textbook solution. This establishes what a good score looks like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2c8fe6eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:18:16.967137Z",
+     "iopub.status.busy": "2026-07-28T19:18:16.967054Z",
+     "iopub.status.idle": "2026-07-28T19:18:17.007348Z",
+     "shell.execute_reply": "2026-07-28T19:18:17.006980Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "oracle: -184.4 +/- 75.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "G, L, M = 10.0, 1.0, 1.0\n",
+    "E_UPRIGHT = 3 * G / (2 * L)\n",
+    "\n",
+    "\n",
+    "class OracleMethod(Method):\n",
+    "    \"\"\"Energy-shaping swing-up with a PD controller near the top.\"\"\"\n",
+    "\n",
+    "    def __init__(self, gain: float = 0.6, kp: float = 20.0, kd: float = 4.0,\n",
+    "                 switch: float = 0.6) -> None:\n",
+    "        self._gain, self._kp, self._kd, self._switch = gain, kp, kd, switch\n",
+    "\n",
+    "    def train(self, train_seeds: list[int]) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def reset(self, obs: np.ndarray, info: dict) -> None:\n",
+    "        pass\n",
+    "\n",
+    "    def step(self, obs: np.ndarray) -> np.ndarray:\n",
+    "        cos_th, sin_th, thdot = obs\n",
+    "        theta = np.arctan2(sin_th, cos_th)\n",
+    "        if abs(theta) < self._switch:\n",
+    "            torque = -self._kp * theta - self._kd * thdot\n",
+    "        else:\n",
+    "            energy = 0.5 * thdot**2 + E_UPRIGHT * cos_th\n",
+    "            direction = np.sign(thdot) if thdot != 0 else 1.0\n",
+    "            torque = self._gain * (E_UPRIGHT - energy) * direction\n",
+    "        return np.clip([torque], -2.0, 2.0)\n",
+    "\n",
+    "\n",
+    "oracle_result = evaluate(OracleMethod(), EVAL_SEEDS)\n",
+    "print(f\"oracle: {oracle_result[0]:.1f} +/- {oracle_result[1]:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9489c0c3",
+   "metadata": {},
+   "source": [
+    "## Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "11a5eeea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T19:18:17.008630Z",
+     "iopub.status.busy": "2026-07-28T19:18:17.008554Z",
+     "iopub.status.idle": "2026-07-28T19:18:17.010697Z",
+     "shell.execute_reply": "2026-07-28T19:18:17.010284Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "method        mean return      std\n",
+      "random            -1354.5    298.9\n",
+      "pure agent         -184.2     75.5\n",
+      "oracle             -184.4     75.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = {\n",
+    "    \"random\": random_result,\n",
+    "    \"pure agent\": agent_result,\n",
+    "    \"oracle\": oracle_result,\n",
+    "}\n",
+    "print(f\"{'method':<12} {'mean return':>12} {'std':>8}\")\n",
+    "for name, (mean, std) in results.items():\n",
+    "    print(f\"{name:<12} {mean:>12.1f} {std:>8.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "631f5a0b",
+   "metadata": {},
+   "source": [
+    "## What this tells you\n",
+    "\n",
+    "The pure agent tied the oracle: -184.2 against -184.4, well inside the spread\n",
+    "across evaluation seeds. Reading its `policy.py` shows why. It identified the\n",
+    "environment's dynamics from the name, derived the energy-shaping swing-up, and\n",
+    "then went past the hand-written oracle by solving the algebraic Riccati equation\n",
+    "for the balance controller using the actual cost weights from the reward\n",
+    "function, where the oracle uses PD gains chosen by hand.\n",
+    "\n",
+    "That is the outcome the blog warns about, and it is informative rather than\n",
+    "disappointing. On this problem there is no gap between the stupidest sophisticated\n",
+    "method and the best one, so nothing here would justify a new method. The useful\n",
+    "response is to return to Step 1: dynamics the agent cannot name, observations it\n",
+    "cannot interpret, or an interaction budget that rules out writing and testing\n",
+    "code offline. The pure agent baseline is what tells you which of those you need.\n",
+    "\n",
+    "Two properties of `prpl-agent-utils` carried the method above. The sandbox\n",
+    "persists, so `policy.py` from one round is there to be revised in the next. The\n",
+    "conversation persists, so the agent sees the score for the code it just wrote\n",
+    "without being re-told the problem. Both come from constructing the agent once and\n",
+    "holding it as a member of the method."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/prpl-agent-utils/pyproject.toml
+++ b/prpl-agent-utils/pyproject.toml
@@ -11,6 +11,10 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]
+examples = [
+    "gymnasium[classic-control]",
+    "jupyter",
+]
 develop = [
     "black",
     "docformatter",


### PR DESCRIPTION
Adds an `examples/` directory with a notebook that works through the recipe in [*Now what? A recipe for after the problem setting*](https://tomsilver.github.io/blog/2026/now-whats-your-solution/) on gymnasium's `Pendulum-v1`:

1. **A concrete problem** — the `Method` interface (`train` / `reset` / `step`) and an evaluation loop.
2. **The stupidest approach** — uniformly random torques.
3. **The pure agent** — a `PureAgentMethod` built on `ClaudeCodeAgent`.
4. **An oracle** — energy-shaping swing-up with a PD catch, written with knowledge of the dynamics.

The notebook is committed with its outputs from a real cold-start run.

## The one deviation from the post

The post's `PureAgentMethod` queries the agent inside `step()`. That is not workable here: `Pendulum-v1` runs at 20 Hz, so one episode is 200 actions and one evaluation is 4000. No agent closes that loop at the necessary rate or price. This is one of the limitations the post itself points to when arguing where research remains competitive, so the notebook states the reason rather than papering over it.

Instead the pure agent writes the policy rather than being the policy. During `train`, it authors `policy.py` in its sandbox; the host evaluates that file on the training seeds and hands back the score; the agent revises. `step` calls the function it wrote. This exercises both persistence properties directly: the sandbox keeps `policy.py` between rounds, and the conversation keeps the context so the agent sees the score for the code it just wrote without being re-told the problem.

## Result

| method | mean return | std |
| --- | ---: | ---: |
| random | -1354.5 | 298.9 |
| pure agent | -184.2 | 75.5 |
| oracle | -184.4 | 75.3 |

The pure agent tied the oracle. It identified the dynamics from the environment name, derived the energy-shaping swing-up, and then improved on the hand-written oracle by solving the algebraic Riccati equation for the balance controller using the actual cost weights from the reward function, where the oracle uses PD gains chosen by hand. That is the outcome the post warns about: no gap between the naive sophisticated method and the best one means nothing here would justify a new method, and the useful response is to go back to Step 1.

## Notes

- Loading `policy.py` runs agent-written code in the notebook process. The sandbox protects the authoring step, not the evaluation step; the notebook says so, and points at evaluating inside the container as the way to close that gap.
- Adds an `examples` extra (`gymnasium[classic-control]`, `jupyter`). Nothing in CI executes the notebook, which needs API access and Docker.
- The generated `examples/pendulum_sandbox/` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
