### PR TITLE
prpl-kinematics: make ompl an optional dependency

### DIFF
--- a/prpl-kinematics/README.md
+++ b/prpl-kinematics/README.md
@@ -26,6 +26,19 @@ From the monorepo root, with [uv](https://docs.astral.sh/uv/):
 uv pip install -e "./prpl-kinematics[develop]"
 ```
 
+### Optional extras
+
+`OMPLPlanner` and `seed_ompl` need the `planning` extra, because `ompl` publishes
+wheels for far fewer platforms than everything else here (none for Windows, and
+macOS 15 or newer only):
+
+```
+uv pip install -e "./prpl-kinematics[planning]"
+```
+
+Without it, importing those two names raises an `ImportError` saying so; everything
+else, including `BiRRTPlanner`, works untouched.
+
 ## Development
 
 ```

--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -21,13 +21,20 @@ dependencies = [
    "pybullet-arm64>=3.2.8",
    "imageio>=2.30",
    "eaik>=1.2.1",
-   "ompl>=2.0.0",
 ]
 
 [project.optional-dependencies]
+# OMPL-backed motion planning (OMPLPlanner, seed_ompl). Kept optional because ompl
+# publishes no sdist and wheels for far fewer platforms than everything else here --
+# none for Windows, and macOS 15 or newer only -- so requiring it would narrow the
+# whole package to those platforms. BiRRTPlanner needs nothing extra.
+planning = ["ompl>=2.0.0"]
 # Optional analytic IK backend (ssik); requires numpy>=2. See ik/ssik.py.
 ssik = ["ssik[urdf]>=1.2"]
 develop = [
+    # Pulled in so that the OMPL tests still run in CI and in a dev install, even
+    # though ompl is optional for users.
+    "ompl>=2.0.0",
     "black",
     "docformatter",
     "isort",

--- a/prpl-kinematics/src/prpl_kinematics/planning/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/planning/__init__.py
@@ -1,11 +1,16 @@
 """Motion planning: configuration spaces over a tree and planners over them."""
 
+import importlib
+from typing import TYPE_CHECKING, Any
+
 from prpl_kinematics.planning.birrt import BiRRTPlanner
 from prpl_kinematics.planning.configuration_space import ConfigurationSpace
 from prpl_kinematics.planning.joint_space import JointSpace
 from prpl_kinematics.planning.motion_planner import MotionPlanner
-from prpl_kinematics.planning.ompl_planner import OMPLPlanner, seed_ompl
 from prpl_kinematics.planning.se2_space import SE2Space
+
+if TYPE_CHECKING:
+    from prpl_kinematics.planning.ompl_planner import OMPLPlanner, seed_ompl
 
 __all__ = [
     "BiRRTPlanner",
@@ -16,3 +21,23 @@ __all__ = [
     "SE2Space",
     "seed_ompl",
 ]
+
+# The OMPL-backed exports resolve on first attribute access so that importing anything
+# under this package does not require ompl. ompl publishes wheels for far fewer
+# platforms than the rest of the dependencies -- none for Windows, and macOS 15 or
+# newer only -- and eagerly importing it here would impose that on the whole package,
+# since every submodule import runs this file. BiRRTPlanner requires nothing extra.
+_OMPL_EXPORTS = frozenset({"OMPLPlanner", "seed_ompl"})
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _OMPL_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        module = importlib.import_module("prpl_kinematics.planning.ompl_planner")
+    except ImportError as exc:
+        raise ImportError(
+            f"{name} requires ompl, which is an optional dependency. Install it with: "
+            'pip install "prpl_kinematics[planning]"'
+        ) from exc
+    return getattr(module, name)

--- a/prpl-kinematics/tests/planning/test_ompl_planner.py
+++ b/prpl-kinematics/tests/planning/test_ompl_planner.py
@@ -6,16 +6,15 @@ from spatialmath import SE3
 
 from prpl_kinematics.collision import PyBulletCollisionChecker
 from prpl_kinematics.geometry.shapes import BoxShape
-from prpl_kinematics.planning import (
-    BiRRTPlanner,
-    JointSpace,
-    MotionPlanner,
-    OMPLPlanner,
-    ompl_planner,
-    seed_ompl,
-)
+from prpl_kinematics.planning import BiRRTPlanner, JointSpace, MotionPlanner
 from prpl_kinematics.tree.joints import FixedJoint, PrismaticJoint
 from prpl_kinematics.tree.kinematic_tree import Edge, KinematicTree, Node
+
+# ompl is an optional dependency, so skip this module rather than fail collection when
+# it is absent.
+ompl_planner = pytest.importorskip("prpl_kinematics.planning.ompl_planner")
+OMPLPlanner = ompl_planner.OMPLPlanner
+seed_ompl = ompl_planner.seed_ompl
 
 
 def _gantry_tree() -> KinematicTree:


### PR DESCRIPTION
Makes `ompl` an optional dependency. Split out of #524, which is the packaging work for the PyPI release.

## Why

`planning/ompl_planner.py` imports `ompl` at module scope, and `planning/__init__.py` re-exports from it. Importing *any* submodule runs the package `__init__`, so `from prpl_kinematics.planning.joint_space import JointSpace` pulls in `ompl` — and that path is reached by `robots/` and `manipulation.py`. In practice `ompl` was a hard import-time dependency of nearly the whole package.

`ompl` 2.0.1 publishes no sdist and a thin wheel matrix:

| Platform | ompl wheel |
|---|---|
| manylinux x86_64 / aarch64 | ✅ |
| macOS 15+ arm64 / x86_64 | ✅ |
| macOS 13, 14 | ❌ |
| Windows | ❌ |

So `prpl_kinematics` inherited that matrix entirely. That is tolerable for a monorepo-internal package and not for one on PyPI — kindergarden, which is about to grow a `[prpl-kinematics]` extra, advertises macOS 13–15 and Windows 10.

## What

`OMPLPlanner` and `seed_ompl` now resolve through a module `__getattr__`, and `ompl` moves to a `planning` extra. Nothing else changes; `BiRRTPlanner` was already pure Python and needs nothing extra.

Without `ompl` installed:

```
>>> from prpl_kinematics.planning import OMPLPlanner
ImportError: OMPLPlanner requires ompl, which is an optional dependency.
Install it with: pip install "prpl_kinematics[planning]"
```

The `develop` extra still installs `ompl`, so CI keeps exercising the OMPL tests, and `tests/planning/test_ompl_planner.py` skips instead of failing collection when it is absent.

## Verification

`./run_ci_checks.sh` passes (90 passed, 7 skipped) — the same counts as before, so the OMPL tests still run.

With `ompl` blocked from importing:

```
package imports without ompl: OK
vega loads without ompl: vega-1u
OMPLPlanner -> OMPLPlanner requires ompl, which is an optional dependency. ...
seed_ompl -> seed_ompl requires ompl, which is an optional dependency. ...
```

With `ompl` present, `OMPLPlanner` and `seed_ompl` import exactly as before, and an unknown attribute still raises `AttributeError` rather than `ImportError`.

## Note

Branched from `main`, so it does not include #524. The two touch the same README section and will need a trivial rebase depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
