### PR TITLE
prpl-kinematics: consolidate the README extras section

### DIFF
--- a/prpl-kinematics/README.md
+++ b/prpl-kinematics/README.md
@@ -31,32 +31,25 @@ pip install prpl_kinematics
 IKFast solvers are compiled from the bundled C++ sources on first use, which needs
 a C++ toolchain and LAPACK/BLAS. The other IK backends have no such requirement.
 
-The optional `ssik` extra adds the SSIK analytic IK backend:
+### Optional extras
 
 ```
-pip install "prpl_kinematics[ssik]"
+pip install "prpl_kinematics[planning]"   # OMPLPlanner and seed_ompl
+pip install "prpl_kinematics[ssik]"       # the SSIK analytic IK backend
 ```
 
-For development, from the monorepo root, with [uv](https://docs.astral.sh/uv/):
+`ompl` publishes wheels for far fewer platforms than everything else here (none for
+Windows, and macOS 15 or newer only), so it stays out of the base install. Importing
+`OMPLPlanner` or `seed_ompl` without it raises an `ImportError` saying so; everything
+else, including `BiRRTPlanner`, works untouched.
+
+## Development
+
+From the monorepo root, with [uv](https://docs.astral.sh/uv/):
 
 ```
 uv pip install -e "./prpl-kinematics[develop]"
 ```
-
-### Optional extras
-
-`OMPLPlanner` and `seed_ompl` need the `planning` extra, because `ompl` publishes
-wheels for far fewer platforms than everything else here (none for Windows, and
-macOS 15 or newer only):
-
-```
-uv pip install -e "./prpl-kinematics[planning]"
-```
-
-Without it, importing those two names raises an `ImportError` saying so; everything
-else, including `BiRRTPlanner`, works untouched.
-
-## Development
 
 ```
 ./run_ci_checks.sh   # autoformat, mypy, pylint, pytest


### PR DESCRIPTION
Small README cleanup, an artifact of merging #524 and #525.

Both touched the Installation section, and the merge left the two extras documented in separate places:

- `ssik` above the development instructions
- `planning` below them, under an `### Optional extras` heading that did not mention `ssik`

The `planning` example also used `uv pip install -e "./prpl-kinematics[planning]"`, the monorepo-relative editable form, which nobody reading this on PyPI can run.

Both extras now sit in one section above development, using the `pip install "prpl_kinematics[...]"` form. Documentation only, no code changes.

Verified on merged `main` before publishing: `./run_ci_checks.sh` passes (90 passed, 7 skipped), and the built wheel installs into a clean venv both without the extra and with it:

```
ompl NOT installed (correct)
vega: vega-1u
FK: [ 0.715 -0.397  0.675]
panda: panda
BiRRTPlanner: ok
OMPLPlanner -> OMPLPlanner requires ompl, which is an optional dependency. Install it with: pip install "prpl_kinematics[planning]"

# then with [planning]
with [planning] extra: OMPLPlanner + seed_ompl import OK
```

Wheel audit on merged `main`: 0 build artifacts, all 79 asset files present, `License-Expression: MIT AND Apache-2.0`, and `ompl` confined to the `planning` and `develop` extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
