### PR TITLE
prpl-llm-utils: publish 0.1.0 to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ export UV_PUBLISH_TOKEN=pypi-YOUR_TOKEN_HERE
 | tomsgeoms2d | `tomsgeoms2d` | `toms-geoms-2d/` |
 | pybullet_helpers | `pybullet_helpers` | `pybullet-helpers/` |
 | bilevel_planning | `bilevel_planning` | `bilevel-planning/` |
+| prpl_kinematics | `prpl_kinematics` | `prpl-kinematics/` |
+| prpl_llm_utils | `prpl_llm_utils` | `prpl-llm-utils/` |
 
 ## Troubleshooting
 

--- a/prpl-llm-utils/pyproject.toml
+++ b/prpl-llm-utils/pyproject.toml
@@ -7,12 +7,22 @@ name = "prpl_llm_utils"
 version = "0.1.0"
 description = "LLM utils from the Princeton Robot Planning and Learning group."
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
+classifiers = [
+   "Programming Language :: Python :: 3",
+   "Operating System :: OS Independent",
+]
 dependencies = [
    "ImageHash",
    "openai",
    "google-genai",
+   "Pillow",
 ]
+
+[project.urls]
+Repository = "https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono"
 
 [project.optional-dependencies]
 develop = [


### PR DESCRIPTION
Implements option 1 of #527: publish `prpl_llm_utils` to PyPI so downstream repos stop consuming it as a git dependency, which costs a 2GB monorepo fetch per install (~19 minutes in kinder-baselines CI).

## What's in this PR

- `prpl-llm-utils/pyproject.toml`: release metadata following the prpl-kinematics pattern from #524 — SPDX license expression (`MIT`) with `license-files`, classifiers, and a repository URL. Also declares `Pillow`, which `models.py` and `structs.py` import directly but which previously arrived only transitively via ImageHash.
- `README.md`: the "Packages currently on PyPI" table gains `prpl_llm_utils` and `prpl_kinematics` (the latter was missing since #524).

## Already done outside this PR

Version **0.1.0 is published**: https://pypi.org/project/prpl-llm-utils/

Verification:
- Package CI checks pass (mypy, pylint, 25 tests).
- The wheel contains only the 8 source files, `py.typed`, and LICENSE — no `__pycache__` or egg-info.
- Installed from PyPI into a clean venv and imported every module successfully.

## Follow-up (downstream)

`kinder-baselines`' `kinder-vlm-planning` should switch its dependency from the git URL to `prpl_llm_utils>=0.1.0`, which resolves the CI regression described in #527. Options 2 and 3 of the issue (publishing the other three packages, reducing clone weight) remain open.

Closes #527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
