### PR TITLE
vega: make the home posture left-right symmetric

### DIFF
--- a/prpl-kinematics/src/prpl_kinematics/robots/vega.py
+++ b/prpl-kinematics/src/prpl_kinematics/robots/vega.py
@@ -29,13 +29,20 @@ def _gripper_joints(side: str) -> list[str]:
 
 
 # A natural, manipulation-ready home (per-arm j1..j7): forearms down-forward with
-# the grippers angled downward at chest height. Each arm was optimized to minimize
-# static gravity torque (so the arms nearly hold themselves) and stay well inside
-# its joint limits, while pointing the gripper down-forward -- a ready posture from
-# which a tabletop grasp is a short, smooth reach. The two arms are optimized
-# independently (Vega's arms are not a simple sign-flip mirror of each other).
+# the grippers angled downward at chest height, a ready posture from which a
+# tabletop grasp is a short, smooth reach. The left posture was optimized to
+# reduce static gravity torque while staying well inside its joint limits; the
+# right home is its mirror, so the robot rests symmetrically. Between the two
+# candidate postures, the left one holds gravity with the lower peak joint torque
+# (about 15 vs 21 N*m in the URDF model, 2.9 vs 4.0 A on hardware), which matters
+# for a long-lived parked pose; even so, the shoulder joints work noticeably to
+# hold it. Vega's arms are not exact mechanical mirrors, so the mirrored posture's
+# gravity load and the symmetry of the gripper poses (~2.5 cm residual) are
+# approximate. See prpl-mono issue #529 for the measurements behind this choice.
 _LEFT_ARM_HOME = [1.809, 0.636, -0.244, -2.04, 0.841, 0.129, -0.833]
-_RIGHT_ARM_HOME = [-1.043, -1.278, -0.793, -1.778, -0.148, -0.396, 0.417]
+# The left-to-right mirror map (from the URDF joint limits) flips the sign of
+# every joint except j4, the elbow, whose range is identical on both arms.
+_RIGHT_ARM_HOME = [q if i == 3 else -q for i, q in enumerate(_LEFT_ARM_HOME)]
 # Rest the parallel jaws open (each finger is revolute over [0, 0.785]); like the
 # Panda's open home, this is the ready-to-grasp pose, and a grasp closes on the
 # object rather than starting clamped shut through it.

--- a/prpl-kinematics/tests/robots/test_vega.py
+++ b/prpl-kinematics/tests/robots/test_vega.py
@@ -72,6 +72,29 @@ def test_vega_left_arm_solves_top_down_grasp():
     assert np.linalg.norm(np.asarray(reached.t) - np.asarray(target.t)) < 1e-2
 
 
+def test_vega_home_is_mirror_symmetric():
+    """At home the two gripper frames sit near-mirrored about the y=0 plane.
+
+    The right arm home is defined as the mirror of the left. Vega's arms are not exact
+    mechanical mirrors, so the residual is a few centimeters, not zero.
+    """
+    robot = make_vega()
+    left = np.asarray(robot.tree.forward_kinematics("L_ee", robot.home).t)
+    right = np.asarray(robot.tree.forward_kinematics("R_ee", robot.home).t)
+    assert np.abs(left - right * np.array([1.0, -1.0, 1.0])).max() < 0.04
+
+
+def test_vega_home_is_within_joint_limits():
+    """Every home joint value sits strictly inside its URDF limits."""
+    robot = make_vega()
+    for name in robot.tree.actuated_joint_names():
+        joint = robot.tree.joint(name)
+        for value, low, high in zip(
+            robot.home[name], joint.lower_limits, joint.upper_limits
+        ):
+            assert low <= value <= high, f"{name}: {value} outside [{low}, {high}]"
+
+
 def test_vega_home_is_self_collision_free(physics_client_id):
     """Home is collision-free once the robot's intrinsic ACM is allowed."""
     robot = make_vega()


### PR DESCRIPTION
Fixes #529 by symmetrizing the Vega home posture — in the direction the issue's follow-up comment recommends, not the direction originally proposed.

## Which direction won and why

The issue proposed `left := mirror(right)`. The hardware data in the comment showed the current left posture holds gravity with the lower peak joint current (2.9 A vs 4.0 A), so both directions were evaluated as requested; `right := mirror(left)` wins:

| | peak gravity torque (URDF model) | peak current (hardware, from #529) |
|---|---|---|
| A: `left := mirror(right)` | **21.7 N·m** (j1) | ~4.0 A inherited |
| B: `right := mirror(left)` (this PR) | **15.0 N·m** (j1) | ~2.9 A inherited |

Torques are static gravity torques from PyBullet inverse dynamics on `vega_1u_gripper.urdf` (massless dummy frames like `L_ee`/`R_ee` given negligible inertials rather than PyBullet's default 1 kg). The model independently agrees with the hardware ranking, and mirroring transfers a posture's torque profile to the other arm within ~3%, so the mirrored right arm should draw close to what the left does today.

## The change

- `_RIGHT_ARM_HOME` is now computed from `_LEFT_ARM_HOME` via the mirror map (sign flip on every joint except j4, the elbow, whose range is identical on both arms), so the mirror relationship cannot drift. New value: `[-1.809, -0.636, 0.244, -2.04, -0.841, -0.129, 0.833]`.
- The comment block no longer claims the arms "nearly hold themselves" (per the issue comment — the posture takes real shoulder torque) and records the selection criterion.
- New tests: FK-level mirror symmetry of the two gripper frames at home (catches a wrong mirror map, which a sign-flip re-derivation would not), and home-inside-joint-limits for every actuated joint.

## Validation (per the checklist in #529)

- Mirrored pose inside the right arm's URDF limits, >0.05 rad margin on every joint.
- Collision-free at home; cross-arm and gripper-vs-body clearances ≥ 30 cm.
- `discover_allowed_pairs` at the new home: identical set (+0/−0 pairs).
- FK mirror residual ~2.5 cm, matching the issue's measurement (the arms are not exact mechanical mirrors).
- Full package CI passes (mypy, pylint, 92 tests).

## Follow-ups for consumers (from the issue)

- Anyone parking the real robot at model home (prpl-dexmate remote-mode planning start) needs to re-park the **right** arm after upgrading — the left is unchanged, which is convenient since the left was the arm already measured at 2.9 A.
- Worth measuring the right arm's resting currents at the new pose on hardware; the model predicts close to the left arm's profile, but the mirror is approximate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
