### PR TITLE
prpl-kinematics: release 0.0.2 to PyPI

### DIFF
--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prpl_kinematics"
-version = "0.0.1"
+version = "0.0.2"
 description = "Kinematics-only robot modeling, IK, motion planning, and manipulation primitives built on a general KinematicTree."
 readme = "README.md"
 # PEP 639 form. The bundled IKFast sources under third_party/ are Apache-2.0; see


### PR DESCRIPTION
Version bump for the `prpl_kinematics` 0.0.2 release, which is already live: https://pypi.org/project/prpl-kinematics/0.0.2/

The release picks up the symmetric Vega home posture from #530 (fixes #529): `_RIGHT_ARM_HOME` is now the mirror of `_LEFT_ARM_HOME`.

Verification:
- Wheel contains no compiled IKFast build products (the #524 failure mode) — 140 files, all git-tracked sources and assets.
- Installed the wheel into a clean venv before publishing: `make_vega()` assembles and the right home matches the mirror map.
- Installed `prpl_kinematics==0.0.2` from PyPI with `--no-cache` after publishing and re-checked the new right home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
