### PR TITLE
prpl-kinematics: release 0.0.3 to PyPI

### DIFF
--- a/prpl-kinematics/pyproject.toml
+++ b/prpl-kinematics/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prpl_kinematics"
-version = "0.0.2"
+version = "0.0.3"
 description = "Kinematics-only robot modeling, IK, motion planning, and manipulation primitives built on a general KinematicTree."
 readme = "README.md"
 # PEP 639 form. The bundled IKFast sources under third_party/ are Apache-2.0; see

--- a/prpl-kinematics/src/prpl_kinematics/__init__.py
+++ b/prpl-kinematics/src/prpl_kinematics/__init__.py
@@ -6,4 +6,6 @@ is the single source of truth for forward kinematics, and physics engines such
 as PyBullet are used only as pluggable collision/render backends.
 """
 
-__version__ = "0.0.1"
+from importlib.metadata import version as _version
+
+__version__ = _version("prpl-kinematics")


### PR DESCRIPTION
Version bump for the `prpl_kinematics` 0.0.3 release, which is already live: https://pypi.org/project/prpl-kinematics/0.0.3/

The release picks up the Dexgripper S sync from #533 (#532): new dexs gripper meshes and remounted gripper base in `vega_1u_gripper.urdf`, with the stale dexd meshes removed.

Also fixes `prpl_kinematics.__version__`, which was hardcoded to "0.0.1" and never bumped with the releases; it now derives from the installed package metadata so it cannot drift again.

Verification:
- Wheel contains no compiled IKFast build products (the #524 failure mode) — 140 files, every one a git-tracked source or asset (checked against `git ls-files`).
- Installed the wheel into a clean venv before publishing: `make_vega()` assembles, the bundled URDF references only `dexs_gripper`, and `__version__` reports 0.0.3.
- Installed `prpl_kinematics==0.0.3` from PyPI with `--no-cache` after publishing and re-checked all of the above, including that the dexs visual meshes ship and the dexd ones are gone.
- Full local CI passes: mypy, pylint, 92 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
