### PR TITLE
Bound IK sampling attempts in run_smooth_motion_planning_to_pose

### DIFF
--- a/pybullet-helpers/src/pybullet_helpers/motion_planning.py
+++ b/pybullet-helpers/src/pybullet_helpers/motion_planning.py
@@ -191,6 +191,7 @@ def run_smooth_motion_planning_to_pose(
     base_link_to_held_obj: Pose | None = None,
     max_time: float = np.inf,
     max_candidate_plans: int | None = None,
+    ik_max_time_per_candidate: float = 1.0,
     joint_geometric_scalar: float = 0.9,
     birrt_extend_num_interp: int = 10,
     birrt_num_attempts: int = 10,
@@ -236,6 +237,10 @@ def run_smooth_motion_planning_to_pose(
     rng = np.random.default_rng(seed)
 
     while time.perf_counter() - start_time < max_time and num_iters < iter_ub:
+        # Count attempts rather than successes: with an unreachable target pose no
+        # plan is ever found, and counting successes would loop forever whenever
+        # max_time is infinite.
+        num_iters += 1
         # Sample a target pose.
         target_pose = target_pose_sampler()
         # Transform to end effector space.
@@ -244,12 +249,16 @@ def run_smooth_motion_planning_to_pose(
         )
         # Sample a collision-free joint target. If none exist, we'll just
         # go back to sampling a different target pose.
+        # Bound each IK sampling attempt: with an unreachable target the sampler
+        # yields nothing, and an unbounded budget would spin forever regardless of
+        # max_candidate_plans (which limits yielded candidates, not attempts).
+        remaining_time = max_time - (time.perf_counter() - start_time)
         for target_joint_positions in sample_collision_free_inverse_kinematics(
             robot,
             end_effector_pose,
             collision_ids,
             rng,
-            max_time=max_time,
+            max_time=min(ik_max_time_per_candidate, remaining_time),
             max_candidates=1,
         ):
             # Try motion planning to the target.
@@ -273,7 +282,6 @@ def run_smooth_motion_planning_to_pose(
             )
             # Score the motion plan.
             if motion_plan is not None:
-                num_iters += 1
                 score = _score_motion_plan(motion_plan)
                 if score < best_motion_plan_score:
                     best_motion_plan = motion_plan

--- a/pybullet-helpers/tests/test_motion_planning.py
+++ b/pybullet-helpers/tests/test_motion_planning.py
@@ -19,6 +19,7 @@ from pybullet_helpers.motion_planning import (
     run_base_motion_planning,
     run_motion_planning,
     run_single_arm_mobile_base_motion_planning,
+    run_smooth_motion_planning_to_pose,
     select_shortest_motion_plan,
     smoothly_follow_end_effector_path,
 )
@@ -623,3 +624,44 @@ def test_base_motion_planning_to_goal():
     # for base_pose in plan:
     #     robot.set_base(base_pose)
     #     time.sleep(0.5)
+
+
+def test_run_smooth_motion_planning_to_pose_unreachable_target(physics_client_id):
+    """An unreachable target fails in bounded time instead of hanging.
+
+    With the default max_time (inf), the per-candidate IK budget and
+    attempt-counting must terminate the search; previously an unreachable
+    target spun the IK sampler indefinitely.
+    """
+    import time as _time
+
+    robot = KinovaGen3RobotiqGripperPyBulletRobot(physics_client_id)
+    unreachable_pose = Pose((10.0, 0.0, 0.0))
+    start = _time.perf_counter()
+    plan = run_smooth_motion_planning_to_pose(
+        unreachable_pose,
+        robot,
+        collision_ids=set(),
+        end_effector_frame_to_plan_frame=Pose.identity(),
+        seed=123,
+        max_candidate_plans=3,
+    )
+    elapsed = _time.perf_counter() - start
+    assert plan is None
+    # Three attempts at <= 1 s of IK sampling each, plus generous slack.
+    assert elapsed < 15.0
+
+
+def test_run_smooth_motion_planning_to_pose_reachable_target(physics_client_id):
+    """The per-candidate IK budget does not break feasible queries."""
+    robot = KinovaGen3RobotiqGripperPyBulletRobot(physics_client_id)
+    reachable_pose = robot.get_end_effector_pose()
+    plan = run_smooth_motion_planning_to_pose(
+        reachable_pose,
+        robot,
+        collision_ids=set(),
+        end_effector_frame_to_plan_frame=Pose.identity(),
+        seed=123,
+        max_candidate_plans=3,
+    )
+    assert plan is not None

--- a/pybullet-helpers/tests/test_motion_planning.py
+++ b/pybullet-helpers/tests/test_motion_planning.py
@@ -1,5 +1,6 @@
 """Tests for PyBullet motion planning."""
 
+import time
 from functools import partial
 
 import numpy as np
@@ -633,11 +634,9 @@ def test_run_smooth_motion_planning_to_pose_unreachable_target(physics_client_id
     attempt-counting must terminate the search; previously an unreachable
     target spun the IK sampler indefinitely.
     """
-    import time as _time
-
     robot = KinovaGen3RobotiqGripperPyBulletRobot(physics_client_id)
     unreachable_pose = Pose((10.0, 0.0, 0.0))
-    start = _time.perf_counter()
+    start = time.perf_counter()
     plan = run_smooth_motion_planning_to_pose(
         unreachable_pose,
         robot,
@@ -646,7 +645,7 @@ def test_run_smooth_motion_planning_to_pose_unreachable_target(physics_client_id
         seed=123,
         max_candidate_plans=3,
     )
-    elapsed = _time.perf_counter() - start
+    elapsed = time.perf_counter() - start
     assert plan is None
     # Three attempts at <= 1 s of IK sampling each, plus generous slack.
     assert elapsed < 15.0


### PR DESCRIPTION
## Summary

Bound the IK sampling inside `run_smooth_motion_planning_to_pose` so an unreachable target pose fails in bounded time instead of livelocking:

- each inner `sample_collision_free_inverse_kinematics` call now gets a finite budget (`ik_max_time_per_candidate`, default 1.0 s, further capped by the remaining outer budget) instead of inheriting the outer `max_time` verbatim — with the default `max_time=np.inf` and an unreachable target, the inner sampler otherwise iterates the unbounded IKFast free-joint generator for ~1e9 attempts (`max_candidates` limits *yielded* candidates, not attempts); and
- `max_candidate_plans` counts attempts rather than successes — with an unreachable pose no plan is ever found, so success-counting looped forever even with bounded inner calls.

## Motivation

Observed downstream as a deterministic planning livelock: kinder bilevel planning on PrplLab3D (under kindergarden's newly enforced action bounds, which made a skill's pre-grasp IK target unreachable) spun for 28.5 CPU-minutes against a 60 s planning timeout, hot frame confirmed by stack dump in `pybullet_helpers/ikfast/utils.py::free_joints_generator`. The outer timeout can never fire because it is only checked between iterations, and the iteration never completes. With this change the same episode plans successfully in seconds — the planner discards the unreachable sample and finds a reachable one.

## Choice of default

The 1.0 s per-candidate budget is measured, not guessed: across real Kinematic3D planning workloads (Shelf3D/PrplLab3D/Transport3D, 16 episodes, instrumented sampler), feasible IK calls yield in p50 1.7 ms / p99 3.2 ms / max 3.3 ms — ~300× headroom — and clearly-unreachable poses fail in ~0 ms. The parameter is caller-tunable for harder IK problems.

## Test plan

Adds the first test coverage for `run_smooth_motion_planning_to_pose`:
- unreachable target → returns `None` in bounded time (verified to hang >60 s on the unpatched code);
- reachable target → still finds a plan under the per-candidate budget.

Both pass (4.6 s / 1.3 s); existing motion-planning tests unaffected.
