### PR TITLE
Fix ConcatTrajectory failure at t == duration on Python 3.12+

### DIFF
--- a/prpl-utils/src/prpl_utils/trajopt/trajectory.py
+++ b/prpl-utils/src/prpl_utils/trajopt/trajectory.py
@@ -81,7 +81,13 @@ class _ConcatTrajectory(Trajectory):
                 assert time >= start_time
                 return traj(time - start_time)
             start_time = end_time
-        raise ValueError(f"Time {time} exceeds duration {self.duration}")
+        if not self.trajs:
+            raise ValueError(f"Time {time} exceeds duration {self.duration}")
+        # Compensated summation in self.duration (CPython 3.12+ sum()) can exceed
+        # the naive fold above by one ULP, so a time equal to the total duration
+        # falls through the loop. Return the end of the final segment instead.
+        last_traj = self.trajs[-1]
+        return last_traj(last_traj.duration)
 
     def get_sub_trajectory(self, start_time: float, end_time: float) -> Trajectory:
         new_trajs: list[Trajectory] = []

--- a/prpl-utils/tests/test_trajopt_trajectory_boundary.py
+++ b/prpl-utils/tests/test_trajopt_trajectory_boundary.py
@@ -1,0 +1,25 @@
+"""Regression test: _ConcatTrajectory must be callable at exactly t == duration.
+
+See pybullet-helpers/tests/test_trajectory_boundary.py for the mechanism
+(CPython 3.12+ compensated sum() vs the naive segment fold, one-ULP mismatch).
+"""
+
+import numpy as np
+
+from prpl_utils.trajopt.trajectory import _ConcatTrajectory, _TrajectorySegment
+
+DURATIONS = [
+    0.34475140273571014, 0.1414589475579653, 0.14145881566227003,
+    0.14145866239931015, 0.1414591006327488, 0.14145870251896164,
+    0.14145887962159054, 0.1414587834763923, 0.1414589024844985,
+    0.14145877032865228, 0.14145886964314117, 1.0386589765548706,
+    0.19324145689126673,
+]
+
+
+def test_concat_trajectory_callable_at_total_duration() -> None:
+    """A query at exactly the total duration returns the final endpoint."""
+    segs = [_TrajectorySegment(np.zeros(2), np.ones(2), d) for d in DURATIONS]
+    traj = _ConcatTrajectory(segs)
+    out = traj(traj.duration)
+    assert np.allclose(np.asarray(out), np.ones(2))

--- a/pybullet-helpers/src/pybullet_helpers/trajectory.py
+++ b/pybullet-helpers/src/pybullet_helpers/trajectory.py
@@ -127,7 +127,13 @@ class ConcatTrajectory(Trajectory[TrajectoryPoint]):
                 assert time >= start_time
                 return traj(time - start_time)
             start_time = end_time
-        raise ValueError(f"Time {time} exceeds duration {self.duration}")
+        if not self.trajs:
+            raise ValueError(f"Time {time} exceeds duration {self.duration}")
+        # Compensated summation in self.duration (CPython 3.12+ sum()) can exceed
+        # the naive fold above by one ULP, so a time equal to the total duration
+        # falls through the loop. Return the end of the final segment instead.
+        last_traj = self.trajs[-1]
+        return last_traj(last_traj.duration)
 
     def get_sub_trajectory(
         self, start_time: float, end_time: float

--- a/pybullet-helpers/tests/test_trajectory_boundary.py
+++ b/pybullet-helpers/tests/test_trajectory_boundary.py
@@ -1,0 +1,38 @@
+"""Regression test: ConcatTrajectory must be callable at exactly t == duration.
+
+On CPython 3.12+, built-in sum() uses Neumaier-compensated summation for
+floats, so the cached `duration` (computed with sum()) can exceed the naive
+running fold used when walking the segments by one ULP. A query at the total
+duration then falls through the walk and raises "Time X exceeds duration X"
+with both numbers printing identically. The durations below are captured from
+a real failing planning episode and reproduce the mismatch deterministically.
+"""
+
+import numpy as np
+
+from pybullet_helpers.trajectory import ConcatTrajectory, TrajectorySegment
+
+DURATIONS = [
+    0.34475140273571014, 0.1414589475579653, 0.14145881566227003,
+    0.14145866239931015, 0.1414591006327488, 0.14145870251896164,
+    0.14145887962159054, 0.1414587834763923, 0.1414589024844985,
+    0.14145877032865228, 0.14145886964314117, 1.0386589765548706,
+    0.19324145689126673,
+]
+
+
+def test_concat_trajectory_callable_at_total_duration() -> None:
+    """A query at exactly the total duration returns the final endpoint."""
+    segs = [
+        TrajectorySegment(
+            np.zeros(2),
+            np.ones(2),
+            d,
+            lambda a, b, t: a + t * (b - a),
+            lambda a, b: float(np.linalg.norm(b - a)),
+        )
+        for d in DURATIONS
+    ]
+    traj = ConcatTrajectory(segs)
+    out = traj(traj.duration)
+    assert np.allclose(np.asarray(out), np.ones(2))


### PR DESCRIPTION
## Summary

Make `ConcatTrajectory` callable at exactly `t == duration` on Python 3.12+ (identical fix in `pybullet_helpers/trajectory.py` and `prpl_utils/trajopt/trajectory.py`): when the segment walk falls through with a non-empty segment list, return the end of the final segment instead of raising. Adds a regression test per package built from segment durations captured from a real failing episode.

## The bug

`ConcatTrajectory.__call__` clips the query time to the cached `duration` — computed with built-in `sum()` — and then walks the segments with a naive running fold:

```python
time = np.clip(time, 0, self.duration)        # clipped to sum(durations)
for traj in self.trajs:
    end_time = start_time + traj.duration     # naive left-to-right fold
    if time <= end_time: ...
raise ValueError(f"Time {time} exceeds duration {self.duration}")
```

On CPython ≤3.11 `sum()` *is* that same fold, so the two totals are bit-identical and the raise is unreachable. **On CPython 3.12+, `sum()` of floats uses Neumaier-compensated summation**, which can exceed the naive fold by one ULP. A query at exactly the total duration then falls through every `time <= end_time` check and raises — with the message printing two *identical* numbers (`Time 2.991240270507378 exceeds duration 2.991240270507378`), because the mismatch is against the fold, which the message never shows.

Repro (Python 3.12, 13 real segment durations from a failing episode):

```
sum(durations)  = 2.991240270507378
naive fold      = 2.9912402705073777   # sum() != fold → boundary query raises
```

## Why this matters despite looking minor

The numerical error is one ULP; nothing about the trajectory is meaningfully wrong. But evaluating a trajectory **at its own endpoint is the most common query in the stack** ("give me the final configuration"), so the boundary is hit by design, not by accident — and the failure mode is not a slightly-off number, it's an **exception that aborts skill sampling mid-planning**. The planner interprets it as "sample infeasible", exhausts its candidates on equally-doomed valid trajectories, and reports "No plan found".

Concretely, in the kinder Kinematic3D validation study: plans made of many equal-length segments (the textbook case where summation order matters) turned this from an occasional mystery exception (2/250 Transport expert episodes) into **44/44 PrplLab3D and 65/91 Shelf3D planning failures** — a benchmark table reading "success 1.00 → 0.00" for motions that were entirely feasible. The same code and data give 1.00 on Python 3.11 and 0.00 on Python 3.12, with the failures silently misattributed to the method under evaluation.

## Test plan

New regression tests (`pybullet-helpers/tests/test_trajectory_boundary.py`, `prpl-utils/tests/test_trajopt_trajectory_boundary.py`) construct the 13-segment trajectory and assert it is callable at exactly `t = duration`, returning the final endpoint. Verified to fail on the unpatched code (both packages) and pass with the fix; on ≤3.11 the tests pass vacuously (the sums agree).
